### PR TITLE
fix: default worktree storage to model-agnostic .worktrees/ location

### DIFF
--- a/skills/execute-plan/references/parallel-dispatch.md
+++ b/skills/execute-plan/references/parallel-dispatch.md
@@ -87,6 +87,20 @@ this, but it's not infallible): escalate to the user. Do not attempt
 automatic conflict resolution — the risk of introducing subtle bugs
 outweighs the convenience.
 
+## Worktree Location
+
+Use `.worktrees/` in the project root as the default worktree directory.
+This is model-agnostic — it works the same regardless of which AI coding
+tool dispatches the subagents.
+
+Ensure `.worktrees/` is in the project's `.gitignore` (the `wos:init`
+skill includes this automatically for new projects).
+
+**Platform overrides:** Some platforms default to vendor-specific paths
+(e.g., `.claude/worktrees/`). When dispatching, prefer specifying
+`.worktrees/<branch-name>` explicitly so worktrees land in a consistent
+location across tools.
+
 ## Worktree Cleanup
 
 After merging a worktree's changes, remove the worktree and its branch
@@ -102,8 +116,8 @@ git branch -d <worktree-branch>
 Example:
 
 ```bash
-git worktree remove .claude/worktrees/agent-task-3
-git branch -d worktree-agent-task-3
+git worktree remove .worktrees/task-3
+git branch -d worktree-task-3
 ```
 
 If `git worktree remove` fails because of untracked files, use

--- a/skills/init/SKILL.md
+++ b/skills/init/SKILL.md
@@ -67,6 +67,7 @@ dist/
 .ruff_cache/
 .pytest_cache/
 .env
+.worktrees/
 ```
 
 Ask: "Want me to create a `.gitignore` with Python defaults? (yes / modify / skip)"


### PR DESCRIPTION
## Summary

- Add "Worktree Location" section to `parallel-dispatch.md` establishing `.worktrees/` as the model-agnostic default convention
- Update cleanup examples from `.claude/worktrees/` to `.worktrees/`
- Include `.worktrees/` in the `wos:init` `.gitignore` template for new projects

Closes #175

## Test plan

- [x] `uv run python -m pytest tests/ -v` — 300 passed
- [ ] Verify parallel-dispatch.md Worktree Location section reads correctly
- [ ] Verify init SKILL.md `.gitignore` template includes `.worktrees/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)