### PR TITLE
chore: bump version to 0.41.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
         "repo": "bcbeidel/wos"
       },
       "description": "Claude Code plugin for building and maintaining structured project context",
-      "version": "0.40.0",
+      "version": "0.41.0",
       "license": "MIT"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wos",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "description": "Claude Code plugin for building and maintaining structured project context",
   "author": {
     "name": "bbeidel"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.41.0] - 2026-04-13
+
+### Added
+
+- **`/wos:build-hook` — hook authoring skill.** Full authoring workflow with
+  primitive routing (hook vs `permissions.deny` vs CLAUDE.md), structured
+  elicitation, script drafting with a 16-check safety gate, a review gate
+  before any file is written, and a three-layer test procedure. Offers
+  `/wos:check-hook` after testing completes.
+
+- **`/wos:check-hook` — hook audit skill.** 16-check audit covering event
+  coverage, script safety, async/blocking contradictions, Stop hook loop
+  guards, stdin correctness, matcher casing, enforcement intent, rule overlap,
+  idempotency, latency, safety preamble, injection safety, jq availability,
+  ShellCheck, style conventions, and `settings.json` attack surface. Includes
+  primitive routing scan of CLAUDE.md and cross-platform gap reporting.
+
+- **Hook domain context corpus (37 context files, 4 research docs).** Complete
+  knowledge base for Claude Code hooks: event payload schemas, matcher syntax,
+  output/decision control, handler type comparison, path expansion quirks,
+  platform coverage (Claude Code, Cursor, Copilot, Cline, Codex CLI,
+  Windsurf), script authoring safety (preamble, injection prevention, JSON
+  handling, ShellCheck, bash style conventions, testing strategies), hook
+  quality criteria, and primitive routing guidance.
+
+### Removed
+
+- **`/wos:build-command` and `/wos:check-command`** — superseded by the hook
+  skill pair.
+
 ## [0.40.0] - 2026-04-12
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wos"
-version = "0.40.0"
+version = "0.41.0"
 description = "Claude Code plugin for building and maintaining structured project context"
 requires-python = ">=3.9"
 dependencies = []


### PR DESCRIPTION
Version bump to 0.41.0.

## Added
- `/wos:build-hook` — hook authoring skill with 16-check safety gate
- `/wos:check-hook` — hook audit skill (16 checks, cross-platform gap reporting)
- Hook domain context corpus: 37 context files + 4 research docs

## Removed
- `/wos:build-command` and `/wos:check-command` — superseded by hook skill pair

🤖 Generated with [Claude Code](https://claude.com/claude-code)