### PR TITLE
feat: add skill quality criteria from Anthropic skill-creator analysis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ Prefix: `/wos:` (e.g., `/wos:init`, `/wos:audit`). 7 skills:
 5. **Related paths** (fail) — file paths in `related` frontmatter exist on disk
 6. **Index sync** (fail + warn) — `_index.md` matches directory contents, preamble presence
 7. **Project files** (warn) — AGENTS.md/CLAUDE.md existence and configuration
-8. **Skill quality** (fail + warn) — skill name format/reserved words (fail), description length/XML/voice (warn), instruction lines exceeding threshold (warn, default 200, configurable), SKILL.md body exceeding 500 lines (warn)
+8. **Skill quality** (fail + warn) — skill name format/reserved words (fail), description length/XML/voice (warn), instruction lines exceeding threshold (warn, default 200, configurable), SKILL.md body exceeding 500 lines (warn), ALL-CAPS directive density (warn, threshold 3)
 
 ### Key Entry Points
 

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -167,8 +167,12 @@ Present judgment findings as a narrative after the automated results:
 Skill Evaluation: [skill-name]
 
 - **Description triggers:** [finding + explanation]
+- **Description breadth:** [finding + explanation]
 - **Freedom ↔ fragility:** [finding + explanation]
+- **Rationale over rigidity:** [finding + explanation]
 - **Unnecessary context:** [finding + explanation]
+- **Token-earning:** [finding + explanation]
+- **Generality:** [finding + explanation]
 - **Examples:** [finding + explanation]
 - **Terminology:** [finding + explanation]
 - **Reference depth:** [finding + explanation]

--- a/skills/audit/references/skill-authoring-guide.md
+++ b/skills/audit/references/skill-authoring-guide.md
@@ -84,13 +84,22 @@ The body contains instructions Claude follows when the skill triggers.
 - **Imperative voice:** "Read the document" not "The document should be read"
 - **Consistent terminology:** Pick one term and use it throughout
 - **No time-sensitive information**
+- **Adapt to audience:** Consider the likely technical range of users.
+  Briefly explain domain-specific terms (e.g., "assertion", "JSON")
+  when context cues suggest the user may not know them. Don't
+  over-explain for expert audiences.
 
-### The Conciseness Test
+### The Token-Earning Test
 
-For every instruction, ask: "Does Claude already know this?" Claude is
-a highly capable model — only add context it doesn't have. A paragraph
-explaining what PDFs are wastes tokens. A line showing which library to
-use earns its place.
+Every instruction should earn its place. Two questions to ask:
+
+1. **"Does Claude already know this?"** — A paragraph explaining what
+   PDFs are wastes tokens. A line showing which library to use earns
+   its place.
+2. **"Is this pulling its weight?"** — An instruction can be correct
+   and still not help. If removing a section wouldn't change output
+   quality, the section is dead weight. Lean skills outperform verbose
+   ones because signal isn't diluted by noise.
 
 ### Freedom Matches Fragility
 
@@ -162,8 +171,12 @@ When evaluating a skill, check these criteria:
 | Check | What to evaluate |
 |-------|-----------------|
 | Description triggers | Does it include both what + when? |
+| Description breadth | Does it cast a wide enough net? Claude undertriggers — descriptions should be slightly "pushy", covering adjacent phrasings and contexts even when the user doesn't name the skill explicitly. |
 | Freedom ↔ fragility | Do guardrail vs. guidance levels match the task? |
+| Rationale over rigidity | Does the skill explain *why* behind instructions, or rely on rigid ALL-CAPS directives (MUST, NEVER, ALWAYS)? Explaining reasoning produces more intelligent adaptation than rigid commands. |
 | Unnecessary context | Does the skill explain things Claude already knows? |
+| Token-earning | Is every instruction pulling its weight, or could sections be removed without affecting output quality? |
+| Generality | Is the skill written for broad use, or narrowly overfit to specific examples? Constraints should serve the general purpose, not patch individual test cases. |
 | Examples quality | Are examples concrete and demonstrate expected depth? |
 | Terminology consistency | Is vocabulary consistent throughout? |
 | Reference depth | Are all references one level deep from SKILL.md? |

--- a/tests/test_skill_audit.py
+++ b/tests/test_skill_audit.py
@@ -319,6 +319,39 @@ class TestCheckSkillMeta:
         issues = check_skill_meta(tmp_path / "long-skill")
         assert any("500" in i["issue"] for i in issues)
 
