### PR TITLE
Unify project description across config files

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "wos",
   "version": "0.7.0",
-  "description": "Personal work operating system — a collection of Claude Code skills for daily workflows",
+  "description": "Claude Code plugin for building and maintaining structured project context",
   "author": {
     "name": "bbeidel"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "wos"
 version = "0.7.0"
-description = "Claude Code plugin for building and maintaining structured knowledge bases"
+description = "Claude Code plugin for building and maintaining structured project context"
 requires-python = ">=3.9"
 dependencies = []
 


### PR DESCRIPTION
## Summary

- Standardize description to "Claude Code plugin for building and maintaining structured project context" in all config files
- `plugin.json`: was "Personal work operating system — a collection of Claude Code skills for daily workflows"
- `pyproject.toml`: was "Claude Code plugin for building and maintaining structured knowledge bases"
- `marketplace.json`: already correct (canonical source)

Closes #94

## Test plan

- [ ] `test_version_consistent_across_config_files` passes
- [ ] All 247 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)