### PR TITLE
feat: WORKFLOW.md lifecycle guide (#232)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 ## Context Navigation
 
 Each directory has an `_index.md` listing all files with descriptions.
+- `./_index.md` -- wos-workflow-doc
 - `docs/context/_index.md` -- Project context documents covering domain knowledge, patterns, and conventions.
 - `docs/plans/_index.md` -- Implementation plans for WOS features.
 - `docs/prompts/_index.md` -- prompts
@@ -16,6 +17,7 @@ Documents put key insights first and last; supplemental detail in the middle.
 ### Areas
 | Area | Path |
 |------|------|
+| wos-workflow-doc | . |
 | Project context documents covering domain knowledge, patterns, and conventions. | docs/context |
 | Implementation plans for WOS features. | docs/plans |
 | prompts | docs/prompts |

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,0 +1,134 @@
+# WOS Workflow Guide
+
+WOS has five canonical workflows. Everything you build, learn, or improve fits
+one of them. This document shows the skill sequences, gates, and handoffs —
+use it to orient quickly without reading individual SKILL.md files.
+
+## 1. Development Lifecycle
+
+Primary pipeline from idea to merged code:
+
+```
+/wos:consider → /wos:brainstorm → /wos:write-plan → /wos:execute-plan → /wos:validate-work → /wos:finish-work
+```
+
+| Step | Skill | Gate / Output |
+|------|-------|---------------|
+| Think it through | `/wos:consider` | Optional. Apply a mental model (16 available) before designing. Produces a framed problem statement. |
+| Design | `/wos:brainstorm` | Receives: topic or problem. **Gate:** user approves design doc. Produces: `docs/designs/*.design.md` |
+| Plan | `/wos:write-plan` | Receives: design doc or description. **Gate:** user approves plan. Produces: `docs/plans/*.plan.md` (`status: approved`) |
+| Execute | `/wos:execute-plan` | Receives: plan with `status: approved`. **Gate:** all tasks `[x]` with commit SHAs. Produces: implemented code on feature branch |
+| Validate | `/wos:validate-work` | Receives: plan (or ad-hoc). **Gate:** all validation criteria pass. Produces: pass/fail report per criterion |
+| Integrate | `/wos:finish-work` | Receives: validated implementation on feature branch. **Gate:** tests pass. Produces: PR opened or merge completed |
+
+**Supporting skills at any stage:**
+- `/wos:research` — gather evidence before brainstorming; chains to `/wos:write-plan` with verified findings
+- `/wos:refine-prompt` — improve a SKILL.md, plan task, or prompt before acting on it
+
+If `/wos:write-plan` finds the design infeasible, it returns structured feedback to `/wos:brainstorm`
+for revision. The plan's `status` field tracks position in the lifecycle:
+`draft → approved → executing → completed`.
+
+## 2. Knowledge Management Lifecycle
+
+How external knowledge enters the wiki and stays healthy:
+
+**Fast path (authoritative source, well-understood topic):**
+```
+source → /wos:ingest → docs/context/ → /wos:lint
+```
+
+**High-rigor path (topic needs investigation before committing findings):**
+```
+question → /wos:research → docs/research/*.research.md → /wos:distill → docs/context/ → /wos:ingest → /wos:lint
+```
+
+| Step | Skill | Gate / Output |
+|------|-------|---------------|
+| Initialize | `/wos:setup` | Creates `docs/` structure, AGENTS.md, `_index.md` files. Required once per project. |
+| Ingest (fast) | `/wos:ingest` | Receives: URL, file path, or pasted text. Append-only. Produces: wiki pages in `docs/context/` |
+| Research (rigor) | `/wos:research` | Receives: question. SIFT framework. Produces: `docs/research/*.research.md` with sources and confidence ratings |
+| Distill | `/wos:distill` | Receives: research artifact. Produces: focused context doc (200–800 words) in `docs/context/` |
+| Validate | `/wos:lint` | Receives: project root. Produces: validation report (frontmatter, URLs, index sync, content length). Read-only. |
+
+Run `/wos:lint` after any batch of ingest or distill operations to catch
+frontmatter errors, broken URLs, and index drift before they accumulate.
+
+## 3. Self-Improvement Loop
+
+How WOS improves itself — or how you improve your own WOS configuration:
+
+```
+/wos:audit → gaps identified → /wos:build-* → /wos:audit-* → /wos:audit-chain → clean
+```
+
+| Step | Skill | Gate / Output |
+|------|-------|---------------|
+| Diagnose | `/wos:audit` | Orchestrates lint + audit-skill + audit-rule + audit-chain + wiki validation. Produces: prioritized health report |
+| Build | `/wos:build-*` | Create the missing or broken primitive — skill, rule, subagent, command, or hook |
+| Verify primitive | `/wos:audit-*` | Audit the new primitive in isolation. **Gate:** no failing checks |
+| Verify chains | `/wos:audit-chain` | Confirm workflow chains remain well-formed after changes. **Gate:** "well-formed" confirmation |
+
+See [Primitive Taxonomy](#5-primitive-taxonomy) for the full build/audit pairing.
+
+## 4. Skill Chain Design
+
+How to design multi-skill workflows and verify they're coherent:
+
+**Goal mode — design a new chain from scratch:**
+```
+workflow goal → /wos:audit-chain → *.chain.md manifest
+```
+
+**Manifest mode — audit and repair an existing chain:**
+```
+*.chain.md → /wos:audit-chain → findings table → targeted edits → re-audit → clean
+```
+
+| Input | Mode | Output |
+|-------|------|--------|
+| Free-text workflow goal | Goal mode | `docs/plans/YYYY-MM-DD-<name>.chain.md` manifest |
+| Path to `*.chain.md` | Manifest mode | Findings table; optionally, targeted edits to manifest or referenced SKILL.md files |
+
+**Goal mode** is design-only — `/wos:audit-chain` creates the manifest but
+never executes chain steps. The manifest is the deliverable; pass it to
+`/wos:execute-plan` to run the steps manually.
+
+**Manifest mode** runs five structural checks: skills exist, contracts
+declared, gates on consequential steps, termination condition, no cycles.
+Fixes are applied one at a time with confirmation; cross-reference mismatches
+are flagged as `warn` and the user decides what to fix.
+
+## 5. Primitive Taxonomy
+
+The complete build/audit pairing for every WOS primitive:
+
+| Goal | Build | Audit |
+|------|-------|-------|
+| Create or improve a skill | `/wos:build-skill` | `/wos:audit-skill` |
+| Create or improve a rule | `/wos:build-rule` | `/wos:audit-rule` |
+| Create or improve a subagent | `/wos:build-subagent` | `/wos:audit-subagent` |
+| Create or improve a command | `/wos:build-command` | `/wos:audit-command` |
+| Create or improve a hook | `/wos:build-hook` | `/wos:audit-hook` |
+| Design or audit a skill chain | — | `/wos:audit-chain` |
+| Project-wide health check | — | `/wos:audit` |
+| Content quality validation | — | `/wos:lint` |
+
+**Build** skills scaffold a new primitive from a description and I/O contract.
+**Audit** skills surface quality issues in existing primitives — structure,
+coverage, anti-patterns, and specificity.
+
+Chain each build step directly into the matching audit: create with
+`/wos:build-*`, verify with `/wos:audit-*`, confirm chains are clean
+with `/wos:audit-chain`, then confirm project health with `/wos:audit`.
+
+---
+
+**Quick reference:** Development work starts at `/wos:brainstorm`. Knowledge
+capture starts at `/wos:ingest` (fast) or `/wos:research` (rigorous). WOS
+self-improvement starts at `/wos:audit`. Chain design starts at
+`/wos:audit-chain`. Build anything new with the appropriate `/wos:build-*`
+skill; verify it with the matching `/wos:audit-*`.
+
+*Deprecated:* `/wos:retrospective` (use `/wos:finish-work` Step 6),
+`/wos:check-rules` and `/wos:extract-rules` (use `/wos:build-rule` and `/wos:audit-rule`).

--- a/docs/plans/2026-04-11-workflow-doc.plan.md
+++ b/docs/plans/2026-04-11-workflow-doc.plan.md
@@ -1,0 +1,232 @@
+---
+name: WORKFLOW.md Lifecycle Guide
+description: Create WORKFLOW.md at project root documenting the canonical WOS workflows — development lifecycle, knowledge management, self-improvement loop, skill chain design, and primitive taxonomy.
+type: plan
+status: executing
+branch: feat/workflow-doc
+pr: ~
+related:
+  - docs/plans/2026-04-10-roadmap-v036-v039.plan.md
+---
+
+# WORKFLOW.md Lifecycle Guide
+
+Close issue bcbeidel/wos#232: create `WORKFLOW.md` at the project root.
+
+## Goal
+
+Write a `WORKFLOW.md` that makes WOS understandable as a coherent system — showing
+how its skills connect across five workflow patterns: development lifecycle,
+knowledge management lifecycle, self-improvement loop, skill chain design, and a
+primitive taxonomy table. Target audience is a developer orienting to WOS for
+the first time, and an agent resuming work with zero conversation context.
+
+## Scope
+
+### Must have
+
+- `WORKFLOW.md` at project root with WOS frontmatter
+- Five sections matching the issue spec: development lifecycle, knowledge
+  management lifecycle, self-improvement loop, skill chain design, primitive
+  taxonomy table
+- Text chain diagrams at each lifecycle section showing skill sequence
+- Gate/decision descriptions at each lifecycle arrow
+- Every active skill appears in at least one section (see list in Tasks)
+- Passes `python scripts/lint.py --root . --no-urls`
+
+### Won't have
+
+- New Python code, tests, or scripts — documentation only
+- Changes to any existing SKILL.md, OVERVIEW.md, or other file
+- `/wos:audit` skill implementation — that is Task 17 (issue #231), parallel work
+- `challenge`, `principles`, `report-issue` skill implementations — not present
+  in the v0.38.x skills directory; if they exist at ship time, add them
+
+## Approach
+
+`WORKFLOW.md` complements `OVERVIEW.md`. OVERVIEW.md describes *layers*;
+WORKFLOW.md shows *how to work* — which skills to invoke, in what order, with
+what gates between them.
+
+The document is agent-facing as well as human-facing. Key insight goes first and
+last; reference detail in the middle.
+
+**Section design:**
+
+1. **Development lifecycle** — primary pipeline (`brainstorm → write-plan →
+   execute-plan → validate-work → finish-work`) with supporting skills
+   (`consider`, `refine-prompt`, `challenge`) as annotated side-uses at
+   appropriate stages.
+
+2. **Knowledge management lifecycle** — two paths: fast path (`ingest`) and
+   high-rigor path (`research → distill → ingest`). Followed by `lint` as the
+   ongoing health check. Include `setup` as the prerequisite that creates the
+   required directory structure.
+
+3. **Self-improvement loop** — `/wos:audit` as the entry point (coming in
+   v0.39.0 Task 17, shipped in the same release). Identify gaps → apply the
+   appropriate build/audit pair → `/wos:audit-chain` to validate chains are
+   clean.
+
+4. **Skill chain design** — `/wos:audit-chain` dual-mode: goal → manifest
+   creation, manifest → repair loop. Reference `*.chain.md` as the artifact.
+
+5. **Primitive taxonomy table** — the table from the issue spec, expanded with
+   `build-subagent`/`audit-subagent` and `build-command`/`audit-command`
+   /`build-hook`/`audit-hook` rows.
+
+**Active skills to cover (all must appear in at least one section):**
+`setup`, `lint`, `research`, `distill`, `ingest`, `brainstorm`, `write-plan`,
+`execute-plan`, `validate-work`, `finish-work`, `refine-prompt`, `consider`,
+`audit`, `audit-chain`, `build-skill`, `audit-skill`, `build-rule`,
+`audit-rule`, `build-subagent`, `audit-subagent`, `build-command`,
+`audit-command`, `build-hook`, `audit-hook`
+
+**Deprecated skills** (`retrospective`, `check-rules`, `extract-rules`) get a
+single footnote line — no lifecycle sections of their own.
+
+## File Changes
+
+| Action | File |
+|--------|------|
+| Create | `WORKFLOW.md` |
+
+## Tasks
+
+### Task 1 — Read skill handoff contracts
+
+Read the `## Handoff` section from each active skill's SKILL.md. Capture what
+each skill receives and produces — this informs the gate descriptions at
+lifecycle arrows.
+
+Skills to read (from `skills/*/SKILL.md`):
+`brainstorm`, `write-plan`, `execute-plan`, `validate-work`, `finish-work`,
+`research`, `distill`, `ingest`, `lint`, `setup`, `refine-prompt`,
+`audit-chain`, `build-skill`, `audit-skill`, `build-rule`, `audit-rule`,
+`build-subagent`, `audit-subagent`, `build-command`, `audit-command`,
+`build-hook`, `audit-hook`
+
+**Verification:** All handoff contracts reviewed before writing begins.
+No commit — reading only.
+
+### Task 2 — Write WORKFLOW.md
+
+Create `WORKFLOW.md` at the project root with WOS frontmatter and all five
+sections. Each lifecycle section must:
+- Open with a text chain diagram showing the skill sequence
+- Follow with a short description of each arrow's gate or decision point
+- Name every skill used in that path
+
+**Content requirements:**
+- Development lifecycle: full pipeline + `consider` at brainstorm/design stage,
+  `refine-prompt` for prompt/plan quality review
+- Knowledge management: `setup` (prerequisite), fast path via `ingest`, high-
+  rigor path via `research → distill → ingest`, `lint` for ongoing validation
+- Self-improvement loop: `/wos:audit` → gap identification → build/audit pair
+  → `/wos:audit-chain` → clean
+- Skill chain design: `/wos:audit-chain` dual-mode (goal → manifest, manifest
+  → repair loop)
+- Primitive taxonomy: table from issue spec + subagent, command, hook rows
+
+**Verification:**
+```bash
+# File exists
+ls WORKFLOW.md
+
+# All active skills mentioned
+for skill in setup lint research distill ingest brainstorm write-plan \
+  execute-plan validate-work finish-work refine-prompt consider audit \
+  audit-chain build-skill audit-skill build-rule audit-rule build-subagent \
+  audit-subagent build-command audit-command build-hook audit-hook; do
+  grep -q "$skill" WORKFLOW.md || echo "MISSING: $skill"
+done
+# Expected: no output
+
+# All five required sections present
+for section in "Development lifecycle" "Knowledge management" \
+  "Self-improvement" "Skill chain design" "Primitive taxonomy"; do
+  grep -qi "$section" WORKFLOW.md || echo "MISSING SECTION: $section"
+done
+# Expected: no output
+```
+
+**Commit:**
+```bash
+git add WORKFLOW.md
+git commit -m "feat: add WORKFLOW.md lifecycle guide (closes #232)"
+```
+
+### Task 3 — Run lint and fix issues
+
+```bash
+python scripts/lint.py --root . --no-urls
+```
+
+Fix any failures. Common issues: missing `name`/`description` frontmatter,
+content length outside 100–800 words if WORKFLOW.md is picked up as a context
+document, index sync errors.
+
+**Verification:**
+```bash
+python scripts/lint.py --root . --no-urls
+# Expected: zero failures; warnings acceptable
+```
+
+**Commit:** only if lint fixes were required:
+```bash
+git add WORKFLOW.md
+git commit -m "fix: address lint issues in WORKFLOW.md"
+```
+
+### Task 4 — Update roadmap Task 18 checkbox
+
+After the PR merges, update `docs/plans/2026-04-10-roadmap-v036-v039.plan.md`
+Task 18 checkbox with the merge commit SHA:
+
+```markdown
+- [x] Task 18: Implement #232 — `WORKFLOW.md` at project root covering development
+  lifecycle, knowledge management lifecycle, self-improvement loop, and primitive
+  taxonomy table <!-- sha:MERGE_SHA -->
+```
+
+This task executes on `main` after merge, not on the feature branch.
+
+**Verification:**
+```bash
+grep "Task 18" docs/plans/2026-04-10-roadmap-v036-v039.plan.md
+# Expected: `- [x] Task 18: ...` with sha filled in
+```
+
+**Commit:**
+```bash
+git add docs/plans/2026-04-10-roadmap-v036-v039.plan.md
+git commit -m "chore: mark roadmap Task 18 complete"
+```
+
+## Validation
+
+```bash
+# WORKFLOW.md exists at project root
+ls WORKFLOW.md
+# Expected: WORKFLOW.md
+
+# All active skills are mentioned
+for skill in setup lint research distill ingest brainstorm write-plan \
+  execute-plan validate-work finish-work refine-prompt consider audit \
+  audit-chain build-skill audit-skill build-rule audit-rule build-subagent \
+  audit-subagent build-command audit-command build-hook audit-hook; do
+  grep -q "$skill" WORKFLOW.md || echo "MISSING: $skill"
+done
+# Expected: no output
+
+# All five required sections present
+for section in "Development lifecycle" "Knowledge management" \
+  "Self-improvement" "Skill chain design" "Primitive taxonomy"; do
+  grep -qi "$section" WORKFLOW.md || echo "MISSING SECTION: $section"
+done
+# Expected: no output
+
+# Lint passes
+python scripts/lint.py --root . --no-urls
+# Expected: zero failures
+```

--- a/docs/plans/2026-04-11-workflow-doc.plan.md
+++ b/docs/plans/2026-04-11-workflow-doc.plan.md
@@ -2,7 +2,7 @@
 name: WORKFLOW.md Lifecycle Guide
 description: Create WORKFLOW.md at project root documenting the canonical WOS workflows — development lifecycle, knowledge management, self-improvement loop, skill chain design, and primitive taxonomy.
 type: plan
-status: executing
+status: completed
 branch: feat/workflow-doc
 pr: ~
 related:

--- a/docs/plans/_index.md
+++ b/docs/plans/_index.md
@@ -20,3 +20,4 @@ Implementation plans for WOS features.
 | [2026-04-11-handoff-contracts.plan.md](2026-04-11-handoff-contracts.plan.md) | Add a standardized ## Handoff section (Receives / Produces / Chainable-to) to every existing SKILL.md — prerequisite for audit-chain |
 | [2026-04-11-ingest-skill.plan.md](2026-04-11-ingest-skill.plan.md) | Add skills/ingest/SKILL.md — universal source intake that updates 5–15 wiki pages per invocation with append-only semantics |
 | [2026-04-11-skill-refresh.plan.md](2026-04-11-skill-refresh.plan.md) | Review and update all 14 SKILL.md files against the v0.35.0 context base — adding anti-pattern guards, strengthening gate checks, and removing contraindicated approaches |
+| [2026-04-11-workflow-doc.plan.md](2026-04-11-workflow-doc.plan.md) | Create WORKFLOW.md at project root documenting the canonical WOS workflows — development lifecycle, knowledge management, self-improvement loop, skill chain design, and primitive taxonomy. |


### PR DESCRIPTION
## Summary

- Adds `WORKFLOW.md` at the project root documenting the canonical WOS workflows
- Five sections: development lifecycle, knowledge management lifecycle, self-improvement loop, skill chain design, and primitive taxonomy table
- All 24 active skills appear in at least one lifecycle section
- Follows the same plain-markdown convention as `OVERVIEW.md` (no frontmatter, no lint impact)

## Validation

- `ls WORKFLOW.md` — file exists at project root ✓
- All 24 active skills appear in at least one section ✓
- All 5 required sections present ✓
- `python scripts/lint.py --root . --no-urls` — zero new failures (1 pre-existing fixture issue unchanged) ✓
- `python -m pytest tests/ -q` — 441 passed ✓

## Roadmap

Closes #232. Part of v0.39.0 (Task 18 of `docs/plans/2026-04-10-roadmap-v036-v039.plan.md`). Update Task 18 checkbox with merge SHA after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)