### PR TITLE
feat: auto-derive AGENTS.md areas table from disk state

### DIFF
--- a/skills/create/SKILL.md
+++ b/skills/create/SKILL.md
@@ -45,8 +45,7 @@ content outside these markers.
 1. Ask for area name (lowercase-hyphenated)
 2. Create `docs/context/{area}/`
 3. Ask the user for a 1-2 sentence area description. Write it as the preamble in `_index.md` above the file table.
-4. Run `uv run <plugin-scripts-dir>/reindex.py --root .`
-5. Update AGENTS.md areas table
+4. Run `uv run <plugin-scripts-dir>/reindex.py --root .` (also auto-updates AGENTS.md areas table)
 
 ## 3. Create Document
 

--- a/wos/index.py
+++ b/wos/index.py
@@ -70,12 +70,15 @@ def _extract_preamble(index_path: Path) -> Optional[str]:
             table_idx = i
             break
 
-    if heading_idx is None or table_idx is None:
+    if heading_idx is None:
         return None
 
-    # Extract lines between heading and table, strip blanks
+    # End boundary: table line if present, otherwise end of content
+    end_idx = table_idx if table_idx is not None else len(lines)
+
+    # Extract lines between heading and boundary, strip blanks
     preamble_lines = [
-        line for line in lines[heading_idx + 1:table_idx] if line.strip()
+        line for line in lines[heading_idx + 1:end_idx] if line.strip()
     ]
     if not preamble_lines:
         return None


### PR DESCRIPTION
## Summary
- Add `discover_areas()` function to `wos/agents_md.py` that scans `docs/context/` subdirectories and extracts area names from `_index.md` preambles
- Fix `_extract_preamble()` in `wos/index.py` to handle empty directories (no table delimiter) by treating end-of-content as a valid boundary
- Wire auto-discovery into `scripts/reindex.py` so the AGENTS.md areas table updates automatically on every reindex
- Simplify create skill step 5 ("Update AGENTS.md areas table") — now handled automatically by reindex

Closes #97

## Test plan
- [x] 5 unit tests for `discover_areas()` (preamble extraction, fallback to dir name, empty context dir, file filtering, alphabetical sorting)
- [x] 2 integration tests for reindex AGENTS.md auto-update (areas populated, skips when no AGENTS.md)
- [x] Existing `_extract_preamble()` tests still pass (no regression)
- [x] Full test suite: 254 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)