### PR TITLE
Remove excluded techniques section from technique-registry.md

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
         "repo": "bcbeidel/wos"
       },
       "description": "Claude Code plugin for building and maintaining structured project context",
-      "version": "0.12.2",
+      "version": "0.12.3",
       "license": "MIT"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wos",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "Claude Code plugin for building and maintaining structured project context",
   "author": {
     "name": "bbeidel"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.3] - 2026-03-05
+
+### Removed
+
+- **Excluded Techniques section removed from technique-registry.md.** Removed
+  ~155 words describing techniques that were intentionally excluded from the
+  registry. Mentioning excluded techniques by name may prime models to consider
+  them, and every token competes for attention budget.
+  ([#120](https://github.com/bcbeidel/wos/issues/120))
+
 ## [0.12.2] - 2026-03-05
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wos"
-version = "0.12.2"
+version = "0.12.3"
 description = "Claude Code plugin for building and maintaining structured project context"
 requires-python = ">=3.9"
 dependencies = []

--- a/skills/refine-prompt/references/technique-registry.md
+++ b/skills/refine-prompt/references/technique-registry.md
@@ -144,14 +144,3 @@ expert" adds nothing).
 **Evidence:** Anthropic Tier 1 documentation — "Even a single sentence of
 role context makes a measurable difference on domain-specific tasks."
 
----
-
-## Excluded Techniques
-
-These were evaluated and intentionally excluded:
-
-| Technique | Why excluded |
-|-----------|-------------|
-| Chain-of-thought injection | Decreasing value on reasoning models (Claude 4.x has built-in reasoning); 20-80% latency cost (Mollick et al., Wharton 2025) |
-| Self-reflection loops | Unreliable without external feedback; TACL survey shows minimal benefit |
-| Meta-prompting | Handled by agent/subagent systems, not individual prompts |


### PR DESCRIPTION
## Summary

- Removes the "Excluded Techniques" section (~155 words) from `technique-registry.md`
- Mentioning excluded techniques by name may prime models to consider them
- Bumps version to 0.12.3

Closes #120

## Test plan

- [x] Verify the 7 active technique entries are unchanged
- [x] Verify the Excluded Techniques section is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)