### PR TITLE
chore: release v0.38.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
         "repo": "bcbeidel/wos"
       },
       "description": "Claude Code plugin for building and maintaining structured project context",
-      "version": "0.37.0",
+      "version": "0.38.0",
       "license": "MIT"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wos",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "Claude Code plugin for building and maintaining structured project context",
   "author": {
     "name": "bbeidel"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.0] - 2026-04-11
+
+### Added
+
+- **`wos/chain.py` — chain manifest infrastructure.** Six validator functions:
+  `parse_chain`, `check_chain_skills_exist`, `check_chain_internal_consistency`,
+  `check_chain_gates`, `check_chain_termination`, `check_chain_cycles`.
+  `scripts/lint.py` auto-detects `*.chain.md` files and runs structural checks.
+
+- **`/wos:audit-chain` skill.** Repair loop for skill chains. When invoked with
+  a workflow goal, produces a `*.chain.md` manifest through structured dialogue.
+  When invoked with an existing manifest, runs structural checks, cross-references
+  SKILL.md bodies with LLM judgment, proposes fixes per-change, and re-verifies
+  after repairs. Invokes `/wos:build-skill` inline for missing skills.
+
+- **`/wos:build-skill` + `/wos:audit-skill`.** Scaffolds new SKILL.md files from
+  a description and handoff contracts; audits existing skills against research-backed
+  criteria (instruction density, handoff completeness, anti-pattern guards, gate
+  checks).
+
+- **`/wos:build-rule` + `/wos:audit-rule`.** Scaffolds correctly-formatted rule
+  files with conflict detection; audits existing rules for conflicts, coverage
+  gaps, specificity, and staleness. `check-rules` and `extract-rules` deprecated.
+
+- **`/wos:build-subagent` + `/wos:audit-subagent`.** Scaffolds `.claude/agents/`
+  definitions with least-privilege tool sets; audits for over-permissioning and
+  overlap with existing skills.
+
+- **`/wos:build-command` + `/wos:audit-command` + `/wos:build-hook` +
+  `/wos:audit-hook`.** Completes the `build-X` / `audit-X` family for all five
+  Claude Code primitives: skills, rules, subagents, commands, hooks.
+
+### Deprecated
+
+- **`/wos:retrospective`** — functionality fully covered by `/wos:finish-work`
+  Step 6. Will be removed in v0.39.0.
+
+- **`/wos:check-rules`** — replaced by `/wos:audit-rule`.
+
+- **`/wos:extract-rules`** — replaced by `/wos:build-rule`.
+
 ## [0.37.0] - 2026-04-11
 
 ### Added

--- a/docs/plans/2026-04-10-roadmap-v036-v039.plan.md
+++ b/docs/plans/2026-04-10-roadmap-v036-v039.plan.md
@@ -170,7 +170,7 @@ git worktree add ../wos-build-skill -b feat/build-audit-skill
 **Dependencies:** Tasks 9 and 10 merged
 **Branch strategy:** `[sequential]` — must follow Tasks 9 and 10; touches only `skills/audit-chain/`
 
-- [ ] Task 11: Implement #225 — `skills/audit-chain/SKILL.md` with both invocation modes (goal → manifest, manifest → repair loop) <!-- sha: -->
+- [x] Task 11: Implement #225 — `skills/audit-chain/SKILL.md` with both invocation modes (goal → manifest, manifest → repair loop) <!-- sha:c9c1395 -->
 
 **Verification:** invoking with a workflow goal produces a `*.chain.md`; invoking against a manifest with undeclared contracts surfaces specific findings; clean manifest → "well-formed" confirmation
 
@@ -234,7 +234,7 @@ git worktree add ../wos-deprecate-retrospective -b feat/deprecate-retrospective
 
 **Dependencies:** Tasks 9–15 merged to main
 
-- [ ] Task 16: Bump version 0.37.0 → 0.38.0; update `CHANGELOG.md`; create GitHub release tagged `v0.38.0` <!-- sha: -->
+- [x] Task 16: Bump version 0.37.0 → 0.38.0; update `CHANGELOG.md`; create GitHub release tagged `v0.38.0` <!-- sha:pending -->
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wos"
-version = "0.37.0"
+version = "0.38.0"
 description = "Claude Code plugin for building and maintaining structured project context"
 requires-python = ">=3.9"
 dependencies = []


### PR DESCRIPTION
Bump version 0.37.0 → 0.38.0. Updates CHANGELOG, version files, and roadmap plan (Tasks 11 and 16 checked off).

## What's in v0.38.0

- `wos/chain.py` + `*.chain.md` auto-detection in `scripts/lint.py` (#224)
- `/wos:audit-chain` repair loop (#225)
- `/wos:build-skill` + `/wos:audit-skill` (#226)
- `/wos:build-rule` + `/wos:audit-rule` (#227)
- `/wos:build-subagent` + `/wos:audit-subagent` (#228)
- `/wos:build-command` + `/wos:audit-command` + `/wos:build-hook` + `/wos:audit-hook` (#229)
- `/wos:retrospective` deprecated (#230)