### PR TITLE
Align CI workflow with documented uv patterns

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         uses: astral-sh/setup-uv@v4
 
       - name: Install dependencies
-        run: uv sync --dev
+        run: uv sync --extra dev
 
       - name: Lint with ruff
         run: uv run ruff check wos/ tests/ scripts/


### PR DESCRIPTION
## Summary

- Replace `pip install -e ".[dev]"` with `uv sync --dev`
- Add `astral-sh/setup-uv@v4` action step
- Use `uv run` prefix for `ruff check` and `pytest` (matches CLAUDE.md principle #8)
- Add `scripts/` to ruff check path (matches documented `ruff check wos/ tests/ scripts/`)

Closes #93

## Test plan

- [ ] CI passes with the new uv-based workflow (this PR is the test)
- [ ] Ruff now lints `scripts/` directory
- [ ] All 247 tests pass via `uv run python -m pytest tests/ -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)