### PR TITLE
fix: worktree cleanup in parallel dispatch, enforce docs/context/ in distill

### DIFF
--- a/skills/distill/SKILL.md
+++ b/skills/distill/SKILL.md
@@ -40,6 +40,10 @@ Present a distillation plan as a table:
 |---|---------|-------------|----------|--------------|
 | 1 | Key finding one | docs/context/area/ | finding-one.md | ~400 |
 
+**Target Area must be under `docs/context/`.** If the user requests a
+different location, write to `docs/context/` first (the canonical
+location), then offer to copy files to the additional location.
+
 User approves, edits, or rejects individual rows.
 
 ### 4. Generate

--- a/skills/execute-plan/references/parallel-dispatch.md
+++ b/skills/execute-plan/references/parallel-dispatch.md
@@ -80,8 +80,33 @@ After all tasks in a wave complete:
 2. Run verification commands for each completed task
 3. Update checkboxes and append SHAs in the plan file
 4. Commit the plan file update
+5. Clean up worktrees and branches for merged tasks
 
 **If merge conflicts occur** (the file-boundary analysis should prevent
 this, but it's not infallible): escalate to the user. Do not attempt
 automatic conflict resolution — the risk of introducing subtle bugs
 outweighs the convenience.
+
+## Worktree Cleanup
+
+After merging a worktree's changes, remove the worktree and its branch
+immediately. Do not defer cleanup to the end of the plan.
+
+For each merged worktree:
+
+```bash
+git worktree remove <worktree-path>
+git branch -d <worktree-branch>
+```
+
+Example:
+
+```bash
+git worktree remove .claude/worktrees/agent-task-3
+git branch -d worktree-agent-task-3
+```
+
+If `git worktree remove` fails because of untracked files, use
+`--force` only after confirming the merge was successful. If
+`git branch -d` fails because the branch is not fully merged,
+investigate before using `-D` — this usually indicates a merge problem.


### PR DESCRIPTION
## Summary

- **#178**: Added worktree and branch cleanup steps to the parallel-dispatch merge protocol. Worktrees and branches are now removed immediately after merging, preventing orphaned directories from accumulating.
- **#176**: Enforced `docs/context/` as the canonical output location in the distill skill. If users want files elsewhere, the skill writes to `docs/context/` first, then offers to copy.

Closes #178
Closes #176

## Test plan

- [x] All 300 tests pass
- [x] Audit clean (pre-existing execute-plan line count warning only)
- [ ] Verify parallel dispatch cleans up worktrees after merge in a real plan execution
- [ ] Verify distill skill enforces `docs/context/` when a non-standard path is proposed

🤖 Generated with [Claude Code](https://claude.com/claude-code)