### PR TITLE
chore: release v0.37.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
         "repo": "bcbeidel/wos"
       },
       "description": "Claude Code plugin for building and maintaining structured project context",
-      "version": "0.36.0",
+      "version": "0.37.0",
       "license": "MIT"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wos",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "description": "Claude Code plugin for building and maintaining structured project context",
   "author": {
     "name": "bbeidel"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.37.0] - 2026-04-11
+
+### Added
+
+- **`## Handoff` contracts on all skills.** Every SKILL.md now declares
+  `Receives`, `Produces`, and `Chainable-to` fields, making skill chains
+  inspectable and auditable.
+
+### Changed
+
+- **All 14 skills refreshed against v0.35.0 research and context base.**
+  Anti-pattern guards added, gate checks strengthened, and examples updated
+  across brainstorm, check-rules, distill, execute-plan, extract-rules,
+  finish-work, ingest, lint, refine-prompt, research, retrospective, setup,
+  validate-work, and write-plan.
+
 ## [0.36.0] - 2026-04-11
 
 ### Added

--- a/docs/plans/2026-04-10-roadmap-v036-v039.plan.md
+++ b/docs/plans/2026-04-10-roadmap-v036-v039.plan.md
@@ -122,7 +122,7 @@ git checkout -b feat/skill-refresh
 **Dependencies:** Task 6 merged
 **Branch strategy:** `[sequential after Task 6]` — continues on `feat/skill-refresh`
 
-- [ ] Task 7: Implement #223 — each skill reviewed against relevant context files; anti-pattern guards added; gate checks strengthened <!-- sha: -->
+- [x] Task 7: Implement #223 — each skill reviewed against relevant context files; anti-pattern guards added; gate checks strengthened <!-- sha:b98e7c7 -->
 
 **Verification:** each SKILL.md has at least one substantive change (not cosmetic); `python scripts/lint.py --root .` — no skill exceeds 500 instruction lines; no new warnings
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wos"
-version = "0.36.0"
+version = "0.37.0"
 description = "Claude Code plugin for building and maintaining structured project context"
 requires-python = ">=3.9"
 dependencies = []


### PR DESCRIPTION
Bump version 0.36.0 → 0.37.0. Updates CHANGELOG and version files.

## What's in v0.37.0

- `## Handoff` contracts added to all 14 skills (#222)
- All 14 skills refreshed against v0.35.0 research and context base (#223)