### PR TITLE
feat: add backtracking support with artifact preservation (#80)

### DIFF
--- a/scripts/experiment_state.py
+++ b/scripts/experiment_state.py
@@ -141,7 +141,6 @@ def main() -> None:
         else:
             print(f"Gates satisfied for {phase}.")
 
-<<<<<<< HEAD
     elif args.command == "generate-manifest":
         if not state_path.is_file():
             print("No experiment-state.json found.", file=sys.stderr)

--- a/skills/experiment/SKILL.md
+++ b/skills/experiment/SKILL.md
@@ -423,6 +423,39 @@ Then check gates and advance:
   a rubric, "quality" means whatever the evaluator feels in the moment.
   Define scoring criteria before collecting data.
 
+## Backtracking
+
+Backtracking returns to an earlier phase. It's re-entry, not undo —
+existing artifacts are preserved as `.prev` files.
+
+### When to Suggest Backtracking
+
+- User realizes the hypothesis is wrong during Audit
+- Audit reveals a fundamental design flaw
+- Execution reveals evaluation criteria need updating
+- Analysis shows data collection was flawed
+
+### How to Backtrack
+
+1. Confirm with the user: **"Backtracking to [phase] will reset
+   [downstream phases]. Existing work will be saved as .prev files.
+   Proceed?"**
+2. Run:
+
+       uv run <plugin-scripts-dir>/experiment_state.py --root . backtrack --phase <phase>
+
+3. Show the updated progress display
+4. Remind the user: **"Your previous work is saved as .prev files
+   if you need to reference it."**
+
+### Rules
+
+- **Always confirm before backtracking.** Show what will be reset.
+- **Backtracking preserves artifacts.** Files get a `.prev` suffix, not deleted.
+- **Only one level of history.** If `.prev` files already exist, they're overwritten.
+- **Backtracking is normal.** Especially at Pilot/Exploratory tiers, changing
+  direction is expected and healthy. Don't treat it as failure.
+
 ## Key Rules
 
 - **Don't skip phases.** All tiers use all 6 phases. Depth varies, not count.

--- a/tests/test_experiment_state.py
+++ b/tests/test_experiment_state.py
@@ -9,7 +9,6 @@ import pytest
 
 from wos.experiment_state import (
     OPAQUE_IDS,
-    PHASE_ARTIFACTS,
     PHASE_ORDER,
     ExperimentState,
     PhaseState,
@@ -413,7 +412,7 @@ class TestBacktrackToPhase:
             phases={name: PhaseState(status="complete") for name in PHASE_ORDER},
         )
         state.phases["publication"].status = "in_progress"
-        report = backtrack_to_phase(state, "audit")
+        backtrack_to_phase(state, "audit")
         assert state.phases["audit"].status == "in_progress"
         assert state.phases["evaluation"].status == "pending"
         assert state.phases["execution"].status == "pending"
@@ -469,7 +468,7 @@ class TestBacktrackToPhase:
                 for name in PHASE_ORDER
             },
         )
-        report = backtrack_to_phase(state, "design")
+        backtrack_to_phase(state, "design")
         assert state.phases["design"].status == "in_progress"
         assert all(
             state.phases[name].status == "pending"

--- a/tests/test_experiment_state_script.py
+++ b/tests/test_experiment_state_script.py
@@ -113,7 +113,6 @@ class TestCheckGates:
         assert "satisfied" in stdout
 
 
-<<<<<<< HEAD
 class TestGenerateManifest:
     def test_creates_manifest_file(self, tmp_path: Path) -> None:
         _run_cli(

--- a/wos/experiment_state.py
+++ b/wos/experiment_state.py
@@ -31,7 +31,10 @@ PHASE_ARTIFACTS: Dict[str, List[str]] = {
     "audit": ["protocol/audit.md"],
     "evaluation": ["evaluation/criteria.md", "evaluation/blinding-manifest.json"],
     "execution": ["data/raw/", "protocol/prompts/"],
-    "analysis": ["results/analysis.md", "results/unblinding.md", "results/statistics.json"],
+    "analysis": [
+        "results/analysis.md", "results/unblinding.md",
+        "results/statistics.json",
+    ],
     "publication": ["CONCLUSION.md"],
 }
 


### PR DESCRIPTION
## Summary

Cross-cutting feature for the experiment framework (#67). Adds:

- `backtrack_to_phase()` function — resets target + downstream phases
- `preserve_artifacts()` function — renames files to `.prev` before backtracking
- `PHASE_ARTIFACTS` mapping of phases to their artifact files
- `backtrack` CLI subcommand with progress display
- Backtracking guidance section in SKILL.md (when/how/rules)

15 new tests (223 total), all passing.

## Test plan

- [ ] `uv run python -m pytest tests/ -v` — 223/223 pass
- [ ] `ruff check` clean
- [ ] SKILL.md frontmatter parses correctly

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)