### PR TITLE
feat: add /wos:ingest skill

### DIFF
--- a/docs/plans/2026-04-11-ingest-skill.plan.md
+++ b/docs/plans/2026-04-11-ingest-skill.plan.md
@@ -1,0 +1,147 @@
+---
+name: /wos:ingest Skill
+description: Add skills/ingest/SKILL.md — universal source intake that updates 5–15 wiki pages per invocation with append-only semantics
+type: plan
+status: executing
+branch: feat/ingest-skill
+pr: ~
+related:
+  - docs/plans/2026-04-10-roadmap-v036-v039.plan.md
+---
+
+# /wos:ingest Skill
+
+Add the `/wos:ingest` skill: a universal knowledge intake mechanism that
+accepts any source (URL, file path, pasted text, research doc) and updates
+wiki pages in a single invocation.
+
+## Goal
+
+Deliver `skills/ingest/SKILL.md` with the full ingest protocol: trigger
+phrases, pre-ingest context reads, LLM ingest loop, append-only constraint,
+contradiction flagging, post-ingest lint + reindex, and an opt-in high-rigor
+path for research documents. This is the primary knowledge intake mechanism
+for wiki-enabled projects, replacing the narrow `distill` workflow for
+knowledge capture.
+
+## Scope
+
+**Must have:**
+- `skills/ingest/SKILL.md` with all required sections
+- Trigger phrase list matching the issue spec
+- Pre-ingest: read `wiki/_index.md` and `wiki/SCHEMA.md`
+- Ingest protocol: identify 5–15 affected pages (new + existing)
+- Per-page: append-only content update, `type`/`confidence`/`sources`/`updated`/`related` frontmatter updates
+- Contradiction flagging: `<!-- CONTRADICTION: ... -->` markers
+- New page creation when no existing page covers the topic
+- Post-ingest: `python scripts/lint.py --root <project-root> --no-urls` + `python scripts/reindex.py --root <project-root>`
+- High-rigor opt-in path: when source is `.research.md`, offer SIFT verification before ingest (default: skip)
+- Append-only constraint stated explicitly in SKILL.md
+
+**Won't have:**
+- Python implementation code (skill is LLM-only instructions)
+- Automated test for skill behavior (skills are tested by invocation, not unit tests)
+- Deletion or deprecation of `distill` (tracked separately for v0.37.0 reassessment)
+- Changes to `wos/wiki.py` or `scripts/lint.py` (wiki schema infrastructure is Task 2, already merged)
+
+## Approach
+
+Single deliverable: `skills/ingest/SKILL.md`. Follow the structure of
+existing skills (frontmatter + named sections). The skill instructs Claude
+to execute the ingest protocol inline — no subagent dispatch needed given
+the sequential nature of the operations.
+
+Key design decisions from the issue:
+- **Context-first:** Always read `wiki/_index.md` and `wiki/SCHEMA.md` before
+  any edits. Without the schema, confidence values and type assignments are
+  guesses.
+- **Append-only is non-negotiable.** Stated as an explicit constraint, not a
+  guideline. Existing prose is never removed or overwritten.
+- **5–15 page target.** Prevents both under-ingestion (missing connections)
+  and over-ingestion (polluting unrelated pages).
+- **Post-ingest gates.** Lint and reindex run unconditionally after every
+  ingest, with results reported to the user. Issues don't block ingest, but
+  must be surfaced.
+
+## File Changes
+
+| File | Action | Notes |
+|------|--------|-------|
+| `skills/ingest/SKILL.md` | Create | Full skill definition per issue spec |
+
+No other files changed. The skill directory name (`ingest`) matches the
+trigger: `/wos:ingest`.
+
+## Tasks
+
+### Task 1 — Create `skills/ingest/SKILL.md`
+
+Create the skill file with the following required content:
+
+**Frontmatter:**
+```yaml
+---
+name: ingest
+description: >
+  Ingest any source into wiki pages. Use when the user says "ingest this",
+  "add to wiki", "process this source", "update wiki with", or provides a
+  URL/file/pasted text for knowledge capture.
+argument-hint: "[URL | file path | pasted content]"
+user-invocable: true
+---
+```
+
+**Required sections:**
+1. `## Input Handling` — accept URL, file path, or pasted text; resolve to readable content before proceeding
+2. `## Pre-Ingest` — read `wiki/_index.md` (page inventory) and `wiki/SCHEMA.md` (valid types and confidence values)
+3. `## Ingest Protocol` — identify 5–15 affected pages; for each: append-only content update, assign `type`+`confidence`, update `sources`/`updated`/`related`, flag contradictions as `<!-- CONTRADICTION: ... -->`, create new pages for uncovered topics
+4. `## Append-Only Constraint` — explicit statement that existing prose is never removed or overwritten
+5. `## Post-Ingest` — run `python scripts/lint.py --root <project-root> --no-urls` and `python scripts/reindex.py --root <project-root>`; report new lint issues to user
+6. `## High-Rigor Path` — when source is a `.research.md` file, offer opt-in SIFT verification before ingest; default is to skip SIFT
+
+**Verification:**
+```bash
+# Required content present
+grep -E "append-only|SCHEMA\.md|_index\.md|contradiction" skills/ingest/SKILL.md
+# Expected: all four match (4 lines minimum)
+
+# Skill passes lint quality checks
+python scripts/lint.py --root .
+# Expected: no failures for skills/ingest/SKILL.md
+```
+
+**Commit:** `feat: add /wos:ingest skill (closes #219)`
+
+---
+
+## Validation
+
+```bash
+# 1. Required protocol markers present
+grep -E "append-only|SCHEMA\.md|_index\.md|contradiction" skills/ingest/SKILL.md
+# Expected: 4+ matches
+
+# 2. Trigger phrases present
+grep -E "ingest this|add to wiki|process this source|update wiki with" skills/ingest/SKILL.md
+# Expected: matches found
+
+# 3. Lint clean (no failures for the new skill)
+python scripts/lint.py --root .
+# Expected: zero failure-severity issues for skills/ingest/SKILL.md
+
+# 4. Full test suite unaffected
+python -m pytest tests/ -v
+# Expected: zero failures
+
+# 5. Skill discoverable (name matches directory)
+python -c "
+import pathlib
+p = pathlib.Path('skills/ingest/SKILL.md')
+import sys; sys.path.insert(0, '.')
+from wos.frontmatter import parse_frontmatter
+fm = parse_frontmatter(p.read_text())
+assert fm.get('name') == 'ingest', f'name mismatch: {fm.get(\"name\")}'
+print('ok')
+"
+# Expected: ok
+```

