### PR TITLE
fix: audit --fix preserves preambles in _index.md files

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
         "repo": "bcbeidel/wos"
       },
       "description": "Claude Code plugin for building and maintaining structured project context",
-      "version": "0.12.4",
+      "version": "0.12.5",
       "license": "MIT"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wos",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "Claude Code plugin for building and maintaining structured project context",
   "author": {
     "name": "bbeidel"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wos"
-version = "0.12.4"
+version = "0.12.5"
 description = "Claude Code plugin for building and maintaining structured project context"
 requires-python = ">=3.9"
 dependencies = []

--- a/scripts/audit.py
+++ b/scripts/audit.py
@@ -77,7 +77,7 @@ def main() -> None:
     args = parser.parse_args()
 
     # Deferred imports — keeps --help fast
-    from wos.index import generate_index
+    from wos.index import extract_preamble, generate_index
     from wos.validators import validate_file, validate_project
 
     root = Path(args.root).resolve()
@@ -102,7 +102,8 @@ def main() -> None:
             ):
                 idx_path = Path(file_path_str)
                 directory = idx_path.parent
-                content = generate_index(directory)
+                preamble = extract_preamble(idx_path)
+                content = generate_index(directory, preamble=preamble)
                 idx_path.write_text(content, encoding="utf-8")
                 fixed.append(file_path_str)
                 print(

--- a/scripts/reindex.py
+++ b/scripts/reindex.py
@@ -32,7 +32,7 @@ def main() -> None:
     args = parser.parse_args()
 
     # Deferred import — keeps --help fast
-    from wos.index import _extract_preamble, generate_index
+    from wos.index import extract_preamble, generate_index
 
     root = Path(args.root).resolve()
 
@@ -53,14 +53,14 @@ def main() -> None:
             continue
 
         # Also index the top-level subdir itself
-        if _reindex_directory(subdir, generate_index, _extract_preamble):
+        if _reindex_directory(subdir, generate_index, extract_preamble):
             count += 1
 
         # Walk all subdirectories
         for dirpath in sorted(subdir.rglob("*")):
             if not dirpath.is_dir():
                 continue
-            if _reindex_directory(dirpath, generate_index, _extract_preamble):
+            if _reindex_directory(dirpath, generate_index, extract_preamble):
                 count += 1
 
     print(f"Wrote {count} _index.md files.")

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -167,3 +167,38 @@ class TestFixOutput:
             _, stderr, _ = _run_audit("--root", str(root), "--no-urls", "--fix")
         assert str(root) not in stderr
         assert "docs/plans/_index.md" in stderr
+
+    def test_fix_preserves_preamble(self, tmp_path: Path) -> None:
+        """--fix should preserve existing preambles in _index.md files."""
+        from wos.index import generate_index
+
+        root = tmp_path / "project"
+        idx_dir = root / "docs" / "context"
+        idx_dir.mkdir(parents=True)
+        # Create a doc file and generate index with preamble
+        (idx_dir / "auth.md").write_text(
+            "---\nname: Auth\ndescription: Authentication guide\n---\n# Auth\n"
+        )
+        idx_file = idx_dir / "_index.md"
+        preamble_text = "This area covers authentication and authorization."
+        initial = generate_index(idx_dir, preamble=preamble_text)
+        idx_file.write_text(initial)
+
+        # Add a new file so index is out of sync
+        (idx_dir / "tokens.md").write_text(
+            "---\nname: Tokens\ndescription: Token handling\n---\n# Tokens\n"
+        )
+
+        issues = [
+            {
+                "file": str(idx_file),
+                "issue": "_index.md is out of sync with directory contents",
+                "severity": "fail",
+            },
+        ]
+        with patch("wos.validators.validate_project", return_value=issues):
+            _run_audit("--root", str(root), "--no-urls", "--fix")
+
+        result = idx_file.read_text(encoding="utf-8")
+        assert preamble_text in result
+        assert "tokens.md" in result

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -250,32 +250,32 @@ class TestPreamble:
     def test_extract_preamble_returns_text_between_heading_and_table(
         self, tmp_path: Path
     ) -> None:
-        from wos.index import _extract_preamble
+        from wos.index import extract_preamble
 
         index = tmp_path / "_index.md"
         index.write_text(
             "# My Area\n\nThis area covers authentication.\n\n"
             "| File | Description |\n| --- | --- |\n| [a.md](a.md) | Doc A |\n"
         )
-        assert _extract_preamble(index) == "This area covers authentication."
+        assert extract_preamble(index) == "This area covers authentication."
 
     def test_extract_preamble_returns_none_when_no_preamble(
         self, tmp_path: Path
     ) -> None:
-        from wos.index import _extract_preamble
+        from wos.index import extract_preamble
 
         index = tmp_path / "_index.md"
         index.write_text(
             "# My Area\n\n| File | Description |\n| --- | --- |\n"
         )
-        assert _extract_preamble(index) is None
+        assert extract_preamble(index) is None
 
     def test_extract_preamble_returns_none_for_missing_file(
         self, tmp_path: Path
     ) -> None:
-        from wos.index import _extract_preamble
+        from wos.index import extract_preamble
 
-        assert _extract_preamble(tmp_path / "nonexistent.md") is None
+        assert extract_preamble(tmp_path / "nonexistent.md") is None
 
     def test_generate_index_includes_preamble(self, tmp_path: Path) -> None:
         from wos.index import generate_index
@@ -317,7 +317,7 @@ class TestPreamble:
     def test_preamble_preserved_during_regeneration(
         self, tmp_path: Path
     ) -> None:
-        from wos.index import _extract_preamble, generate_index
+        from wos.index import extract_preamble, generate_index
 
         (tmp_path / "doc.md").write_text(
             "---\nname: Doc\ndescription: A document\n---\n# Doc\n"
@@ -327,7 +327,7 @@ class TestPreamble:
         (tmp_path / "_index.md").write_text(initial)
 
         # Extract preamble and regenerate
-        preamble = _extract_preamble(tmp_path / "_index.md")
+        preamble = extract_preamble(tmp_path / "_index.md")
         regenerated = generate_index(tmp_path, preamble=preamble)
 
         assert "My area description." in regenerated

--- a/wos/agents_md.py
+++ b/wos/agents_md.py
@@ -32,7 +32,7 @@ def discover_areas(root: Path) -> List[Dict[str, str]]:
     Returns:
         Sorted list of dicts with 'name' and 'path' keys.
     """
-    from wos.index import _extract_preamble
+    from wos.index import extract_preamble
 
     context_dir = root / "docs" / "context"
     if not context_dir.is_dir():
@@ -43,7 +43,7 @@ def discover_areas(root: Path) -> List[Dict[str, str]]:
         if not entry.is_dir():
             continue
         index_path = entry / "_index.md"
-        preamble = _extract_preamble(index_path)
+        preamble = extract_preamble(index_path)
         name = preamble if preamble else entry.name
         rel_path = str(entry.relative_to(root))
         areas.append({"name": name, "path": rel_path})

--- a/wos/index.py
+++ b/wos/index.py
@@ -44,7 +44,7 @@ def _directory_display_name(directory: Path) -> str:
     return directory.name.replace("-", " ").replace("_", " ").title()
 
 
-def _extract_preamble(index_path: Path) -> Optional[str]:
+def extract_preamble(index_path: Path) -> Optional[str]:
     """Extract preamble text from an existing _index.md.
 
     The preamble is any text between the heading line and the first
@@ -167,7 +167,7 @@ def check_index_sync(directory: Path) -> List[dict]:
         ]
 
     # Preserve preamble when comparing
-    preamble = _extract_preamble(index_path)
+    preamble = extract_preamble(index_path)
     current_content = generate_index(directory, preamble=preamble)
     existing_content = index_path.read_text(encoding="utf-8")
 

--- a/wos/validators.py
+++ b/wos/validators.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import List
 
 from wos.document import Document, parse_document
-from wos.index import _extract_preamble, check_index_sync
+from wos.index import check_index_sync, extract_preamble
 from wos.url_checker import check_urls
 
 # ── Individual checks ──────────────────────────────────────────
@@ -228,7 +228,7 @@ def check_all_indexes(directory: Path) -> List[dict]:
 
     # WARN: index exists but has no preamble (area description)
     index_path = directory / "_index.md"
-    if index_path.is_file() and _extract_preamble(index_path) is None:
+    if index_path.is_file() and extract_preamble(index_path) is None:
         issues.append({
             "file": str(index_path),
             "issue": "Index has no area description (preamble)",


### PR DESCRIPTION
## Summary

- **Bug fix:** `audit --fix` now extracts and passes the existing preamble when regenerating `_index.md` files, preventing silent data loss of user-authored area descriptions
- **API cleanup:** Renamed `_extract_preamble` → `extract_preamble` (public) since it was already imported across module boundaries (`validators.py`, `agents_md.py`, `reindex.py`, `audit.py`)
- **Version bump:** 0.12.4 → 0.12.5

Closes #122

## Test plan

- [x] New test `test_fix_preserves_preamble` verifies preamble survives `--fix` regeneration
- [x] All 202 existing tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)