### PR TITLE
feat: create wos:finish-work skill (#162)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ instructions, areas table, metadata format, and communication preferences.
 
 ### Skills
 
-Prefix: `/wos:` (e.g., `/wos:init`, `/wos:audit`). 8 skills:
+Prefix: `/wos:` (e.g., `/wos:init`, `/wos:audit`). 9 skills:
 
 | Skill | Purpose |
 |-------|---------|
@@ -96,6 +96,7 @@ Prefix: `/wos:` (e.g., `/wos:init`, `/wos:audit`). 8 skills:
 | `/wos:research` | SIFT-based research with source verification |
 | `/wos:distill` | Convert research artifacts into focused context files |
 | `/wos:refine-prompt` | Assess and refine prompts using evidence-backed techniques |
+| `/wos:finish-work` | Structured work integration (merge/PR/keep/discard) |
 | `/wos:report-issue` | File GitHub issues against WOS repo |
 | `/wos:retrospective` | Session review and feedback submission |
 | `/wos:principles` | Capture and maintain project principles |

--- a/docs/plans/2026-03-11-finish-work-skill-design.md
+++ b/docs/plans/2026-03-11-finish-work-skill-design.md
@@ -1,0 +1,147 @@
+---
+name: "finish-work skill design"
+description: "Design spec for wos:finish-work — structured work termination with 4 integration options, safety gates, and optional retrospective"
+type: plan
+status: completed
+related:
+  - docs/plans/2026-03-11-validate-plan-skill-design.md
+  - docs/plans/2026-03-11-execute-plan-skill-design.md
+---
+
+# finish-work Skill Design
+
+## Context
+
+Terminal step in the WOS plan lifecycle pipeline (brainstorm → write-plan →
+execute-plan → validate-plan → **finish-work**). Replaces
+`superpowers:finishing-a-development-branch` with a WOS-native skill that
+integrates with plan lifecycle tracking.
+
+Issue: #162
+
+## Skill Metadata
+
+```yaml
+name: finish-work
+description: >
+  Use when implementation is complete and validated, to decide how to
+  integrate the work. Presents structured options for merge, PR, keep,
+  or discard with safety verification. Triggers on "finish", "done",
+  "merge this", "create PR", "wrap up", "ship it".
+argument-hint: "[plan file path]"
+user-invocable: true
+references:
+  - references/option-execution.md
+  - references/retrospective-format.md
+  - ../_shared/references/preflight.md
+  - ../_shared/references/plan-format.md
+```
+
+## Workflow
+
+### Step 1: Verify Readiness
+
+Run the project's test suite. Detect test command from the plan's Validation
+section code blocks (if plan found), or from CLAUDE.md / project conventions.
+
+Hard gate: if tests fail, stop and report failures. Do not present options
+until tests pass.
+
+### Step 2: Locate Plan (optional)
+
+- If user provided a plan path, use it.
+- Otherwise, use `plan_assess.py --scan` to search `docs/plans/` for plans
+  with `status: executing` or `status: completed`.
+- If exactly one found, use it. If multiple, ask which one. If none, proceed
+  without plan (pure git workflow).
+- If plan found and status is `executing`, update to `completed`. If already
+  `completed`, leave it.
+- If no plan, skip plan-related steps (status update, retrospective).
+
+### Step 3: Determine Base Branch
+
+Check `git merge-base HEAD main`, fall back to `master`. Confirm with user:
+"This branch diverged from `main` — is that correct?"
+
+### Step 4: Present 4 Options
+
+```
+Implementation complete. What would you like to do?
+
+1. Merge back to <base-branch> locally
+2. Push and create a Pull Request
+3. Keep the branch as-is (I'll handle it later)
+4. Discard this work
+```
+
+No additional explanation — keep options concise.
+
+### Step 5: Execute Chosen Option
+
+Delegate to `option-execution.md` for detailed per-option behavior:
+
+- **Merge**: checkout base, pull, merge, run tests on merged result, delete
+  branch, cleanup worktree if applicable
+- **PR**: push with `-u`, create PR (plan-derived body if plan exists, git
+  log fallback), keep worktree, suggest returning to main worktree
+- **Discard**: show what will be lost, require typed "discard" confirmation,
+  update plan status to `abandoned` if plan exists, delete branch, cleanup
+  worktree
+- **Keep**: confirm branch name, no action, keep worktree
+
+### Step 6: Optional Retrospective (plan only)
+
+Offer only if a plan file was found: "Would you like to add a retrospective
+to the plan?" If yes, add `## Retrospective` section per
+`retrospective-format.md`.
+
+## File Structure
+
+```
+skills/finish-work/
+  SKILL.md
+  references/
+    option-execution.md
+    retrospective-format.md
+```
+
+Plus shared references: `_shared/references/preflight.md`,
+`_shared/references/plan-format.md`.
+
+## Safety Gates
+
+| Gate | Mechanism |
+|------|-----------|
+| Tests must pass | Hard stop in Step 1; no options presented until green |
+| Discard confirmation | Typed "discard" required before destructive action |
+| Worktree cleanup scope | Only on merge or discard; keep and PR preserve worktree |
+| Plan status accuracy | Set `completed` only if executing; set `abandoned` only on discard |
+
+## Anti-Pattern Guards
+
+1. **Presenting options with failing tests** — hard gate prevents this
+2. **Skipping discard confirmation** — must get typed "discard"
+3. **Cleaning up worktree on keep/PR** — only on merge/discard
+4. **Creating PR without plan context** — use plan Goal for PR body when available
+5. **Forcing plan requirement** — skill works with or without a plan file
+
+## Design Justification
+
+| Decision | Source | Evidence |
+|----------|--------|----------|
+| Tests must pass before presenting options | Anthropic effective harnesses (2025) | Hard gates prevent shipping broken work |
+| Exactly 4 structured options | Superpowers v5.0.0 audit | Proven pattern covering all terminal states |
+| Typed discard confirmation | Destructive operation safety patterns | Prevents accidental work loss |
+| Optional retrospective | Codex PLANS.md (OpenAI, 2025) | Living document retrospective, not post-hoc artifact |
+| Plan-optional design | WOS convention | Skill works for plan-backed and ad-hoc branches |
+
+## Acceptance Criteria
+
+- [ ] SKILL.md written and under 500 lines
+- [ ] Skill triggers on "finish", "done", "merge", "create PR"
+- [ ] Tests verified before presenting options
+- [ ] Exactly 4 options presented (merge/PR/keep/discard)
+- [ ] Discard requires typed confirmation
+- [ ] Plan status updated to `completed` (or `abandoned` on discard)
+- [ ] Worktree cleanup handled correctly per option
+- [ ] Optional retrospective offered (plan-only)

--- a/docs/plans/2026-03-11-finish-work-skill-implementation.md
+++ b/docs/plans/2026-03-11-finish-work-skill-implementation.md
@@ -1,0 +1,144 @@
+---
+name: "finish-work skill implementation"
+description: "Implementation plan for wos:finish-work skill — SKILL.md, 2 reference files, CLAUDE.md registration"
+type: plan
+status: completed
+related:
+  - docs/plans/2026-03-11-finish-work-skill-design.md
+---
+
+# finish-work Skill Implementation
+
+## Goal
+
+Create the `wos:finish-work` skill with SKILL.md and 2 reference files, register
+it in CLAUDE.md, and verify with audit. This is the terminal step in the plan
+lifecycle pipeline (issue #162).
+
+## Scope
+
+**Must have:**
+- `skills/finish-work/SKILL.md` — 6-step workflow, under 500 lines
+- `skills/finish-work/references/option-execution.md` — per-option git commands
+- `skills/finish-work/references/retrospective-format.md` — retrospective section format
+- CLAUDE.md updated with finish-work in skills table
+- Indexes regenerated
+- Audit passes
+
+**Won't have:**
+- Python scripts (no automated assessment needed for this skill)
+- Changes to existing planning skills
+- Superpowers deprecation (that's issue #164)
+
+## Approach
+
+Create the 3 markdown files following the patterns established by sibling
+planning skills (validate-plan, execute-plan). Register in CLAUDE.md skills
+table. Run audit to validate.
+
+## File Changes
+
+- **Create:** `skills/finish-work/SKILL.md`
+- **Create:** `skills/finish-work/references/option-execution.md`
+- **Create:** `skills/finish-work/references/retrospective-format.md`
+- **Modify:** `CLAUDE.md` — add finish-work to skills table
+- **Regenerate:** `skills/_index.md` (via reindex script)
+
+## Tasks
+
+### Task 1: Create SKILL.md
+
+**Files:**
+- Create: `skills/finish-work/SKILL.md`
+
+- [x] Create `skills/finish-work/` directory and `SKILL.md` with frontmatter
+  matching the design spec metadata (name, description, argument-hint,
+  user-invocable, references list including shared refs).
+
+- [x] Write the SKILL.md body with the 6-step workflow:
+  1. Verify Readiness — run tests, hard gate on failure
+  2. Locate Plan — optional, use `plan_assess.py --scan`, handle 0/1/many
+  3. Determine Base Branch — `git merge-base`, confirm with user
+  4. Present 4 Options — exact text block, no explanation
+  5. Execute Chosen Option — delegate to `option-execution.md`
+  6. Optional Retrospective — offer only if plan found
+
+- [x] Add Key Instructions section (5 items: test gate, plan-optional,
+  discard safety, worktree rules, status accuracy).
+
+- [x] Add Anti-Pattern Guards section (5 guards from design spec).
+
+- [x] Verify SKILL.md body is under 500 lines:
+  ```bash
+  wc -l skills/finish-work/SKILL.md
+  ```
+
+### Task 2: Create option-execution.md reference
+
+**Files:**
+- Create: `skills/finish-work/references/option-execution.md`
+
+- [x] Write the reference with 4 sections (one per option), each containing:
+  - Preconditions and behavior summary
+  - Git command sequence (platform-agnostic descriptions with example commands)
+  - Worktree handling (cleanup on merge/discard, preserve on PR/keep)
+  - Quick reference table matching the superpowers pattern
+
+- [x] Include PR body format: plan-derived (Goal section) as default, git log
+  as fallback. Include suggestion to return to main worktree after PR creation.
+
+- [x] Include discard confirmation format: show what will be lost (branch name,
+  commit list, worktree path), require typed "discard", update plan status to
+  `abandoned` if plan exists.
+
+### Task 3: Create retrospective-format.md reference
+
+**Files:**
+- Create: `skills/finish-work/references/retrospective-format.md`
+
+- [x] Write the reference covering:
+  - When to offer (only when plan file exists)
+  - Retrospective section format (3 subsections: Completed, Deviations, Lessons)
+  - Where to insert in plan file (after Validation section)
+  - Example retrospective section
+  - Keep it concise — this is a simple reference
+
+### Task 4: Register in CLAUDE.md and reindex
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Regenerate: indexes
+
+- [x] Add `finish-work` to the skills table in CLAUDE.md:
+  ```
+  | `/wos:finish-work` | Structured work integration (merge/PR/keep/discard) |
+  ```
+  Update skill count from 8 to 9.
+
+- [x] Run reindex:
+  ```bash
+  uv run scripts/reindex.py
+  ```
+
+- [x] Run audit to verify:
+  ```bash
+  uv run python -m pytest tests/ -v
+  uv run scripts/audit.py --root .
+  ```
+
+### Task 5: Update design doc status
+
+**Files:**
+- Modify: `docs/plans/2026-03-11-finish-work-skill-design.md`
+
+- [x] Update design doc frontmatter `status: draft` → `status: completed`.
+
+## Validation
+
+1. `uv run python -m pytest tests/ -v` — all tests pass
+2. `uv run scripts/audit.py --root .` — no fail-severity issues
+3. `wc -l skills/finish-work/SKILL.md` — under 500 lines
+4. SKILL.md contains all 6 workflow steps, 5 key instructions, 5 anti-pattern guards
+5. All 4 options documented in option-execution.md with git commands and worktree rules
+6. Retrospective format documented with example
+7. CLAUDE.md lists `/wos:finish-work` in skills table with count updated to 9

--- a/docs/plans/_index.md
+++ b/docs/plans/_index.md
@@ -18,6 +18,8 @@
 | [2026-03-11-brainstorm-skill.md](2026-03-11-brainstorm-skill.md) | Create wos:brainstorm skill with SKILL.md and two reference files — issue #158 |
 | [2026-03-11-execute-plan-skill-design.md](2026-03-11-execute-plan-skill-design.md) | Design spec for wos:execute-plan skill — plan execution with lifecycle gates, parallel dispatch, and deterministic assessment |
 | [2026-03-11-execute-plan-skill-implementation.md](2026-03-11-execute-plan-skill-implementation.md) | Implementation plan for wos:execute-plan skill — entry script, SKILL.md, and 4 reference files |
+| [2026-03-11-finish-work-skill-design.md](2026-03-11-finish-work-skill-design.md) | "Design spec for wos:finish-work — structured work termination with 4 integration options, safety gates, and optional retrospective" |
+| [2026-03-11-finish-work-skill-implementation.md](2026-03-11-finish-work-skill-implementation.md) | "Implementation plan for wos:finish-work skill — SKILL.md, 2 reference files, CLAUDE.md registration" |
 | [2026-03-11-plan-document-format-design.md](2026-03-11-plan-document-format-design.md) | "Design spec for plan document format, lifecycle, and status field — issue #157" |
 | [2026-03-11-plan-document-format-implementation.md](2026-03-11-plan-document-format-implementation.md) | Add status field to Document model, create plan-format reference, and retrofit existing plans — issue #157 |
 | [2026-03-11-validate-plan-skill-design.md](2026-03-11-validate-plan-skill-design.md) | Design spec for wos:validate-plan skill — plan-level validation with automated/human criteria, failure diagnosis, and recovery |

--- a/skills/finish-work/SKILL.md
+++ b/skills/finish-work/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: finish-work
+description: >
+  Use when implementation is complete and validated, to decide how to
+  integrate the work. Presents structured options for merge, PR, keep,
+  or discard with safety verification. Use when the user wants to
+  "finish", "done", "merge this", "create PR", "wrap up", "ship it",
+  or after completing all tasks and validation in a plan.
+argument-hint: "[plan file path]"
+user-invocable: true
+references:
+  - references/option-execution.md
+  - references/retrospective-format.md
+  - ../_shared/references/preflight.md
+  - ../_shared/references/plan-format.md
+---
+
+# Finish Work
+
+Decide how to integrate completed work — merge, PR, keep, or discard —
+with safety verification and optional plan lifecycle updates.
+
+**Announce at start:** "I'm using the finish-work skill to complete this work."
+
+## Workflow
+
+### 1. Verify Readiness
+
+Run the project's test suite before anything else. Detect the test command
+from:
+
+1. The plan's **Validation** section code blocks (if a plan is found in
+   Step 2 — read ahead to locate it first)
+2. CLAUDE.md or project conventions (e.g., `package.json` scripts, pytest
+   configuration)
+3. Ask the user if no test command is discoverable
+
+```
+Tests passing (N passed). Proceeding to integration options.
+```
+
+**Hard gate:** if tests fail, stop and report failures. Do not present
+options until tests pass.
+
+```
+Tests failing (N failures). Must fix before completing:
+
+[Show failures]
+
+Cannot proceed until tests pass.
+```
+
+### 2. Locate Plan (optional)
+
+If the user provided a plan path as an argument, use it. Otherwise, search
+for a plan file:
+
+```bash
+uv run <plugin-scripts-dir>/check_runtime.py
+uv run <plugin-skills-dir>/execute-plan/scripts/plan_assess.py --scan --root <project-root>
+```
+
+Parse the JSON output to find plans with `status: executing` or
+`status: completed`.
+
+| Result | Action |
+|--------|--------|
+| Exactly one plan found | Use it |
+| Multiple plans found | Ask the user which one applies |
+| No plans found | Proceed without plan — skip plan-related steps |
+
+If a plan is found with `status: executing`, update frontmatter to
+`status: completed`. If already `completed`, leave it unchanged.
+
+### 3. Determine Base Branch
+
+Identify the branch this work should integrate into:
+
+```bash
+git merge-base HEAD main
+```
+
+If that fails, try `master`. Confirm with the user:
+
+> "This branch diverged from `main` — is that correct?"
+
+### 4. Present 4 Options
+
+Present exactly these options with no additional explanation:
+
+```
+Implementation complete. What would you like to do?
+
+1. Merge back to <base-branch> locally
+2. Push and create a Pull Request
+3. Keep the branch as-is (I'll handle it later)
+4. Discard this work
+```
+
+### 5. Execute Chosen Option
+
+Follow the detailed procedures in
+[option-execution](references/option-execution.md) for the chosen option.
+
+Summary:
+
+- **Option 1 — Merge locally:** checkout base branch, pull latest, merge
+  feature branch, verify tests on merged result, delete feature branch,
+  clean up worktree if applicable.
+- **Option 2 — Push and create PR:** push branch with `-u`, create PR
+  using plan Goal as body (or git log if no plan), keep worktree, suggest
+  returning to main worktree.
+- **Option 3 — Keep branch:** confirm branch name, take no action, keep
+  worktree.
+- **Option 4 — Discard:** show what will be lost, require typed "discard"
+  confirmation, update plan status to `abandoned` if plan exists, delete
+  branch, clean up worktree.
+
+### 6. Optional Retrospective
+
+Offer only if a plan file was found in Step 2:
+
+> "Would you like to add a retrospective to the plan?"
+
+If yes, follow the format in
+[retrospective-format](references/retrospective-format.md) to append a
+`## Retrospective` section to the plan file.
+
+If no plan was found, skip this step entirely.
+
+## Key Instructions
+
+- **Tests must pass before presenting options.** The hard gate in Step 1
+  enforces this. Shipping broken work is worse than delaying integration.
+- **Plan is optional.** The skill works for both plan-backed branches and
+  ad-hoc feature branches. Skip plan-related steps when no plan exists.
+- **Discard is irreversible — confirm explicitly.** Require the user to
+  type "discard" before deleting any branch or work. Show exactly what
+  will be lost.
+- **Worktree cleanup follows the option.** Only clean up worktrees on
+  merge (Option 1) or discard (Option 4). Keep and PR preserve the
+  worktree for continued access.
+- **Plan status must be accurate.** Set `completed` only when transitioning
+  from `executing`. Set `abandoned` only on discard. Never overwrite a
+  status that's already terminal.
+
+## Anti-Pattern Guards
+
+1. **Presenting options with failing tests** — the hard gate prevents
+   this, but if you discover test failures after Step 1, stop and report
+   them before continuing.
+2. **Skipping discard confirmation** — every discard must get typed
+   "discard" from the user. No shortcuts, no "are you sure?" yes/no.
+3. **Cleaning up worktree on keep or PR** — Options 2 and 3 preserve
+   the worktree. Only Options 1 and 4 trigger cleanup.
+4. **Creating PR without plan context** — when a plan exists, use its
+   Goal section for the PR body. Fall back to git log only when no plan
+   is available.
+5. **Forcing plan requirement** — if no plan is found, proceed with the
+   pure git workflow. Do not ask the user to create a plan just to finish
+   their work.

--- a/skills/finish-work/references/option-execution.md
+++ b/skills/finish-work/references/option-execution.md
@@ -1,0 +1,175 @@
+# Option Execution
+
+Detailed procedures for each of the 4 integration options presented by
+the finish-work skill.
+
+## Option 1: Merge Locally
+
+Merge the feature branch into the base branch on the local machine.
+
+**Steps:**
+
+1. Switch to the base branch:
+   ```bash
+   git checkout <base-branch>
+   ```
+
+2. Pull latest changes:
+   ```bash
+   git pull
+   ```
+
+3. Merge the feature branch:
+   ```bash
+   git merge <feature-branch>
+   ```
+
+4. Run the test suite on the merged result. If tests fail, the merge
+   introduced a conflict or regression — report it and let the user
+   decide how to proceed.
+
+5. Delete the feature branch:
+   ```bash
+   git branch -d <feature-branch>
+   ```
+
+6. Clean up worktree if applicable (see Worktree Cleanup below).
+
+**Report on completion:**
+```
+Merged <feature-branch> into <base-branch>.
+Tests passing on merged result.
+Branch <feature-branch> deleted.
+```
+
+## Option 2: Push and Create PR
+
+Push the branch to the remote and create a pull request.
+
+**Steps:**
+
+1. Push the branch:
+   ```bash
+   git push -u origin <feature-branch>
+   ```
+
+2. Build the PR body:
+   - **If plan exists:** use the plan's **Goal** section as the summary.
+     Include a link to the plan file. Add task count
+     (e.g., "5/5 tasks completed").
+   - **If no plan:** use `git log <base-branch>..HEAD --oneline` to
+     summarize commits.
+
+3. Create the PR:
+   ```bash
+   gh pr create --title "<title>" --body "<body>"
+   ```
+
+4. Report the PR URL to the user.
+
+5. Suggest returning to the main worktree:
+   > "PR created. You may want to return to your main worktree:
+   > `cd <main-worktree-path>`"
+
+**Do not clean up the worktree.** The user may need it for PR review
+feedback or follow-up changes.
+
+## Option 3: Keep Branch
+
+Leave the branch exactly as-is for the user to handle later.
+
+**Steps:**
+
+1. Confirm the branch name:
+   ```
+   Keeping branch <feature-branch>. No changes made.
+   ```
+
+2. If in a worktree, report the worktree path:
+   ```
+   Worktree preserved at <path>.
+   ```
+
+**Take no other action.** Do not push, merge, or clean up anything.
+
+## Option 4: Discard
+
+Delete the branch and all its changes. This is destructive and irreversible.
+
+**Steps:**
+
+1. Show what will be lost:
+   ```
+   This will permanently delete:
+   - Branch: <feature-branch>
+   - Commits: <list recent commits with one-line summaries>
+   - Worktree: <path> (if applicable)
+   ```
+
+2. If a plan file exists, note that its status will be set to `abandoned`.
+
+3. Require typed confirmation:
+   ```
+   Type 'discard' to confirm.
+   ```
+
+4. Wait for exact confirmation. If the user types anything other than
+   "discard", cancel the operation.
+
+5. If confirmed:
+   - Switch to the base branch:
+     ```bash
+     git checkout <base-branch>
+     ```
+   - Delete the feature branch:
+     ```bash
+     git branch -D <feature-branch>
+     ```
+   - Update plan frontmatter to `status: abandoned` if a plan exists.
+   - Clean up worktree if applicable (see Worktree Cleanup below).
+
+**Report on completion:**
+```
+Branch <feature-branch> discarded.
+All changes deleted.
+```
+
+## Worktree Cleanup
+
+Worktree cleanup applies only to Options 1 (Merge) and 4 (Discard).
+
+**Detection:** Check if the current working directory is inside a worktree:
+
+```bash
+git worktree list
+```
+
+If the current directory appears in the worktree list (and is not the
+main working tree), it is a worktree that may need cleanup.
+
+**Cleanup procedure:**
+
+1. Switch to the main working tree first:
+   ```bash
+   cd <main-worktree-path>
+   ```
+
+2. Remove the worktree:
+   ```bash
+   git worktree remove <worktree-path>
+   ```
+
+3. If removal fails (e.g., untracked files), use `--force` only after
+   confirming with the user.
+
+**Options 2 and 3 do NOT trigger worktree cleanup.** The worktree is
+preserved for continued work.
+
+## Quick Reference
+
+| Option | Merge | Push | Delete Branch | Cleanup Worktree | Plan Status |
+|--------|-------|------|---------------|------------------|-------------|
+| 1. Merge | Yes | No | Yes (`-d`) | Yes | completed |
+| 2. PR | No | Yes | No | No | completed |
+| 3. Keep | No | No | No | No | unchanged |
+| 4. Discard | No | No | Yes (`-D`) | Yes | abandoned |

--- a/skills/finish-work/references/retrospective-format.md
+++ b/skills/finish-work/references/retrospective-format.md
@@ -1,0 +1,64 @@
+# Retrospective Format
+
+Format for the optional `## Retrospective` section appended to plan files
+after work is integrated.
+
+## When to Offer
+
+Offer a retrospective only when a plan file was found during the
+finish-work workflow. Do not offer for ad-hoc branches without plans.
+
+## Where to Insert
+
+Append the `## Retrospective` section at the end of the plan file, after
+the **Validation** section. It is the final section in the document.
+
+## Section Structure
+
+The retrospective has 3 subsections:
+
+### Completed
+
+What was actually delivered. Reference task checkboxes and commit SHAs
+from the plan. Keep it factual — this is a record, not a narrative.
+
+### Deviations
+
+Where the implementation diverged from the original plan. Include:
+- Tasks added or removed during execution
+- Scope changes and why they happened
+- Approach changes from the original design
+
+If there were no deviations, state: "None — plan executed as written."
+
+### Lessons
+
+What would be done differently next time. Focus on actionable insights:
+- What assumptions were wrong
+- What was harder or easier than expected
+- What tooling or process changes would help
+
+## Example
+
+```markdown
+## Retrospective
+
+### Completed
+
+5/5 tasks completed. Added URL validation for research documents,
+content length checks for context files, and index sync verification.
+
+### Deviations
+
+- Added Task 3b (content length upper bound) after discovering context
+  files exceeding 1000 words during testing. Not in original plan.
+- Dropped configurable thresholds from Task 4 — YAGNI, hardcoded
+  defaults were sufficient.
+
+### Lessons
+
+- Testing validators against real project files caught edge cases that
+  synthetic test fixtures missed. Use real files in future validator work.
+- The index sync check was simpler than expected — `generate_index()`
+  already returned enough state to diff against disk.
+```


### PR DESCRIPTION
## Summary

- Adds `wos:finish-work` skill — terminal step in the plan lifecycle pipeline (brainstorm → write-plan → execute-plan → validate-plan → **finish-work**)
- Replaces `superpowers:finishing-a-development-branch` with a WOS-native equivalent that integrates with plan lifecycle tracking
- 6-step workflow: verify tests → locate plan → determine base branch → present 4 options (merge/PR/keep/discard) → execute → optional retrospective

## Files

- `skills/finish-work/SKILL.md` (161 lines) — workflow, key instructions, anti-pattern guards
- `skills/finish-work/references/option-execution.md` — per-option git commands, worktree rules, PR body format, discard confirmation
- `skills/finish-work/references/retrospective-format.md` — plan retrospective section format (Completed/Deviations/Lessons)
- `CLAUDE.md` — registered as 9th skill
- Design + implementation plan docs in `docs/plans/`

## Test plan

- [x] `uv run python -m pytest tests/ -v` — 300 tests pass
- [x] `uv run scripts/audit.py --root . --no-urls` — no new issues (all fails are pre-existing)
- [x] SKILL.md under 500 lines (161)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)