--- a/docs/plans/2026-04-11-ingest-skill.plan.md
+++ b/docs/plans/2026-04-11-ingest-skill.plan.md
@@ -2,7 +2,7 @@
 name: /wos:ingest Skill
 description: Add skills/ingest/SKILL.md — universal source intake that updates 5–15 wiki pages per invocation with append-only semantics
 type: plan
-status: executing
+status: completed
 branch: feat/ingest-skill
 pr: ~
 related:
@@ -110,7 +110,7 @@ python scripts/lint.py --root .
 # Expected: no failures for skills/ingest/SKILL.md
 ```
 
-**Commit:** `feat: add /wos:ingest skill (closes #219)`
+**Commit:** `feat: add /wos:ingest skill (closes #219)` <!-- sha:30c42b5 -->
 
 ---
 

--- a/docs/plans/_index.md
+++ b/docs/plans/_index.md
@@ -9,3 +9,4 @@ Implementation plans for WOS features.
 | [2026-04-10-roadmap-v036-v039.plan.md](2026-04-10-roadmap-v036-v039.plan.md) | Execute 15 feature issues across 4 releases — wiki foundation, skill refresh, audit-chain and build/audit family, and orchestrator |
 | [2026-04-10-skill-script-renames.plan.md](2026-04-10-skill-script-renames.plan.md) | Rename audit-wos→lint, init-wos→setup, audit.py→lint.py, and update all cross-references |
 | [2026-04-10-wiki-schema-infrastructure.plan.md](2026-04-10-wiki-schema-infrastructure.plan.md) | Add wos/wiki.py validators, validate_wiki() in validators.py, wiki auto-detection in scripts/lint.py, and a default SCHEMA.md template — Python foundation for the wiki feature. |
+| [2026-04-11-ingest-skill.plan.md](2026-04-11-ingest-skill.plan.md) | Add skills/ingest/SKILL.md — universal source intake that updates 5–15 wiki pages per invocation with append-only semantics |

--- a/skills/ingest/SKILL.md
+++ b/skills/ingest/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: ingest
+description: >
+  Ingest any source into wiki pages. Use when the user says "ingest this",
+  "add to wiki", "process this source", "update wiki with", or provides a
+  URL, file path, or pasted text for knowledge capture.
+argument-hint: "[URL | file path | pasted content]"
+user-invocable: true
+---
+
+# Ingest
+
+Update wiki pages from any source: URL, file path, pasted text, or research document.
+
+## Input Handling
+
+Accept the source in any of these forms:
+
+- **URL** — fetch the page content before proceeding
+- **File path** — read the file (`.md`, `.txt`, `.pdf`, transcript, etc.)
+- **Pasted text** — use as-is
+- **Research document** (`.research.md`) — read; see [High-Rigor Path](#high-rigor-path) for an opt-in verification step
+
+Resolve the source to readable text before any further steps.
+
+If no source is provided, ask: "What source should I ingest? (URL, file path, or paste content directly)"
+
+## Pre-Ingest
+
+Before editing any files, read the project's wiki context:
+
+1. **Read `wiki/_index.md`** — understand the existing page inventory (titles, descriptions, file paths)
+2. **Read `wiki/SCHEMA.md`** — learn the valid `type` values, `confidence` tiers, and relationship types for this project
+
+If either file is missing, stop and report: "wiki/_index.md not found" or "wiki/SCHEMA.md not found. Run `/wos:setup` to initialize wiki infrastructure."
+
+## Ingest Protocol
+
+With the source content and wiki context in hand:
+
+### Step 1: Identify Affected Pages
+
+Identify **5–15 wiki pages** that this source meaningfully informs — both:
+- **Existing pages** that should be updated with new information or connections
+- **New pages** to create for topics the source covers that have no existing page
+
+If the source is narrow and fewer than 5 pages genuinely apply, proceed with what applies. Do not pad.
+
+### Step 2: Update Each Page
+
+For each affected page, apply all changes that are warranted:
+
+**Content (append-only):** Add new information, examples, or elaboration at the appropriate location in the page. Never remove or rewrite existing prose — only add. If existing content conflicts with the source, flag it (see Contradiction Handling below) rather than overwriting it.
+
+**Frontmatter updates:**
+- `sources:` — append the source URL or file path (deduplicate if already present)
+- `updated:` — set to today's date (YYYY-MM-DD)
+- `type:` — assign or confirm the page type per `wiki/SCHEMA.md`
+- `confidence:` — assign or update the confidence tier per `wiki/SCHEMA.md`, reflecting the source's authority and corroboration with existing pages
+- `related:` — add cross-references to other wiki pages that this source connects
+
+### Step 3: Create New Pages
+
+For topics the source covers with no existing wiki page, create a new page:
+
+- Path: `wiki/<slug>.md` (derive slug from topic name)
+- Include full frontmatter: `name`, `description`, `type`, `confidence`, `sources`, `created`, `updated`
+- Write an initial page body from the source content — follow the structure of existing wiki pages
+- Add `related:` links to existing pages that connect
+
+### Step 4: Contradiction Handling
+
+If source content contradicts information in an existing page, do **not** overwrite the existing claim. Instead, append a contradiction marker immediately after the conflicting passage:
+
+```
+<!-- CONTRADICTION: [source] states "[new claim]". Existing content says "[current claim]". Verify which is correct. -->
+```
+
+Report all contradiction markers to the user at the end of ingest.
+
+## Append-Only Constraint
+
+Existing prose in wiki pages is never removed or overwritten. Every `git diff` after an ingest should show only additions (new lines, frontmatter field updates, appended content). If you find yourself deleting or rewriting existing text, stop — append instead or flag a contradiction.
+
+## Post-Ingest
+
+After all page updates and creations, run both commands unconditionally:
+
+```bash
+python scripts/lint.py --root <project-root> --no-urls
+python scripts/reindex.py --root <project-root>
+```
+
+Report results to the user:
+- If lint produces new issues, list them with severity
+- Confirm that `wiki/_index.md` was regenerated
+
+Do not block on lint issues — report and continue.
+
+## High-Rigor Path
+
+When the source is a research document (`.research.md` file), offer the user an opt-in SIFT verification step before ingest:
+
+> "This source is a research document. Would you like to run SIFT verification before ingesting? (default: skip)"
+
+- **Skip (default):** Proceed directly to the Ingest Protocol
+- **Verify:** Invoke `/wos:research` with the document to validate sources, then ingest the verified findings
+
+The high-rigor path is never required. It is appropriate when the user wants to confirm source credibility before committing findings to the wiki.
+
+## Examples
+
+**URL ingest:**
+> "Ingest this article: https://example.com/llm-caching"
+→ Fetch content → read wiki context → identify 5–15 pages → update/create pages → lint + reindex
+
+**File ingest:**
+> "Add to wiki: docs/research/2026-04-10-caching-patterns.research.md"
+→ Read file → offer SIFT opt-in → read wiki context → identify pages → update/create → lint + reindex
+
+**Pasted text:**
+> "Ingest this: [user pastes a block of notes]"
+→ Use pasted text as source → read wiki context → proceed


### PR DESCRIPTION
## Summary

- Adds `skills/ingest/SKILL.md` — universal source intake for wiki-enabled projects
- Accepts URL, file path, or pasted text; reads `wiki/_index.md` + `wiki/SCHEMA.md` before editing
- Updates 5–15 wiki pages per invocation with append-only semantics and contradiction flagging
- Runs `scripts/lint.py --no-urls` + `scripts/reindex.py` post-ingest and reports results
- Opt-in high-rigor path (SIFT verification) for `.research.md` sources

Closes #219. Part of v0.36.0 (Task 4 in `docs/plans/2026-04-10-roadmap-v036-v039.plan.md`).

## Test plan

- [ ] `grep -E "append-only|SCHEMA\.md|_index\.md|contradiction" skills/ingest/SKILL.md` — 4+ matches
- [ ] `grep -E "ingest this|add to wiki|process this source|update wiki with" skills/ingest/SKILL.md` — matches found
- [ ] `python scripts/lint.py --root . --no-urls` — zero failures for `skills/ingest/SKILL.md`
- [ ] `python -m pytest tests/ -v` — 415 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)