### PR TITLE
fix: normalize skill frontmatter fields (Principle 8)

### DIFF
--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -7,6 +7,8 @@ description: >
   "run health check", or "what needs attention".
 argument-hint: "[check|audit|review|coverage|freshness]"
 user-invocable: true
+references:
+  - ../_shared/references/preflight.md
 ---
 
 # Audit Skill

--- a/skills/create/SKILL.md
+++ b/skills/create/SKILL.md
@@ -1,7 +1,10 @@
 ---
 name: create
 description: Create project context, areas, or documents
+argument-hint: "[initialize|add area|create document]"
 user-invocable: true
+references:
+  - ../_shared/references/preflight.md
 ---
 
 # Create

--- a/skills/distill/SKILL.md
+++ b/skills/distill/SKILL.md
@@ -9,6 +9,7 @@ argument-hint: "[path to research artifact]"
 user-invocable: true
 references:
   - references/distillation-guidelines.md
+  - ../_shared/references/preflight.md
 ---
 
 # Distill

--- a/skills/experiment/SKILL.md
+++ b/skills/experiment/SKILL.md
@@ -9,6 +9,8 @@ description: >
 argument-hint: "[action: status, init, or phase name]"
 user-invocable: true
 compatibility: "Requires Python 3 (stdlib only), experiment-template repo"
+references:
+  - ../_shared/references/preflight.md
 ---
 
 # Experiment Skill


### PR DESCRIPTION
## Summary
- Add missing `argument-hint` to `skills/create/SKILL.md` (was the only skill of 10 without it)
- Add `references:` frontmatter declaring `../_shared/references/preflight.md` to the 4 skills that use preflight: create, audit, distill, experiment
- All 10 skills now consistently have `argument-hint` and skills that reference preflight declare it in frontmatter

Closes #99

## Test plan
- [x] All 254 tests pass (frontmatter-only changes, no code changes)
- [x] Audited all 10 skills for consistency:
  - `argument-hint`: all 10 present
  - `references:`: 8 of 10 declare references (consider and retrospective correctly have none — consider uses `models/` subdirectory pattern, retrospective has its own references already declared)

🤖 Generated with [Claude Code](https://claude.com/claude-code)