### PR TITLE
Improve /retrospective: incident anchoring, action items, duplicate search

### DIFF
--- a/skills/retrospective/references/retrospective-workflow.md
+++ b/skills/retrospective/references/retrospective-workflow.md
@@ -41,8 +41,8 @@ ask one targeted follow-up before moving on:
 - Missing why ("I had to copy-paste") → "Why do you think that
   happened? What would have helped?"
 
-Cap at 2 follow-up probes total across all three questions. If the
-response is already specific and grounded, move on.
+Cap at 1 follow-up probe per question. If the response is already
+specific and grounded, move on.
 
 If the user provided a focus area in the invocation, tailor the questions
 to that area instead of using the generic three.
@@ -67,13 +67,15 @@ uname -s -r -m
 Before drafting, search for related existing issues:
 
 ```bash
-gh issue list --repo bcbeidel/wos --state open --search "KEYWORDS_HERE" --limit 5
+gh issue list --repo bcbeidel/wos --state all --search "KEYWORDS_HERE" --limit 5
 ```
 
 Use 2-3 keywords extracted from the user's observations. Vary terms
 (e.g., "research" vs. "workflow") to catch near-duplicates.
 
-If related issues are found, show them to the user and offer:
+If related issues are found, show them to the user. For closed issues,
+note the resolution (fixed, won't-fix, duplicate) so the user has
+context. Then offer:
 
 1. **Comment on existing** — add new context to the existing issue
 2. **File new with cross-reference** — proceed, mentioning related


### PR DESCRIPTION
## Summary

Addresses #111 (scoped to Approach 1 per discussion):

- **Incident-anchored questions** — reworded 3 core reflection questions to elicit specific moments ("Think about a specific moment where WOS helped you...") instead of abstract opinions ("What worked well?")
- **Adaptive follow-up probing** — explicit targeted probes for vague/abstract/missing-why responses, capped at 2 total (consistent with #112 pattern)
- **Duplicate search phase** — new Phase 4 searches existing open issues via `gh issue list --search` before drafting; offers comment/cross-ref/abandon (same pattern as #113)
- **Action-item synthesis** — new Phase 5 extracts 1-3 discrete action items from observations using Observation-Impact-Request structure with user-assigned severity (blocking/friction/nit)
- **Updated issue template** — new "Action Items" section with OIR format and severity labels

### Intentionally excluded (per scope discussion)

- Full DICE probe library (Descriptive/Idiographic/Clarifying/Explanatory) — lightweight probing sufficient
- Full branching decision tree with move-on signals — over-specifies for skill instructions

## Test plan

- [x] 254 tests passing, 0 failures
- [ ] Manual: invoke `/wos:retrospective` and verify incident-anchored questions appear
- [ ] Manual: verify adaptive follow-up triggers on vague responses
- [ ] Manual: verify duplicate search runs before draft phase
- [ ] Manual: verify action-item synthesis phase presents OIR items with severity options

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)