### PR TITLE
Add retrospective skill for session feedback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ instructions, areas table, metadata format, and communication preferences.
 
 ### Skills
 
-Prefix: `/wos:` (e.g., `/wos:create`, `/wos:audit`). 9 skills:
+Prefix: `/wos:` (e.g., `/wos:create`, `/wos:audit`). 10 skills:
 
 | Skill | Purpose |
 |-------|---------|
@@ -99,6 +99,7 @@ Prefix: `/wos:` (e.g., `/wos:create`, `/wos:audit`). 9 skills:
 | `/wos:refine-prompt` | Assess and refine prompts using evidence-backed techniques |
 | `/wos:experiment` | Structured experiment lifecycle (design through publication) |
 | `/wos:report-issue` | File GitHub issues against WOS repo |
+| `/wos:retrospective` | Session review and feedback submission |
 | `/wos:preferences` | Capture communication preferences |
 
 ### Validation (5 checks, warn/fail severity)

--- a/skills/retrospective/SKILL.md
+++ b/skills/retrospective/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: retrospective
+description: >
+  Use when the user wants to "run a retrospective", "review this session",
+  "give feedback on WOS", "how did WOS do", "session review", or at the
+  end of a session to capture what worked, what didn't, and improvement
+  ideas for the WOS tool.
+argument-hint: "[optional: specific focus area]"
+user-invocable: true
+references:
+  - references/retrospective-workflow.md
+---
+
+# Retrospective Skill
+
+Review the current session's use of WOS and submit structured feedback
+to the WOS source repository via GitHub Issues.
+
+## Purpose
+
+Help the WOS maintainer understand how the tool is used in practice —
+what works, what's painful, and what's missing. Feedback comes directly
+from real sessions where the tool was exercised.
+
+## Workflow
+
+Follow the steps in `references/retrospective-workflow.md`.
+
+## Key Rules
+
+- **Session-grounded.** Base observations on what actually happened in
+  this session, not hypothetical scenarios.
+- **User-driven.** The user decides what to include. Ask questions to
+  prompt reflection, but don't invent observations.
+- **Never submit without approval.** Show the full draft and get explicit
+  confirmation before filing.
+- **Target repo is hardcoded:** `bcbeidel/wos`
+- **One issue per retrospective.** Don't split into multiple issues.

--- a/skills/retrospective/references/retrospective-workflow.md
+++ b/skills/retrospective/references/retrospective-workflow.md
@@ -1,0 +1,114 @@
+# Retrospective Workflow
+
+Reflect on the session, gather observations, and submit feedback.
+
+## Phase 1: Check Prerequisites
+
+Verify `gh` is available:
+
+```bash
+gh auth status 2>&1
+```
+
+If `gh` is not installed or not authenticated, respond with:
+
+> To submit retrospective feedback, you need the GitHub CLI installed and authenticated:
+>
+> 1. Install: `brew install gh` (macOS) or see https://cli.github.com
+> 2. Authenticate: `gh auth login`
+> 3. Try again after setup is complete.
+
+Do NOT proceed until `gh auth status` succeeds.
+
+## Phase 2: Reflect
+
+Summarize what happened in this session, then ask the user three questions
+(one at a time, not all at once):
+
+1. **What worked well?** — Which WOS skills or workflows felt smooth?
+   What saved you time or helped you think?
+2. **What was frustrating?** — Where did WOS get in the way, produce
+   poor results, or require workarounds?
+3. **What was missing?** — What did you wish WOS could do that it can't?
+   Any skills or features you wanted but didn't find?
+
+For each answer, ask one brief follow-up if the response is vague
+(e.g., "Can you give a specific example?"). Don't over-interrogate —
+if the user gives a clear answer, move on.
+
+If the user provided a focus area in the invocation, tailor the questions
+to that area instead of using the generic three.
+
+## Phase 3: Gather Context
+
+Auto-gather (do not ask the user for these):
+
+```bash
+# wos version
+uv run <plugin-scripts-dir>/get_version.py
+
+# Python version
+python3 --version
+
+# Platform
+uname -s -r -m
+```
+
+## Phase 4: Draft & Preview
+
+Compose a GitHub issue using this template:
+
+```markdown
+## Session Retrospective
+
+**Focus:** [focus area if provided, otherwise "General session review"]
+
+### What Worked
+
+[Bullet points from user's response to question 1]
+
+### What Was Frustrating
+
+[Bullet points from user's response to question 2]
+
+### What Was Missing
+
+[Bullet points from user's response to question 3]
+
+### Session Context
+
+[Brief, anonymized summary of what the session involved — e.g.,
+"Research workflow on a new topic" or "Auditing and fixing a project".
+Do NOT include repo names, file contents, or sensitive details.]
+
+### Environment
+
+- **wos version:** [version from plugin.json]
+- **Python:** [python3 --version output]
+- **Platform:** [uname output]
+```
+
+**Framing rule:** Write from the WOS tool author's perspective. Use
+"a WOS user" instead of "I". Replace vault-specific details with
+generic descriptions. Strip any repo names, file paths, or personal
+information.
+
+Show the draft to the user: "Here's the retrospective feedback I'd
+submit. Want to change anything before I file it?"
+
+Wait for explicit approval.
+
+## Phase 5: Submit
+
+Only after explicit approval:
+
+```bash
+gh issue create \
+  --repo bcbeidel/wos \
+  --title "Retrospective: [BRIEF_SUMMARY]" \
+  --body "BODY_HERE" \
+  --label "feedback"
+```
+
+On success, show the issue URL. On failure, show the error and suggest
+checking `gh auth status`.


### PR DESCRIPTION
## Summary

- New `/wos:retrospective` skill for reviewing WOS usage and submitting structured feedback
- Five-phase workflow: prerequisites → reflect (3 focused questions) → gather context → draft & preview → submit
- Reuses the `gh issue create` pattern from report-issue, targeting `bcbeidel/wos` with `feedback` label
- Anonymizes session details before submission (no repo names, file paths, or personal info)
- CLAUDE.md skill count updated from 9 to 10

Closes #90

## Test plan

- [ ] Invoke `/wos:retrospective` and verify it asks three reflection questions
- [ ] Verify the draft issue is previewed before submission
- [ ] Verify session details are anonymized in the draft
- [ ] All 234 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)