### PR TITLE
chore: release v0.39.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
         "repo": "bcbeidel/wos"
       },
       "description": "Claude Code plugin for building and maintaining structured project context",
-      "version": "0.38.0",
+      "version": "0.39.0",
       "license": "MIT"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wos",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "description": "Claude Code plugin for building and maintaining structured project context",
   "author": {
     "name": "bbeidel"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.39.0] - 2026-04-11
+
+### Added
+
+- **`/wos:audit` — project health orchestrator.** Combines structural findings
+  from `scripts/lint.py` with LLM-judgment findings from the audit family
+  (audit-skill, audit-rule, audit-chain, wiki validation) into a prioritized
+  health report (Critical / High / Medium / Low). Offers to work through
+  findings in priority order.
+
+- **`WORKFLOW.md` — canonical lifecycle guide.** Documents all WOS workflows:
+  development lifecycle (brainstorm → write-plan → execute-plan → validate-work
+  → finish-work), knowledge management (ingest, research → ingest), skill chain
+  design (audit-chain), and the self-improvement loop (audit → build-X →
+  audit-X). Includes the full primitive taxonomy table.
+
+### Removed
+
+- **`/wos:retrospective`** — removed. Use `/wos:finish-work` Step 6.
+- **`/wos:check-rules`** — removed. Use `/wos:audit-rule`.
+- **`/wos:extract-rules`** — removed. Use `/wos:build-rule`.
+
 ## [0.38.0] - 2026-04-11
 
 ### Added

--- a/docs/plans/2026-04-10-roadmap-v036-v039.plan.md
+++ b/docs/plans/2026-04-10-roadmap-v036-v039.plan.md
@@ -250,7 +250,7 @@ git worktree add ../wos-deprecate-retrospective -b feat/deprecate-retrospective
 git worktree add ../wos-audit-orchestrator -b feat/audit-orchestrator
 ```
 
-- [ ] Task 17: Implement #231 — `skills/audit/SKILL.md` orchestrating lint + audit-skill + audit-rule + audit-chain + wiki validation into a prioritized health report <!-- sha: -->
+- [x] Task 17: Implement #231 — `skills/audit/SKILL.md` orchestrating lint + audit-skill + audit-rule + audit-chain + wiki validation into a prioritized health report <!-- sha:6c2b14d -->
 
 **Verification:** on a clean project → "No critical issues found"; on a project with structural failures → critical issues surface first
 
@@ -264,7 +264,7 @@ git worktree add ../wos-audit-orchestrator -b feat/audit-orchestrator
 git worktree add ../wos-workflow-doc -b feat/workflow-doc
 ```
 
-- [ ] Task 18: Implement #232 — `WORKFLOW.md` at project root covering development lifecycle, knowledge management lifecycle, self-improvement loop, and primitive taxonomy table <!-- sha: -->
+- [x] Task 18: Implement #232 — `WORKFLOW.md` at project root covering development lifecycle, knowledge management lifecycle, self-improvement loop, and primitive taxonomy table <!-- sha:175915c -->
 
 **Verification:** every skill appears in at least one lifecycle; `python scripts/lint.py --root .` — clean pass
 
@@ -272,7 +272,7 @@ git worktree add ../wos-workflow-doc -b feat/workflow-doc
 
 **Dependencies:** Tasks 17–18 merged to main
 
-- [ ] Task 19: Bump version 0.38.0 → 0.39.0; update `CHANGELOG.md`; create GitHub release tagged `v0.39.0` <!-- sha: -->
+- [x] Task 19: Bump version 0.38.0 → 0.39.0; update `CHANGELOG.md`; create GitHub release tagged `v0.39.0` <!-- sha:pending -->
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wos"
-version = "0.38.0"
+version = "0.39.0"
 description = "Claude Code plugin for building and maintaining structured project context"
 requires-python = ">=3.9"
 dependencies = []


### PR DESCRIPTION
Bump version 0.38.0 → 0.39.0. Updates CHANGELOG, version files, and roadmap plan (Tasks 17, 18, 19 checked off).

## What's in v0.39.0

- `/wos:audit` project health orchestrator (#231)
- `WORKFLOW.md` lifecycle guide (#232)
- Removed deprecated skills: retrospective, check-rules, extract-rules