+    def test_rigid_directives_under_threshold_no_warn(self, tmp_path: Path) -> None:
+        from wos.skill_audit import check_skill_meta
+        _create_skill(
+            tmp_path, "mild-skill",
+            "---\nname: mild-skill\ndescription: Valid skill.\n---\n"
+            "# Mild\n\nMUST do X.\nNEVER do Y.\n",
+        )
+        issues = check_skill_meta(tmp_path / "mild-skill")
+        assert not any("directives" in i["issue"] for i in issues)
+
+    def test_rigid_directives_at_threshold_warns(self, tmp_path: Path) -> None:
+        from wos.skill_audit import check_skill_meta
+        _create_skill(
+            tmp_path, "rigid-skill",
+            "---\nname: rigid-skill\ndescription: Valid skill.\n---\n"
+            "# Rigid\n\nMUST do X.\nNEVER do Y.\nALWAYS do Z.\n",
+        )
+        issues = check_skill_meta(tmp_path / "rigid-skill")
+        directive_issues = [i for i in issues if "directives" in i["issue"]]
+        assert len(directive_issues) == 1
+        assert directive_issues[0]["severity"] == "warn"
+
+    def test_rigid_directives_ignores_lowercase(self, tmp_path: Path) -> None:
+        from wos.skill_audit import check_skill_meta
+        _create_skill(
+            tmp_path, "lowercase-skill",
+            "---\nname: lowercase-skill\ndescription: Valid skill.\n---\n"
+            "# Lowercase\n\nYou must do X.\nNever do Y.\nAlways do Z.\n"
+            "This is required.\nThis is forbidden.\n",
+        )
+        issues = check_skill_meta(tmp_path / "lowercase-skill")
+        assert not any("directives" in i["issue"] for i in issues)
+
     def test_no_skill_md_returns_empty(self, tmp_path: Path) -> None:
         from wos.skill_audit import check_skill_meta
         (tmp_path / "empty-dir").mkdir()

--- a/wos/skill_audit.py
+++ b/wos/skill_audit.py
@@ -22,6 +22,8 @@ _SECOND_PERSON_PATTERNS = (
     "i will",
     "this skill should be used when",
 )
+_RIGID_DIRECTIVE_RE = re.compile(r"\b(?:MUST|NEVER|ALWAYS|REQUIRED|FORBIDDEN)\b")
+_RIGID_DIRECTIVE_THRESHOLD = 3
 
 
 def strip_frontmatter(text: str) -> str:
@@ -255,8 +257,21 @@ def check_skill_meta(skill_dir: Path) -> List[dict]:
                 })
                 break
 
-    # Raw line count
+    # Rigid directive density
     body = strip_frontmatter(raw)
+    directive_matches = _RIGID_DIRECTIVE_RE.findall(body)
+    if len(directive_matches) >= _RIGID_DIRECTIVE_THRESHOLD:
+        issues.append({
+            "file": file_str,
+            "issue": (
+                f"SKILL.md body has {len(directive_matches)} ALL-CAPS "
+                f"directives (MUST/NEVER/ALWAYS/etc.) — consider "
+                f"explaining rationale instead of rigid commands"
+            ),
+            "severity": "warn",
+        })
+
+    # Raw line count
     raw_lines = sum(1 for line in body.splitlines() if line.strip())
     if raw_lines > 500:
         issues.append({


### PR DESCRIPTION
## Summary

- Adds automated ALL-CAPS directive density check (`MUST`/`NEVER`/`ALWAYS`/`REQUIRED`/`FORBIDDEN`, warns at 3+) to `skill_audit.py`
- Adds 4 new judgment criteria to skill-authoring-guide: description breadth, rationale over rigidity, token-earning, generality
- Adds audience adaptation guidance to Writing Style section
- Renames "Conciseness Test" → "Token-Earning Test" with expanded dual criteria

Based on comparative analysis of [Anthropic's skill-creator SKILL.md](https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md).

## Test plan

- [x] All 247 tests pass (`uv run python -m pytest tests/ -v`)
- [x] 3 new tests for directive density check (under threshold, at threshold, lowercase ignored)
- [ ] Run `/wos:audit` on a skill with heavy MUST/NEVER usage to verify warning appears
- [ ] Review judgment criteria table renders correctly in markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)