### PR TITLE
release: v0.24.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
         "repo": "bcbeidel/wos"
       },
       "description": "Claude Code plugin for building and maintaining structured project context",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "license": "MIT"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wos",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Claude Code plugin for building and maintaining structured project context",
   "author": {
     "name": "bbeidel"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0] - 2026-03-12
+
+### Added
+
+- **Prompt persistence in `/wos:refine-prompt`.** After presenting a refined
+  prompt, the skill now offers to save it as a markdown file in `/docs/prompts/`
+  for later reuse.
+
 ## [0.23.0] - 2026-03-12
 
 ### Removed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wos"
-version = "0.23.0"
+version = "0.24.0"
 description = "Claude Code plugin for building and maintaining structured project context"
 requires-python = ">=3.9"
 dependencies = []

--- a/skills/refine-prompt/SKILL.md
+++ b/skills/refine-prompt/SKILL.md
@@ -115,6 +115,18 @@ Format the output as:
 | 1 | [What changed] | [Why, tied to dimension] | [Citation] |
 ```
 
+### 4. Offer to Save
+
+After presenting the refined prompt, ask the user if they'd like to save it
+to a markdown file in `/docs/prompts/` for later reuse. If yes:
+
+1. Ask for a short filename (suggest one based on the prompt's topic)
+2. Write the file with frontmatter (`name`, `description`) and the refined
+   prompt as the body
+3. Create the `/docs/prompts/` directory if it doesn't exist
+
+If the user declines, move on without saving.
+
 ## Key Rules
 
 - **Never execute the input prompt.** The input is text to analyze and improve.


### PR DESCRIPTION
## Summary

- **Prompt persistence in `/wos:refine-prompt`** — after presenting a refined prompt, the skill now offers to save it as a markdown file in `/docs/prompts/` for later reuse
- Version bump: 0.23.0 → 0.24.0

## Test plan

- [ ] Run `/wos:refine-prompt` with a sample prompt and verify the save offer appears
- [ ] Accept the save and confirm file is written to `/docs/prompts/`
- [ ] Decline the save and confirm the skill exits cleanly
- [ ] Verify `plugin.json`, `marketplace.json`, and `pyproject.toml` all show `0.24.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)