### PR TITLE
Standardize all scripts to use argparse

### DIFF
--- a/scripts/check_url.py
+++ b/scripts/check_url.py
@@ -10,6 +10,7 @@ Usage:
 """
 from __future__ import annotations
 
+import argparse
 import json
 import sys
 from pathlib import Path
@@ -21,14 +22,20 @@ if str(_plugin_root) not in sys.path:
 
 
 def main() -> None:
-    if len(sys.argv) < 2:
-        print("Usage: check_url.py URL [URL ...]", file=sys.stderr)
-        sys.exit(1)
+    parser = argparse.ArgumentParser(
+        description="Check URL reachability via HTTP HEAD/GET.",
+    )
+    parser.add_argument(
+        "urls",
+        nargs="+",
+        metavar="URL",
+        help="One or more URLs to check",
+    )
+    args = parser.parse_args()
 
     from wos.url_checker import check_urls
 
-    urls = sys.argv[1:]
-    results = check_urls(urls)
+    results = check_urls(args.urls)
     for r in results:
         print(json.dumps({
             "url": r.url,

--- a/scripts/get_version.py
+++ b/scripts/get_version.py
@@ -10,6 +10,7 @@ Usage:
 """
 from __future__ import annotations
 
+import argparse
 import json
 import sys
 from pathlib import Path
@@ -21,6 +22,11 @@ if str(_plugin_root) not in sys.path:
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Print the WOS plugin version from plugin.json.",
+    )
+    parser.parse_args()
+
     plugin_json = _plugin_root / ".claude-plugin" / "plugin.json"
     if not plugin_json.exists():
         print("plugin.json not found", file=sys.stderr)

--- a/scripts/update_preferences.py
+++ b/scripts/update_preferences.py
@@ -13,6 +13,7 @@ Example:
 """
 from __future__ import annotations
 
+import argparse
 import sys
 from pathlib import Path
 
@@ -23,26 +24,32 @@ if str(_plugin_root) not in sys.path:
 
 
 def main() -> None:
-    if len(sys.argv) < 3:
-        print(
-            "Usage: update_preferences.py <file> key=value [key=value ...]",
-            file=sys.stderr,
-        )
-        sys.exit(1)
+    parser = argparse.ArgumentParser(
+        description="Update communication preferences in a target file.",
+    )
+    parser.add_argument(
+        "file",
+        help="Target file to update (e.g., CLAUDE.md)",
+    )
+    parser.add_argument(
+        "preferences",
+        nargs="+",
+        metavar="key=value",
+        help="Preference key=value pairs (e.g., directness=blunt)",
+    )
+    args = parser.parse_args()
 
     from wos.preferences import update_preferences
 
-    target_file = sys.argv[1]
     prefs = {}
-    for arg in sys.argv[2:]:
+    for arg in args.preferences:
         if "=" not in arg:
-            print(f"Invalid preference: {arg!r} (expected key=value)", file=sys.stderr)
-            sys.exit(1)
+            parser.error(f"Invalid preference: {arg!r} (expected key=value)")
         key, value = arg.split("=", 1)
         prefs[key] = value
 
-    update_preferences(target_file, prefs)
-    print(f"Updated preferences in {target_file}")
+    update_preferences(args.file, prefs)
+    print(f"Updated preferences in {args.file}")
 
 
 if __name__ == "__main__":

--- a/tests/test_check_url.py
+++ b/tests/test_check_url.py
@@ -16,5 +16,5 @@ class TestCheckUrlHelp:
             text=True,
             cwd=str(tmp_path),
         )
-        assert result.returncode == 1
-        assert "Usage" in result.stderr
+        assert result.returncode != 0
+        assert "usage" in result.stderr.lower()

--- a/tests/test_update_preferences.py
+++ b/tests/test_update_preferences.py
@@ -16,5 +16,5 @@ class TestUpdatePreferencesHelp:
             text=True,
             cwd=str(tmp_path),
         )
-        assert result.returncode == 1
-        assert "Usage" in result.stderr
+        assert result.returncode != 0
+        assert "usage" in result.stderr.lower()


### PR DESCRIPTION
## Summary

- Convert `check_url.py`, `update_preferences.py`, and `get_version.py` from manual `sys.argv` to `argparse`
- All 7 scripts now use `argparse` and respond to `--help`
- Update tests to accept argparse exit code conventions

| Script | Before | After |
|--------|--------|-------|
| `check_url.py` | Manual `sys.argv` | `argparse` with `URL` positional args |
| `update_preferences.py` | Manual `sys.argv` | `argparse` with `file` + `key=value` args |
| `get_version.py` | No arg parsing | `argparse` (no-arg script, `--help` only) |
| `check_runtime.py` | Already `argparse` | No change |
| `audit.py` | Already `argparse` | No change |
| `reindex.py` | Already `argparse` | No change |
| `experiment_state.py` | Already `argparse` | No change |

Closes #95

## Test plan

- [ ] All 7 scripts respond to `--help`
- [ ] `check_url.py` with no args shows usage and exits non-zero
- [ ] `update_preferences.py` with no args shows usage and exits non-zero
- [ ] All 247 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)