### PR TITLE
Compact manifest format and defensive discovery diagnostics

### DIFF
--- a/tests/test_cross_validators.py
+++ b/tests/test_cross_validators.py
@@ -211,15 +211,17 @@ class TestCheckManifestSync:
         docs = _setup_project(tmp_path)
         run_discovery(str(tmp_path))
 
-        # Add a new topic without running discovery
-        new_topic = tmp_path / "context" / "python" / "testing.md"
-        new_topic.write_text(
-            _topic_md(title="Testing"),
+        # Add a new area without running discovery
+        new_area = tmp_path / "context" / "testing"
+        new_area.mkdir(parents=True)
+        overview = new_area / "_overview.md"
+        overview.write_text(
+            _overview_md(topics_section="- Unit Tests\n"),
             encoding="utf-8",
         )
         new_doc = parse_document(
-            "context/python/testing.md",
-            new_topic.read_text(encoding="utf-8"),
+            "context/testing/_overview.md",
+            overview.read_text(encoding="utf-8"),
         )
         docs.append(new_doc)
 


### PR DESCRIPTION
## Summary

- **Issue #2 (verbose manifest):** `render_manifest()` now produces a single area-level table instead of per-topic tables — ~90% reduction in context overhead for large projects. Areas link to `_overview.md` for progressive disclosure; areas without overviews link to the directory.
- **Issue #3 (overwrite safety):** `update_claude_md()` and `run_discovery()` now print diagnostic messages to stderr (resolved root path, area count, whether creating from template vs appending). Makes CWD mismatches immediately visible.
- Regression test: 305-line CLAUDE.md preserved when appending context section.

Closes #2
Closes #3

## Test plan

- [x] All 233 tests pass (`python3 -m pytest tests/ -v`)
- [ ] Run `scripts/run_discovery.py` on a project with existing CLAUDE.md — verify stderr diagnostics appear and content is preserved
- [ ] Run on a project with many areas — verify compact single-table format in CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)