### PR TITLE
fix: clean up code hygiene issues (Principle 5)

### DIFF
--- a/tests/test_research_protocol.py
+++ b/tests/test_research_protocol.py
@@ -130,7 +130,7 @@ class TestFormatProtocolSummary:
 
 class TestProtocolFromJson:
     def test_parse_full_entry(self) -> None:
-        from wos.research_protocol import _protocol_from_json
+        from wos.research_protocol import protocol_from_json
 
         data = {
             "entries": [
@@ -144,14 +144,14 @@ class TestProtocolFromJson:
             ],
             "not_searched": ["reddit"],
         }
-        protocol = _protocol_from_json(data)
+        protocol = protocol_from_json(data)
         assert len(protocol.entries) == 1
         assert protocol.entries[0].query == "test"
         assert protocol.entries[0].date_range == "2024-2026"
         assert protocol.not_searched == ["reddit"]
 
     def test_parse_null_date_range(self) -> None:
-        from wos.research_protocol import _protocol_from_json
+        from wos.research_protocol import protocol_from_json
 
         data = {
             "entries": [
@@ -165,19 +165,19 @@ class TestProtocolFromJson:
             ],
             "not_searched": [],
         }
-        protocol = _protocol_from_json(data)
+        protocol = protocol_from_json(data)
         assert protocol.entries[0].date_range is None
 
     def test_parse_empty(self) -> None:
-        from wos.research_protocol import _protocol_from_json
+        from wos.research_protocol import protocol_from_json
 
-        protocol = _protocol_from_json({"entries": [], "not_searched": []})
+        protocol = protocol_from_json({"entries": [], "not_searched": []})
         assert protocol.entries == []
         assert protocol.not_searched == []
 
     def test_rejects_dict_not_searched_entries(self) -> None:
         """Issue #52: not_searched with dict entries should raise ValueError."""
-        from wos.research_protocol import _protocol_from_json
+        from wos.research_protocol import protocol_from_json
 
         data = {
             "entries": [],
@@ -186,7 +186,7 @@ class TestProtocolFromJson:
             ],
         }
         try:
-            _protocol_from_json(data)
+            protocol_from_json(data)
             assert False, "Should have raised ValueError"
         except ValueError as exc:
             assert "not_searched" in str(exc)
@@ -194,7 +194,7 @@ class TestProtocolFromJson:
 
     def test_rejects_mixed_not_searched_entries(self) -> None:
         """Issue #52: mix of strings and dicts should also raise."""
-        from wos.research_protocol import _protocol_from_json
+        from wos.research_protocol import protocol_from_json
 
         data = {
             "entries": [],
@@ -204,7 +204,7 @@ class TestProtocolFromJson:
             ],
         }
         try:
-            _protocol_from_json(data)
+            protocol_from_json(data)
             assert False, "Should have raised ValueError"
         except ValueError as exc:
             assert "not_searched" in str(exc)

--- a/wos/document.py
+++ b/wos/document.py
@@ -64,10 +64,8 @@ def parse_document(path: str, text: str) -> Document:
     name: str = str(fm["name"]) if fm["name"] is not None else ""
     description: str = str(fm["description"]) if fm["description"] is not None else ""
     doc_type: Optional[str] = fm.get("type")
-    if isinstance(doc_type, str):
-        doc_type = doc_type
-    else:
-        doc_type = str(doc_type) if doc_type is not None else None
+    if not isinstance(doc_type, str) and doc_type is not None:
+        doc_type = str(doc_type)
     sources: List[str] = fm.get("sources") or []
     related: List[str] = fm.get("related") or []
 

--- a/wos/research_protocol.py
+++ b/wos/research_protocol.py
@@ -70,7 +70,7 @@ def format_protocol_summary(protocol: SearchProtocol) -> str:
     )
 
 
-def _protocol_from_json(data: Dict[str, Any]) -> SearchProtocol:
+def protocol_from_json(data: Dict[str, Any]) -> SearchProtocol:
     """Parse JSON dict into SearchProtocol.
 
     Raises ValueError if not_searched contains non-string entries.


### PR DESCRIPTION
## Summary
- Simplify no-op type assignment in `wos/document.py` — replaced `if isinstance(str): doc_type = doc_type` with the inverse guard suggested in the issue
- Promote `_protocol_from_json()` to public `protocol_from_json()` in `wos/research_protocol.py` — it has tests, validation logic, and was intentionally kept during simplification

Closes #98

## Test plan
- [x] All 254 tests pass (no test logic changes, only import renames)
- [x] `test_numeric_name_and_description_coerced_to_str` covers the document.py type conversion path

🤖 Generated with [Claude Code](https://claude.com/claude-code)