### PR TITLE
feat: chain manifest format + wos/chain.py validators (#224)

### DIFF
--- a/docs/plans/2026-04-11-chain-infrastructure.plan.md
+++ b/docs/plans/2026-04-11-chain-infrastructure.plan.md
@@ -2,7 +2,7 @@
 name: Chain Infrastructure
 description: Add wos/chain.py validators, validate_chain() in validators.py, and lint.py auto-detection for *.chain.md manifests.
 type: plan
-status: executing
+status: completed
 branch: feat/chain-infrastructure
 pr: TBD
 related:

--- a/docs/plans/2026-04-11-chain-infrastructure.plan.md
+++ b/docs/plans/2026-04-11-chain-infrastructure.plan.md
@@ -1,0 +1,268 @@
+---
+name: Chain Infrastructure
+description: Add wos/chain.py validators, validate_chain() in validators.py, and lint.py auto-detection for *.chain.md manifests.
+type: plan
+status: executing
+branch: feat/chain-infrastructure
+pr: TBD
+related:
+  - docs/plans/2026-04-10-roadmap-v036-v039.plan.md
+---
+
+# Chain Infrastructure
+
+**Goal:** Implement the chain manifest format (`*.chain.md`) and a Python validation
+layer (`wos/chain.py`) that checks structural correctness — skills exist, contracts are
+declared, consequential steps have gates, a termination condition is present, and no
+cycles appear in the step sequence. Wire chain auto-detection into `scripts/lint.py` so
+projects with chain manifests get structural validation automatically, with zero behavior
+change for projects that have none.
+
+**Scope:**
+
+Must have:
+- `wos/chain.py` with `parse_chain()` and 5 structural check functions (exact signatures
+  from issue #224 comments)
+- `validate_chain()` added to `wos/validators.py`
+- `scripts/lint.py` scans for `*.chain.md` files at project root (recursively, skip
+  hidden dirs) and calls `validate_chain()` on each — no new CLI flag required
+- `tests/test_chain.py` with inline fixtures and `tmp_path`
+- `tests/test_lint.py` extended with chain auto-detection coverage
+
+Won't have:
+- LLM-based semantic contract matching (structural/presence checks only)
+- Chain execution or dispatch logic (validation only)
+- A new `--chain` CLI flag (auto-detection is additive and flag-free)
+- Changes to the chain manifest schema beyond what is specified in #224
+
+**Approach:** Follow the `wos/wiki.py` + `validate_wiki()` pattern exactly. `chain.py`
+owns parsing and all five structural checks; `validators.py` imports from `chain.py`
+and orchestrates them in `validate_chain()`. `lint.py` auto-activates chain validation
+when `*.chain.md` files are found, mirroring how `wiki/SCHEMA.md` presence triggers
+wiki validation. All issue dicts use the standard `{file, issue, severity}` shape.
+`parse_chain` reads the manifest frontmatter (name, description, type, goal,
+negative-scope) and the `## Steps` markdown pipe table into a structured dict — it
+should reuse `wos.frontmatter` for the YAML block and implement simple line-by-line
+table parsing for the steps section.
+
+**File Changes:**
+- Create: `wos/chain.py`
+- Create: `tests/test_chain.py`
+- Modify: `wos/validators.py` (add `validate_chain()`)
+- Modify: `scripts/lint.py` (add chain auto-detection block after wiki block)
+- Modify: `tests/test_lint.py` (add chain auto-detection tests)
+
+**Branch:** `feat/chain-infrastructure`
+**PR:** TBD
+
+---
+
+### Task 1: Create `wos/chain.py` with parse and check functions
+
+**Files:**
+- Create: `wos/chain.py`
+
+Implement the module following the wiki.py pattern. Module docstring states it provides
+chain manifest parsing and structural validation. All functions return `List[dict]`
+(except `parse_chain`).
+
+Chain manifest frontmatter keys and their parsed dict equivalents:
+
+| YAML key         | dict key          |
+|------------------|-------------------|
+| `name`           | `name`            |
+| `description`    | `description`     |
+| `type`           | `type`            |
+| `goal`           | `goal`            |
+| `negative-scope` | `negative_scope`  |
+
+`parse_chain` must also return `steps`: a list of dicts, one per row in the
+`## Steps` pipe table, with keys `step`, `skill`, `input_contract`,
+`output_contract`, `gate`. Empty or `—` values in table cells are normalized
+to empty string `""`.
+
+The 5 check functions and their behaviors:
+
+- `check_chain_skills_exist(manifest, skills_dirs)` — for each step, fail if
+  `step["skill"]` does not match any directory name under any path in `skills_dirs`.
+- `check_chain_internal_consistency(manifest)` — warn for any step where
+  `input_contract` or `output_contract` is empty; warn when step N's
+  `input_contract` and step N-1's `output_contract` are both non-empty but share
+  no words in common (heuristic mismatch).
+- `check_chain_gates(manifest)` — warn for any step where `gate` is empty and
+  `step["skill"]` is not a read-only skill (heuristic: skill name does not contain
+  `research` or `assess`).
+- `check_chain_termination(manifest)` — fail if `manifest["goal"]` is empty or
+  absent.
+- `check_chain_cycles(manifest)` — fail if any skill name appears in two or more
+  consecutive steps (direct loop) or if the `step` numbers are not strictly
+  increasing integers.
+
+- [x] Implement `parse_chain(manifest_path: Path) -> dict` using `wos.frontmatter`
+  for the YAML block and line-by-line parsing for the `## Steps` pipe table.
+  Raise `ValueError` on missing `## Steps` section or malformed table header.
+- [x] Implement the 5 structural check functions with docstrings matching the
+  exact signatures from the issue.
+- [x] Add `from __future__ import annotations` and `List`, `Path` imports from
+  stdlib only (no new dependencies).
+- [x] Verify: `python -c "from wos.chain import parse_chain, check_chain_skills_exist, check_chain_internal_consistency, check_chain_gates, check_chain_termination, check_chain_cycles; print('ok')"` → `ok`
+- [x] Commit: `feat: add wos/chain.py with parse_chain and 5 structural check functions` <!-- sha:52886e4 -->
+
+---
+
+### Task 2: Create `tests/test_chain.py`
+
+**Files:**
+- Create: `tests/test_chain.py`
+
+Follow `tests/test_wiki.py` structure: helper builders at the top, then one
+`class Test<FunctionName>` per function. Use inline markdown strings + `tmp_path`
+(no external fixtures).
+
+Required helper: `_chain_md(name, goal, negative_scope, steps)` → string that
+produces a valid `*.chain.md` manifest. Default steps: two rows, step 1 uses skill
+`research`, step 2 uses skill `distill`.
+
+Coverage required:
+
+| Class | Cases |
+|-------|-------|
+| `TestParseChain` | valid manifest returns correct frontmatter fields; valid manifest returns steps list with correct keys; missing `## Steps` raises `ValueError`; empty goal parsed as empty string |
+| `TestCheckChainSkillsExist` | declared skill found in skills_dir → no issues; declared skill absent → 1 fail; multiple missing skills → multiple fails |
+| `TestCheckChainInternalConsistency` | empty input_contract on step → warn; empty output_contract on step → warn; contracts both non-empty with no shared words → warn; matching contracts → no issues |
+| `TestCheckChainGates` | consequential step (non-research skill) with empty gate → warn; research step with empty gate → no warn; gate present → no issues |
+| `TestCheckChainTermination` | empty goal → fail; missing goal key → fail; non-empty goal → no issues |
+| `TestCheckChainCycles` | step numbers out of order → fail; same skill in consecutive steps → fail; valid step sequence → no issues |
+| `TestValidateChain` | clean manifest with skills_dir present → no failures; manifest missing skills → failures surface |
+
+- [x] Write all test classes with the cases above. Each test method imports the
+  function under test inside the test body (not at module level) to match project
+  convention.
+- [x] Verify: `python -m pytest tests/test_chain.py -v` → all tests pass, 0 failures
+- [x] Commit: `test: add tests/test_chain.py for wos/chain.py` <!-- sha:26385af -->
+
+---
+
+### Task 3: Add `validate_chain()` to `wos/validators.py`
+
+**Depends on:** Task 1
+
+**Files:**
+- Modify: `wos/validators.py`
+
+Add `validate_chain()` near the bottom of the file, after `validate_wiki()`.
+Follow the exact same structure as `validate_wiki()`: parse first, return a single
+warn on parse error, then run all checks and combine results.
+
+```python
+def validate_chain(manifest_path: Path, skills_dirs: List[Path]) -> List[dict]:
+    """Validate a chain manifest against all structural checks.
+
+    Parses the manifest and runs 5 structural checks. If parsing fails,
+    returns a single warn and exits early.
+
+    Args:
+        manifest_path: Path to a *.chain.md file.
+        skills_dirs: Directories to search for declared skills.
+
+    Returns:
+        List of issue dicts. Empty on a clean manifest.
+    """
+```
+
+- [x] Import `parse_chain` and the 5 check functions inside `validate_chain`
+  (deferred import, matching wiki pattern).
+- [x] On `ValueError` from `parse_chain`, return `[{file: ..., issue: "Invalid chain
+  manifest: {exc}", severity: "warn"}]`.
+- [x] Call all 5 checks, extend issues list, return combined.
+- [x] Verify: `python -c "from wos.validators import validate_chain; print('ok')"` → `ok`
+- [x] Verify: `python -m pytest tests/test_chain.py -v` → still all pass (smoke-tests
+  that validate_chain works end-to-end)
+- [x] Commit: `feat: add validate_chain() to wos/validators.py` <!-- sha:09c999f -->
+
+---
+
+### Task 4: Add chain auto-detection to `scripts/lint.py`
+
+**Depends on:** Task 3
+
+**Files:**
+- Modify: `scripts/lint.py`
+
+Add a chain auto-detection block immediately after the wiki validation block
+(line ~162). Pattern mirrors wiki detection exactly: find files, call validator,
+extend issues.
+
+```python
+# Chain validation — auto-activated when *.chain.md files are present
+chain_manifests = [
+    p for p in root.rglob("*.chain.md")
+    if not any(part.startswith(".") for part in p.parts)
+]
+if chain_manifests:
+    from wos.validators import validate_chain
+    skills_dirs = [root / "skills"] if (root / "skills").is_dir() else []
+    for manifest_path in sorted(chain_manifests):
+        issues.extend(validate_chain(manifest_path, skills_dirs))
+```
+
+- [x] Insert the block above after the wiki validation block. No new argument or
+  flag needed.
+- [x] Verify on a project without `*.chain.md`: run `python scripts/lint.py --root .
+  --no-urls` and confirm output is byte-for-byte identical to pre-patch run.
+- [x] Verify on a temp dir with a malformed chain manifest: `python scripts/lint.py
+  --root <tmp>` → surfaces at least 1 issue with severity `warn`.
+- [x] Commit: `feat: add chain auto-detection to scripts/lint.py` <!-- sha:0677991 -->
+
+---
+
+### Task 5: Add chain auto-detection tests to `tests/test_lint.py`
+
+**Depends on:** Task 4
+
+**Files:**
+- Modify: `tests/test_lint.py`
+
+Add a new test class `TestChainAutoDetection` at the bottom of the file.
+Use `tmp_path` to create a minimal project root. Use `_run_audit` helper (already
+defined in the file) to invoke `main()`.
+
+Required cases:
+
+| Test | Setup | Expected |
+|------|-------|----------|
+| `test_no_chain_files_no_chain_issues` | project root with no `*.chain.md` | `validate_chain` never called (patch it, assert not called) |
+| `test_chain_manifest_issues_surfaced` | write a `*.chain.md` with empty `goal` to `tmp_path` | output contains at least 1 fail from chain validation |
+| `test_chain_in_hidden_dir_skipped` | write `*.chain.md` under `.git/` dir | chain validation not triggered |
+
+- [x] Write the 3 test cases. For `test_chain_manifest_issues_surfaced`, write a
+  minimal chain manifest (use `_chain_md` from `test_chain.py` or inline the string)
+  that triggers a `check_chain_termination` fail (empty goal field).
+- [x] Verify: `python -m pytest tests/test_lint.py -v` → all tests pass, including
+  new ones
+- [x] Commit: `test: add chain auto-detection tests to tests/test_lint.py` <!-- sha:50dde6b -->
+
+---
+
+## Validation
+
+- [ ] `python -c "from wos.chain import parse_chain, check_chain_skills_exist, check_chain_internal_consistency, check_chain_gates, check_chain_termination, check_chain_cycles; print('ok')"` → `ok`
+- [ ] `python -m pytest tests/test_chain.py tests/test_lint.py -v` → zero failures
+- [ ] `python -m pytest tests/ -v` → full suite passes (no regressions)
+- [ ] `python scripts/lint.py --root . --no-urls` on main repo → identical issue count to pre-patch (no `*.chain.md` files exist yet)
+- [ ] Update roadmap Task 9 checkbox in `docs/plans/2026-04-10-roadmap-v036-v039.plan.md` with merge SHA
+
+## Notes
+
+- `parse_chain` should use `wos.frontmatter` for the YAML block to stay consistent
+  with how `parse_document` works. The `## Steps` table is chain-specific; implement
+  a minimal pipe-table parser (split `|`, strip whitespace, skip separator rows).
+- The `check_chain_internal_consistency` word-overlap heuristic is intentionally
+  loose — false positives are warns, not fails. The goal is catching obviously
+  disconnected contracts, not semantic validation.
+- `check_chain_cycles` for a linear step table means: step numbers must be strictly
+  increasing integers (non-monotonic sequence = a structural error), and no skill
+  may appear in two immediately adjacent steps (direct A→A loop). Longer cycles
+  are out of scope for v0.38.0.
+- This plan covers only the infrastructure layer. The `/wos:audit-chain` skill
+  (Task 11, issue #225) that uses this infrastructure is a separate plan.

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -161,6 +161,17 @@ def main() -> None:
         from wos.validators import validate_wiki
         issues.extend(validate_wiki(root / "wiki", wiki_schema))
 
+    # Chain validation — auto-activated when *.chain.md files are present
+    chain_manifests = [
+        p for p in root.rglob("*.chain.md")
+        if not any(part.startswith(".") for part in p.parts)
+    ]
+    if chain_manifests:
+        from wos.validators import validate_chain
+        chain_skills_dirs = [root / "skills"] if (root / "skills").is_dir() else []
+        for manifest_path in sorted(chain_manifests):
+            issues.extend(validate_chain(manifest_path, chain_skills_dirs))
+
     # Skill instruction density reporting
     from wos.skill_audit import check_skill_meta, check_skill_sizes
 

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -1,0 +1,493 @@
+"""Tests for wos/chain.py — chain manifest parsing and validator functions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest  # noqa: F401
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _chain_md(
+    name: str = "Test Chain",
+    description: str = "A test chain",
+    goal: str = "Produce updated wiki pages",
+    negative_scope: str = "Does not handle auth",
+    steps: list[dict] | None = None,
+) -> str:
+    """Build a valid *.chain.md manifest string."""
+    if steps is None:
+        steps = [
+            {
+                "step": "1",
+                "skill": "research",
+                "input_contract": "user question",
+                "output_contract": "research.md file",
+                "gate": "",
+            },
+            {
+                "step": "2",
+                "skill": "distill",
+                "input_contract": "research.md file",
+                "output_contract": "context files updated",
+                "gate": "user approves summary",
+            },
+        ]
+
+    fm = "\n".join([
+        "---",
+        f"name: {name}",
+        f"description: {description}",
+        "type: chain",
+        f"goal: {goal}",
+        f"negative-scope: {negative_scope}",
+        "---",
+        "",
+    ])
+
+    table_header = "| Step | Skill | Input Contract | Output Contract | Gate |"
+    table_sep = "|------|-------|----------------|-----------------|------|"
+    rows = []
+    for s in steps:
+        rows.append(
+            f"| {s['step']} | {s['skill']} | {s['input_contract']}"
+            f" | {s['output_contract']} | {s['gate']} |"
+        )
+
+    body = "\n".join([
+        "## Steps",
+        "",
+        table_header,
+        table_sep,
+        *rows,
+        "",
+    ])
+
+    return fm + body
+
+
+# ── TestParseChain ────────────────────────────────────────────────────
+
+
+class TestParseChain:
+    def test_returns_correct_frontmatter_fields(self, tmp_path: Path) -> None:
+        from wos.chain import parse_chain
+
+        path = tmp_path / "my.chain.md"
+        path.write_text(_chain_md(), encoding="utf-8")
+
+        manifest = parse_chain(path)
+
+        assert manifest["name"] == "Test Chain"
+        assert manifest["description"] == "A test chain"
+        assert manifest["type"] == "chain"
+        assert manifest["goal"] == "Produce updated wiki pages"
+        assert manifest["negative_scope"] == "Does not handle auth"
+
+    def test_returns_steps_list_with_correct_keys(self, tmp_path: Path) -> None:
+        from wos.chain import parse_chain
+
+        path = tmp_path / "my.chain.md"
+        path.write_text(_chain_md(), encoding="utf-8")
+
+        manifest = parse_chain(path)
+
+        assert len(manifest["steps"]) == 2
+        step = manifest["steps"][0]
+        expected_keys = {"step", "skill", "input_contract", "output_contract", "gate"}
+        assert set(step.keys()) == expected_keys
+        assert step["step"] == "1"
+        assert step["skill"] == "research"
+        assert step["input_contract"] == "user question"
+        assert step["output_contract"] == "research.md file"
+
+    def test_missing_steps_section_raises_value_error(self, tmp_path: Path) -> None:
+        from wos.chain import parse_chain
+
+        content = (
+            "---\n"
+            "name: Broken Chain\n"
+            "description: Missing steps\n"
+            "type: chain\n"
+            "goal: Something\n"
+            "negative-scope: Nothing\n"
+            "---\n\n"
+            "No steps table here.\n"
+        )
+        path = tmp_path / "broken.chain.md"
+        path.write_text(content, encoding="utf-8")
+
+        with pytest.raises(ValueError, match="Steps"):
+            parse_chain(path)
+
+    def test_empty_goal_parsed_as_empty_string(self, tmp_path: Path) -> None:
+        from wos.chain import parse_chain
+
+        content = (
+            "---\n"
+            "name: No Goal\n"
+            "description: Missing goal\n"
+            "type: chain\n"
+            "---\n\n"
+            "## Steps\n\n"
+            "| Step | Skill | Input Contract | Output Contract | Gate |\n"
+            "|------|-------|----------------|-----------------|------|\n"
+            "| 1 | research | question | result | |\n"
+        )
+        path = tmp_path / "nogoal.chain.md"
+        path.write_text(content, encoding="utf-8")
+
+        manifest = parse_chain(path)
+
+        assert manifest["goal"] == ""
+
+
+# ── TestCheckChainSkillsExist ─────────────────────────────────────────
+
+
+class TestCheckChainSkillsExist:
+    def _make_skills_dir(self, tmp_path: Path, skill_names: list[str]) -> Path:
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        for name in skill_names:
+            (skills_dir / name).mkdir()
+        return skills_dir
+
+    def test_declared_skill_found_no_issues(self, tmp_path: Path) -> None:
+        from wos.chain import check_chain_skills_exist
+
+        skills_dir = self._make_skills_dir(tmp_path, ["research", "distill"])
+        manifest = {
+            "path": str(tmp_path / "my.chain.md"),
+            "steps": [
+                {"step": "1", "skill": "research", "input_contract": "q",
+                 "output_contract": "r", "gate": ""},
+                {"step": "2", "skill": "distill", "input_contract": "r",
+                 "output_contract": "c", "gate": "approval"},
+            ],
+        }
+
+        issues = check_chain_skills_exist(manifest, [skills_dir])
+
+        assert issues == []
+
+    def test_declared_skill_absent_returns_one_fail(self, tmp_path: Path) -> None:
+        from wos.chain import check_chain_skills_exist
+
+        skills_dir = self._make_skills_dir(tmp_path, ["research"])
+        manifest = {
+            "path": str(tmp_path / "my.chain.md"),
+            "steps": [
+                {"step": "1", "skill": "ghost-skill", "input_contract": "q",
+                 "output_contract": "r", "gate": ""},
+            ],
+        }
+
+        issues = check_chain_skills_exist(manifest, [skills_dir])
+
+        assert len(issues) == 1
+        assert issues[0]["severity"] == "fail"
+        assert "ghost-skill" in issues[0]["issue"]
+
+    def test_multiple_missing_skills_multiple_fails(self, tmp_path: Path) -> None:
+        from wos.chain import check_chain_skills_exist
+
+        skills_dir = self._make_skills_dir(tmp_path, [])
+        manifest = {
+            "path": str(tmp_path / "my.chain.md"),
+            "steps": [
+                {"step": "1", "skill": "missing-a", "input_contract": "x",
+                 "output_contract": "y", "gate": ""},
+                {"step": "2", "skill": "missing-b", "input_contract": "y",
+                 "output_contract": "z", "gate": "approval"},
+            ],
+        }
+
+        issues = check_chain_skills_exist(manifest, [skills_dir])
+
+        assert len(issues) == 2
+        assert all(i["severity"] == "fail" for i in issues)
+
+
+# ── TestCheckChainInternalConsistency ────────────────────────────────
+
+
+class TestCheckChainInternalConsistency:
+    def test_empty_input_contract_returns_warn(self, tmp_path: Path) -> None:
+        from wos.chain import check_chain_internal_consistency
+
+        manifest = {
+            "path": str(tmp_path / "my.chain.md"),
+            "steps": [
+                {"step": "1", "skill": "research", "input_contract": "",
+                 "output_contract": "research.md", "gate": ""},
+            ],
+        }
+
+        issues = check_chain_internal_consistency(manifest)
+
+        assert any(i["severity"] == "warn" and "input contract" in i["issue"]
+                   for i in issues)
+
+    def test_empty_output_contract_returns_warn(self, tmp_path: Path) -> None:
+        from wos.chain import check_chain_internal_consistency
+
+        manifest = {
+            "path": str(tmp_path / "my.chain.md"),
+            "steps": [
+                {"step": "1", "skill": "research", "input_contract": "question",
+                 "output_contract": "", "gate": ""},
+            ],
+        }
+
+        issues = check_chain_internal_consistency(manifest)
+
+        assert any(i["severity"] == "warn" and "output contract" in i["issue"]
+                   for i in issues)
+
+    def test_contracts_no_shared_words_returns_warn(self, tmp_path: Path) -> None:
+        from wos.chain import check_chain_internal_consistency
+
+        manifest = {
+            "path": str(tmp_path / "my.chain.md"),
+            "steps": [
+                {"step": "1", "skill": "research", "input_contract": "user question",
+                 "output_contract": "orange apple banana", "gate": ""},
+                {"step": "2", "skill": "distill",
+                 "input_contract": "totally unrelated xyz",
+                 "output_contract": "context pages", "gate": "approval"},
+            ],
+        }
+
+        issues = check_chain_internal_consistency(manifest)
+
+        assert any("shares no terms" in i["issue"] for i in issues)
+
+    def test_matching_contracts_no_issues(self, tmp_path: Path) -> None:
+        from wos.chain import check_chain_internal_consistency
+
+        manifest = {
+            "path": str(tmp_path / "my.chain.md"),
+            "steps": [
+                {"step": "1", "skill": "research", "input_contract": "user question",
+                 "output_contract": "research.md file", "gate": ""},
+                {"step": "2", "skill": "distill", "input_contract": "research.md path",
+                 "output_contract": "context files updated", "gate": "approval"},
+            ],
+        }
+
+        issues = check_chain_internal_consistency(manifest)
+
+        assert issues == []
+
+
+# ── TestCheckChainGates ───────────────────────────────────────────────
+
+
+class TestCheckChainGates:
+    def test_consequential_step_without_gate_returns_warn(self, tmp_path: Path) -> None:
+        from wos.chain import check_chain_gates
+
+        manifest = {
+            "path": str(tmp_path / "my.chain.md"),
+            "steps": [
+                {"step": "1", "skill": "ingest", "input_contract": "data",
+                 "output_contract": "pages updated", "gate": ""},
+            ],
+        }
+
+        issues = check_chain_gates(manifest)
+
+        assert len(issues) == 1
+        assert issues[0]["severity"] == "warn"
+        assert "ingest" in issues[0]["issue"]
+
+    def test_research_step_without_gate_no_warn(self, tmp_path: Path) -> None:
+        from wos.chain import check_chain_gates
+
+        manifest = {
+            "path": str(tmp_path / "my.chain.md"),
+            "steps": [
+                {"step": "1", "skill": "research", "input_contract": "question",
+                 "output_contract": "research.md", "gate": ""},
+            ],
+        }
+
+        issues = check_chain_gates(manifest)
+
+        assert issues == []
+
+    def test_gate_present_no_issues(self, tmp_path: Path) -> None:
+        from wos.chain import check_chain_gates
+
+        manifest = {
+            "path": str(tmp_path / "my.chain.md"),
+            "steps": [
+                {"step": "1", "skill": "ingest", "input_contract": "data",
+                 "output_contract": "pages updated", "gate": "user approves"},
+            ],
+        }
+
+        issues = check_chain_gates(manifest)
+
+        assert issues == []
+
+
+# ── TestCheckChainTermination ─────────────────────────────────────────
+
+
+class TestCheckChainTermination:
+    def test_empty_goal_returns_fail(self, tmp_path: Path) -> None:
+        from wos.chain import check_chain_termination
+
+        manifest = {
+            "path": str(tmp_path / "my.chain.md"),
+            "goal": "",
+            "steps": [],
+        }
+
+        issues = check_chain_termination(manifest)
+
+        assert len(issues) == 1
+        assert issues[0]["severity"] == "fail"
+
+    def test_missing_goal_key_returns_fail(self, tmp_path: Path) -> None:
+        from wos.chain import check_chain_termination
+
+        manifest = {
+            "path": str(tmp_path / "my.chain.md"),
+            "steps": [],
+        }
+
+        issues = check_chain_termination(manifest)
+
+        assert len(issues) == 1
+        assert issues[0]["severity"] == "fail"
+
+    def test_nonempty_goal_no_issues(self, tmp_path: Path) -> None:
+        from wos.chain import check_chain_termination
+
+        manifest = {
+            "path": str(tmp_path / "my.chain.md"),
+            "goal": "All wiki pages updated and indexed",
+            "steps": [],
+        }
+
+        issues = check_chain_termination(manifest)
+
+        assert issues == []
+
+
+# ── TestCheckChainCycles ──────────────────────────────────────────────
+
+
+class TestCheckChainCycles:
+    def test_step_numbers_out_of_order_returns_fail(self, tmp_path: Path) -> None:
+        from wos.chain import check_chain_cycles
+
+        manifest = {
+            "path": str(tmp_path / "my.chain.md"),
+            "steps": [
+                {"step": "1", "skill": "research", "input_contract": "q",
+                 "output_contract": "r", "gate": ""},
+                {"step": "3", "skill": "distill", "input_contract": "r",
+                 "output_contract": "c", "gate": ""},
+                {"step": "2", "skill": "ingest", "input_contract": "c",
+                 "output_contract": "pages", "gate": ""},
+            ],
+        }
+
+        issues = check_chain_cycles(manifest)
+
+        assert any(i["severity"] == "fail" and "strictly increasing" in i["issue"]
+                   for i in issues)
+
+    def test_same_skill_consecutive_steps_returns_fail(self, tmp_path: Path) -> None:
+        from wos.chain import check_chain_cycles
+
+        manifest = {
+            "path": str(tmp_path / "my.chain.md"),
+            "steps": [
+                {"step": "1", "skill": "research", "input_contract": "q",
+                 "output_contract": "r", "gate": ""},
+                {"step": "2", "skill": "research", "input_contract": "r",
+                 "output_contract": "r2", "gate": ""},
+            ],
+        }
+
+        issues = check_chain_cycles(manifest)
+
+        assert any(i["severity"] == "fail" and "direct loop" in i["issue"]
+                   for i in issues)
+
+    def test_valid_step_sequence_no_issues(self, tmp_path: Path) -> None:
+        from wos.chain import check_chain_cycles
+
+        manifest = {
+            "path": str(tmp_path / "my.chain.md"),
+            "steps": [
+                {"step": "1", "skill": "research", "input_contract": "q",
+                 "output_contract": "r", "gate": ""},
+                {"step": "2", "skill": "distill", "input_contract": "r",
+                 "output_contract": "c", "gate": "approval"},
+                {"step": "3", "skill": "ingest", "input_contract": "c",
+                 "output_contract": "pages updated", "gate": "lint passes"},
+            ],
+        }
+
+        issues = check_chain_cycles(manifest)
+
+        assert issues == []
+
+
+# ── TestValidateChain ─────────────────────────────────────────────────
+
+
+class TestValidateChain:
+    def test_clean_manifest_with_skills_no_failures(self, tmp_path: Path) -> None:
+        from wos.validators import validate_chain
+
+        # Create skills directory with the two skills used
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        (skills_dir / "research").mkdir()
+        (skills_dir / "distill").mkdir()
+
+        manifest_path = tmp_path / "my.chain.md"
+        manifest_path.write_text(_chain_md(), encoding="utf-8")
+
+        issues = validate_chain(manifest_path, [skills_dir])
+
+        failures = [i for i in issues if i["severity"] == "fail"]
+        assert failures == [], failures
+
+    def test_manifest_missing_skills_surfaces_failures(self, tmp_path: Path) -> None:
+        from wos.validators import validate_chain
+
+        # Empty skills directory — no skills defined
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+
+        manifest_path = tmp_path / "my.chain.md"
+        manifest_path.write_text(_chain_md(), encoding="utf-8")
+
+        issues = validate_chain(manifest_path, [skills_dir])
+
+        failures = [i for i in issues if i["severity"] == "fail"]
+        assert len(failures) >= 1
+        assert any("research" in i["issue"] or "distill" in i["issue"]
+                   for i in failures)
+
+    def test_malformed_manifest_returns_single_warn(self, tmp_path: Path) -> None:
+        from wos.validators import validate_chain
+
+        # Missing frontmatter — will fail to parse
+        manifest_path = tmp_path / "bad.chain.md"
+        manifest_path.write_text("No frontmatter here.\n", encoding="utf-8")
+
+        issues = validate_chain(manifest_path, [])
+
+        assert len(issues) == 1
+        assert issues[0]["severity"] == "warn"
+        assert "Invalid chain manifest" in issues[0]["issue"]

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -202,3 +202,69 @@ class TestFixOutput:
         result = idx_file.read_text(encoding="utf-8")
         assert preamble_text in result
         assert "tokens.md" in result
+
+
+# ── TestChainAutoDetection ────────────────────────────────────────────
+
+
+class TestChainAutoDetection:
+    def _write_chain_manifest(self, path: Path, goal: str = "") -> None:
+        """Write a minimal *.chain.md manifest to path."""
+        content = (
+            "---\n"
+            "name: Test Chain\n"
+            "description: A test chain\n"
+            "type: chain\n"
+            f"goal: {goal}\n"
+            "---\n\n"
+            "## Steps\n\n"
+            "| Step | Skill | Input Contract | Output Contract | Gate |\n"
+            "|------|-------|----------------|-----------------|------|\n"
+            "| 1 | research | question | research.md | |\n"
+        )
+        path.write_text(content, encoding="utf-8")
+
+    def test_no_chain_files_validate_chain_not_called(
+        self, tmp_path: Path
+    ) -> None:
+        from unittest.mock import patch as _patch
+
+        root = tmp_path / "project"
+        root.mkdir()
+
+        with _patch("wos.validators.validate_project", return_value=[]), \
+             _patch("wos.validators.validate_chain") as mock_chain:
+            _run_audit("--root", str(root), "--no-urls")
+
+        mock_chain.assert_not_called()
+
+    def test_chain_manifest_issues_surfaced(self, tmp_path: Path) -> None:
+        root = tmp_path / "project"
+        root.mkdir()
+
+        # Write a chain manifest with an empty goal — triggers termination fail
+        self._write_chain_manifest(root / "my.chain.md", goal="")
+
+        with patch("wos.validators.validate_project", return_value=[]):
+            stdout, _, exit_code = _run_audit("--root", str(root), "--no-urls")
+
+        # termination check produces a fail → exit code 1
+        assert exit_code == 1
+        assert "chain" in stdout.lower() or "termination" in stdout.lower()
+
+    def test_chain_in_hidden_dir_skipped(self, tmp_path: Path) -> None:
+        from unittest.mock import patch as _patch
+
+        root = tmp_path / "project"
+        root.mkdir()
+        hidden = root / ".git"
+        hidden.mkdir()
+
+        # Write chain manifest inside a hidden directory
+        self._write_chain_manifest(hidden / "nested.chain.md", goal="some goal")
+
+        with _patch("wos.validators.validate_project", return_value=[]), \
+             _patch("wos.validators.validate_chain") as mock_chain:
+            _run_audit("--root", str(root), "--no-urls")
+
+        mock_chain.assert_not_called()

--- a/wos/chain.py
+++ b/wos/chain.py
@@ -1,0 +1,370 @@
+"""Chain manifest parsing and structural validation.
+
+Provides parse_chain() for reading *.chain.md manifests and five
+structural check functions for validating chain correctness.
+
+Each check returns a list of issue dicts with keys: file, issue, severity.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Optional
+
+from wos.frontmatter import parse_frontmatter
+
+# ── Parsing ────────────────────────────────────────────────────────
+
+
+def parse_chain(manifest_path: Path) -> dict:
+    """Read and parse a *.chain.md manifest. Returns structured dict.
+
+    Parses frontmatter (name, description, type, goal, negative-scope)
+    and the ## Steps markdown pipe table into a list of step dicts.
+
+    Args:
+        manifest_path: Path to a *.chain.md file.
+
+    Returns:
+        Dict with keys: path, name, description, type, goal,
+        negative_scope, steps. ``steps`` is a list of dicts with
+        keys: step, skill, input_contract, output_contract, gate.
+
+    Raises:
+        ValueError: If the file cannot be read, frontmatter is missing,
+            or the ## Steps section is absent.
+    """
+    try:
+        text = manifest_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(f"Cannot read {manifest_path}: {exc}") from exc
+
+    fm, body = parse_frontmatter(text)
+
+    return {
+        "path": str(manifest_path),
+        "name": fm.get("name") or "",
+        "description": fm.get("description") or "",
+        "type": fm.get("type") or "",
+        "goal": fm.get("goal") or "",
+        "negative_scope": fm.get("negative-scope") or "",
+        "steps": _parse_steps_table(body, manifest_path),
+    }
+
+
+def _is_separator_row(cells: List[str]) -> bool:
+    """Return True if this is a markdown table separator row (e.g. |---|---|)."""
+    return bool(cells) and all(
+        bool(c) and all(ch in "-: " for ch in c) for c in cells
+    )
+
+
+_HEADER_KEYWORDS = {"step", "skill", "input contract", "output contract", "gate"}
+
+
+def _is_header_row(cells: List[str]) -> bool:
+    """Return True if this row looks like a table header."""
+    lower = {c.lower() for c in cells}
+    return sum(1 for kw in _HEADER_KEYWORDS if kw in lower) >= 3
+
+
+def _norm_cell(value: str) -> str:
+    """Normalize em-dash / en-dash placeholder cells to empty string."""
+    return "" if value.strip() in ("—", "–", "-") else value.strip()
+
+
+def _parse_steps_table(body: str, manifest_path: Path) -> List[dict]:
+    """Parse the ## Steps pipe table from the chain manifest body.
+
+    Args:
+        body: Markdown body content after frontmatter.
+        manifest_path: Path used in error messages.
+
+    Returns:
+        List of step dicts with keys: step, skill, input_contract,
+        output_contract, gate.
+
+    Raises:
+        ValueError: If no ## Steps section is found.
+    """
+    lines = body.splitlines()
+
+    # Find the ## Steps heading
+    steps_start: Optional[int] = None
+    for i, line in enumerate(lines):
+        if line.strip().lower().startswith("## steps"):
+            steps_start = i
+            break
+
+    if steps_start is None:
+        raise ValueError(
+            f"No '## Steps' section found in {manifest_path}"
+        )
+
+    steps: List[dict] = []
+    in_table = False
+
+    for line in lines[steps_start + 1:]:
+        stripped = line.strip()
+
+        if not stripped:
+            if in_table:
+                break  # Blank line ends the table
+            continue
+
+        if not stripped.startswith("|"):
+            if in_table:
+                break
+            continue
+
+        # Split on | and strip whitespace; drop empty tokens from leading/trailing |
+        cells = [c.strip() for c in stripped.split("|") if c.strip()]
+
+        if not cells:
+            continue
+
+        if _is_separator_row(cells):
+            in_table = True
+            continue
+
+        if not in_table and _is_header_row(cells):
+            in_table = True
+            continue
+
+        if not in_table:
+            continue
+
+        # Pad to 5 columns
+        while len(cells) < 5:
+            cells.append("")
+
+        steps.append({
+            "step": _norm_cell(cells[0]),
+            "skill": _norm_cell(cells[1]),
+            "input_contract": _norm_cell(cells[2]),
+            "output_contract": _norm_cell(cells[3]),
+            "gate": _norm_cell(cells[4]),
+        })
+
+    return steps
+
+
+# ── Structural checks ──────────────────────────────────────────────
+
+
+def check_chain_skills_exist(
+    manifest: dict, skills_dirs: List[Path]
+) -> List[dict]:
+    """Fail issues for each declared skill that doesn't exist.
+
+    For each step, checks whether the skill name matches a subdirectory
+    in any of the provided skills_dirs.
+
+    Args:
+        manifest: Parsed chain manifest dict from parse_chain().
+        skills_dirs: List of directories to search for skill subdirectories.
+
+    Returns:
+        List of issue dicts with severity 'fail'.
+    """
+    file_path = manifest.get("path", "")
+
+    known_skills: set = set()
+    for skills_dir in skills_dirs:
+        p = Path(skills_dir)
+        if p.is_dir():
+            for entry in sorted(p.iterdir()):
+                if entry.is_dir() and not entry.name.startswith("_"):
+                    known_skills.add(entry.name)
+
+    issues: List[dict] = []
+    for step in manifest.get("steps", []):
+        skill = step.get("skill", "")
+        if skill and skill not in known_skills:
+            issues.append({
+                "file": file_path,
+                "issue": (
+                    f"Chain step {step.get('step', '?')} declares skill"
+                    f" '{skill}' which does not exist in skills directories"
+                ),
+                "severity": "fail",
+            })
+
+    return issues
+
+
+def check_chain_internal_consistency(manifest: dict) -> List[dict]:
+    """Warn issues where a step's input contract doesn't match the prior step's output.
+
+    Warns when:
+    - Any step has an empty input_contract or output_contract
+    - Consecutive steps have non-empty contracts with no shared words
+      (heuristic mismatch)
+
+    Args:
+        manifest: Parsed chain manifest dict from parse_chain().
+
+    Returns:
+        List of issue dicts with severity 'warn'.
+    """
+    file_path = manifest.get("path", "")
+    steps = manifest.get("steps", [])
+    issues: List[dict] = []
+
+    for i, step in enumerate(steps):
+        step_id = step.get("step", str(i + 1))
+
+        if not step.get("input_contract"):
+            issues.append({
+                "file": file_path,
+                "issue": f"Chain step {step_id} has no input contract declared",
+                "severity": "warn",
+            })
+
+        if not step.get("output_contract"):
+            issues.append({
+                "file": file_path,
+                "issue": f"Chain step {step_id} has no output contract declared",
+                "severity": "warn",
+            })
+
+        # Heuristic: compare previous step's output with current step's input
+        if i > 0:
+            prev_output = steps[i - 1].get("output_contract", "")
+            curr_input = step.get("input_contract", "")
+            if prev_output and curr_input:
+                prev_words = set(prev_output.lower().split())
+                curr_words = set(curr_input.lower().split())
+                if not prev_words & curr_words:
+                    issues.append({
+                        "file": file_path,
+                        "issue": (
+                            f"Chain step {step_id} input contract"
+                            f" ({curr_input!r}) shares no terms with"
+                            f" prior step output contract ({prev_output!r})"
+                        ),
+                        "severity": "warn",
+                    })
+
+    return issues
+
+
+_READ_ONLY_SKILL_KEYWORDS = ("research", "assess")
+
+
+def check_chain_gates(manifest: dict) -> List[dict]:
+    """Warn issues for consequential steps without a declared gate.
+
+    A step is considered consequential if its skill name does not
+    contain 'research' or 'assess' (heuristic for read-only skills).
+    Warns when such a step has an empty gate field.
+
+    Args:
+        manifest: Parsed chain manifest dict from parse_chain().
+
+    Returns:
+        List of issue dicts with severity 'warn'.
+    """
+    file_path = manifest.get("path", "")
+    issues: List[dict] = []
+
+    for step in manifest.get("steps", []):
+        skill = step.get("skill", "").lower()
+        gate = step.get("gate", "")
+        step_id = step.get("step", "?")
+
+        is_read_only = any(kw in skill for kw in _READ_ONLY_SKILL_KEYWORDS)
+
+        if not is_read_only and not gate:
+            issues.append({
+                "file": file_path,
+                "issue": (
+                    f"Chain step {step_id} (skill: '{step.get('skill', '')}')"
+                    f" has no gate declared for a consequential step"
+                ),
+                "severity": "warn",
+            })
+
+    return issues
+
+
+def check_chain_termination(manifest: dict) -> List[dict]:
+    """Fail issue if no termination condition declared at chain level.
+
+    Checks that the manifest's 'goal' field is non-empty.
+
+    Args:
+        manifest: Parsed chain manifest dict from parse_chain().
+
+    Returns:
+        List of issue dicts with severity 'fail'.
+    """
+    file_path = manifest.get("path", "")
+
+    if not manifest.get("goal"):
+        return [{
+            "file": file_path,
+            "issue": (
+                "Chain manifest has no termination condition"
+                " (goal is missing or empty)"
+            ),
+            "severity": "fail",
+        }]
+
+    return []
+
+
+def check_chain_cycles(manifest: dict) -> List[dict]:
+    """Fail issue for any circular skill references in the step sequence.
+
+    Detects:
+    - Step numbers that are not strictly increasing integers
+    - The same skill appearing in two consecutive steps (direct loop)
+
+    Args:
+        manifest: Parsed chain manifest dict from parse_chain().
+
+    Returns:
+        List of issue dicts with severity 'fail'.
+    """
+    file_path = manifest.get("path", "")
+    steps = manifest.get("steps", [])
+    issues: List[dict] = []
+
+    prev_step_num: Optional[int] = None
+    prev_skill = ""
+
+    for step in steps:
+        step_id = step.get("step", "")
+        skill = step.get("skill", "")
+
+        # Check monotonically increasing step numbers
+        try:
+            step_num = int(step_id)
+            if prev_step_num is not None and step_num <= prev_step_num:
+                issues.append({
+                    "file": file_path,
+                    "issue": (
+                        f"Chain step numbers are not strictly increasing:"
+                        f" step {step_id} follows step {prev_step_num}"
+                    ),
+                    "severity": "fail",
+                })
+            prev_step_num = step_num
+        except (ValueError, TypeError):
+            pass  # Non-integer step IDs are allowed
+
+        # Check consecutive same-skill (direct loop)
+        if skill and skill == prev_skill:
+            issues.append({
+                "file": file_path,
+                "issue": (
+                    f"Chain step {step_id} repeats skill '{skill}'"
+                    f" from the immediately preceding step (direct loop)"
+                ),
+                "severity": "fail",
+            })
+
+        prev_skill = skill
+
+    return issues

--- a/wos/validators.py
+++ b/wos/validators.py
@@ -520,3 +520,44 @@ def validate_wiki(wiki_dir: Path, schema_path: Path) -> List[dict]:
     issues.extend(check_index_sync(wiki_dir))
 
     return issues
+
+
+def validate_chain(manifest_path: Path, skills_dirs: List[Path]) -> List[dict]:
+    """Validate a chain manifest against all structural checks.
+
+    Parses the manifest and runs 5 structural checks. If parsing fails,
+    returns a single warn and exits early.
+
+    Args:
+        manifest_path: Path to a *.chain.md file.
+        skills_dirs: Directories to search for declared skills.
+
+    Returns:
+        List of issue dicts. Empty on a clean manifest.
+    """
+    from wos.chain import (
+        check_chain_cycles,
+        check_chain_gates,
+        check_chain_internal_consistency,
+        check_chain_skills_exist,
+        check_chain_termination,
+        parse_chain,
+    )
+
+    try:
+        manifest = parse_chain(manifest_path)
+    except ValueError as exc:
+        return [{
+            "file": str(manifest_path),
+            "issue": f"Invalid chain manifest: {exc}",
+            "severity": "warn",
+        }]
+
+    issues: List[dict] = []
+    issues.extend(check_chain_skills_exist(manifest, skills_dirs))
+    issues.extend(check_chain_internal_consistency(manifest))
+    issues.extend(check_chain_gates(manifest))
+    issues.extend(check_chain_termination(manifest))
+    issues.extend(check_chain_cycles(manifest))
+
+    return issues


### PR DESCRIPTION
## Summary

- Add `wos/chain.py` with `parse_chain()` and 5 structural check functions (`check_chain_skills_exist`, `check_chain_internal_consistency`, `check_chain_gates`, `check_chain_termination`, `check_chain_cycles`)
- Add `validate_chain()` to `wos/validators.py`, following the `validate_wiki()` pattern
- Add chain auto-detection to `scripts/lint.py` — projects with `*.chain.md` files get structural validation automatically; projects without them see identical behavior
- Add `tests/test_chain.py` (23 tests across 7 classes) and extend `tests/test_lint.py` with 3 chain auto-detection cases

Closes #224. Part of the v0.38.0 roadmap (Task 9 of `docs/plans/2026-04-10-roadmap-v036-v039.plan.md`).

## Test plan

- [x] `python -c "from wos.chain import parse_chain, check_chain_skills_exist, check_chain_internal_consistency, check_chain_gates, check_chain_termination, check_chain_cycles; print('ok')"` → `ok`
- [x] `python -m pytest tests/test_chain.py tests/test_lint.py -v` → 38 passed
- [x] `python -m pytest tests/ -v` → 441 passed, zero failures
- [x] `python scripts/lint.py --root . --no-urls` on a project without `*.chain.md` → no chain issues added

🤖 Generated with [Claude Code](https://claude.com/claude-code)