### PR TITLE
fix: wiki plugin bugfix batch (#265–#270)

### DIFF
--- a/docs/designs/2026-04-15-wiki-plugin-bugfix-batch.design.md
+++ b/docs/designs/2026-04-15-wiki-plugin-bugfix-batch.design.md
@@ -1,0 +1,98 @@
+---
+name: Wiki Plugin Bugfix Batch
+description: Fix 6 bugs in the wiki plugin — 4 root-caused in Python code, 2 in skill text only
+type: design
+status: approved
+related:
+  - plugins/wiki/skills/setup/SKILL.md
+  - plugins/wiki/skills/ingest/SKILL.md
+  - plugins/wiki/scripts/update_preferences.py
+  - plugins/wiki/scripts/_bootstrap.py
+  - plugins/wiki/src/wiki/agents_md.py
+---
+
+# Wiki Plugin Bugfix Batch
+
+**Purpose:** Fix 6 bugs in the wiki plugin across issues #265–#270. No new features; scope is strictly the 6 open issues.
+
+## Issues
+
+| # | Title | Root cause location | Severity |
+|---|-------|-------------------|----------|
+| #265 | wiki:ingest error references `/wos:setup` | SKILL.md text | Low |
+| #266 | wiki:setup step 3 references `reindex.py` (doesn't exist) | SKILL.md + missing script | Medium |
+| #267 | Plugin scripts fail without `PYTHONPATH=src` and `python3` | `_bootstrap.py` sys.path bug | High |
+| #268 | wiki:setup never creates `wiki/SCHEMA.md` or `wiki/_index.md` | SKILL.md missing step | High |
+| #269 | `update_preferences.py` silently rewrites Areas table | `update_preferences.py` calls `discover_areas` as side-effect | Medium |
+| #270 | Uncommitted-changes guard offers no actionable resolution | SKILL.md guard text vague | Low |
+
+## Behavior by Issue
+
+### #265 — ingest typo (text only)
+Change `/wos:setup` → `/wiki:setup` in `skills/ingest/SKILL.md` Pre-Ingest error message.
+
+### #266 — reindex.py doesn't exist (new script + skill text)
+Create `scripts/reindex.py` that:
+1. Walks the project finding directories that contain `.md` files (excluding `_index.md` itself)
+2. For each such directory, reads each `.md` file and extracts `name` and `description` from frontmatter
+3. Writes `<dir>/_index.md` — a markdown table of `| File | Description |` rows, sorted alphabetically
+4. Updates the AGENTS.md areas table: preserves existing descriptions for known paths, uses path as fallback for new ones
+
+Update `setup/SKILL.md` step 3 and `ingest/SKILL.md` post-ingest to call `python3 <plugin-scripts-dir>/reindex.py --root <project-root>`.
+
+### #267 — _bootstrap.py sys.path bug (code)
+`_bootstrap.py` inserts `plugin_root` (= `plugins/wiki/`) into sys.path, but the package lives at `plugins/wiki/src/wiki/`. Fix: also insert `plugin_root / "src"` so scripts work without a prior editable install.
+
+Also update all `python` → `python3` references in skill files.
+
+### #268 — setup never creates wiki infrastructure (skill text)
+Add a step (numbered 2.8, between current steps 2 and 3) to `setup/SKILL.md`:
+- Create `wiki/` directory if missing
+- Create `wiki/SCHEMA.md` from `references/wiki-schema-template.md` if missing
+- Create `wiki/_index.md` with empty page inventory header if missing
+- Idempotent: skip any file that already exists
+
+### #269 — update_preferences.py destroys Areas table (code)
+Root cause: `update_preferences.py` calls `discover_areas(root)` and passes it to `update_agents_md`, which re-renders the entire areas table with bare paths in both name and description columns.
+
+Fix:
+1. Add `extract_areas(content: str) -> List[Dict[str, str]]` to `agents_md.py` — parses the existing `### Areas` table, returning `{"name": <col1>, "path": <col2>}` dicts
+2. Make `areas` parameter in `update_agents_md` optional (default `None`). When `None`, call `extract_areas` to preserve existing table content. Existing callers that supply `areas` explicitly are unaffected.
+3. Remove `discover_areas` call from `update_preferences.py`
+
+### #270 — uncommitted-changes guard vague (skill text)
+Update anti-pattern guard #1 in `setup/SKILL.md`:
+- Scope check to tracked modified files only (check `git diff --name-only HEAD`, not untracked files)
+- Untracked files alone: advisory note, not a blocking gate
+- When tracked modifications are found: suggest `git stash`, explain why (post-setup git diff becomes ambiguous; if setup fails partway, recovery state is unclear)
+
+## Components
+
+**New files:**
+- `plugins/wiki/scripts/reindex.py`
+- `plugins/wiki/tests/test_reindex.py`
+
+**Modified files:**
+- `plugins/wiki/scripts/_bootstrap.py` — add `src/` to sys.path
+- `plugins/wiki/scripts/update_preferences.py` — remove `discover_areas` call
+- `plugins/wiki/src/wiki/agents_md.py` — add `extract_areas`; make `areas` optional in `update_agents_md`
+- `plugins/wiki/skills/setup/SKILL.md` — add step 2.8; fix step 3 ref; improve guard #1; `python3`
+- `plugins/wiki/skills/ingest/SKILL.md` — fix `/wos:setup`; fix post-ingest reindex ref; `python3`
+- `plugins/wiki/tests/test_agents_md.py` — add `extract_areas` tests; `update_agents_md(areas=None)` tests
+- `plugins/wiki/tests/test_update_preferences.py` — update `test_preserves_areas` to match new behavior
+
+## Acceptance Criteria
+
+1. `python3 plugins/wiki/scripts/update_preferences.py --root . directness=blunt` — Preferences section updated, Areas table unchanged
+2. `python3 plugins/wiki/scripts/reindex.py --root .` — `_index.md` created in each directory with `.md` files; AGENTS.md areas table updated with existing descriptions preserved
+3. Any `scripts/*.py` invocation — no `ModuleNotFoundError` without prior `pip install -e .`
+4. `/wiki:setup` on a fresh project → `wiki/SCHEMA.md` and `wiki/_index.md` created
+5. `/wiki:ingest` missing-wiki error says `/wiki:setup`, not `/wos:setup`
+6. All existing tests pass; new tests cover `extract_areas`, `update_agents_md(areas=None)`, and `reindex.py`
+
+## Out of Scope
+
+- `wiki/_index.md` regeneration during reindex (wiki page inventory is managed by ingest)
+- Changes to `lint`, `research`, or other skills
+- Changing AGENTS.md format or WOS section structure
+- Preserving human edits to `_index.md` across reindex runs

--- a/docs/plans/2026-04-15-wiki-plugin-bugfix-batch.plan.md
+++ b/docs/plans/2026-04-15-wiki-plugin-bugfix-batch.plan.md
@@ -65,23 +65,16 @@ Fix all issues that require only SKILL.md changes. No code changes in this task.
 - Modify: `plugins/wiki/skills/ingest/SKILL.md`
 - Modify: `plugins/wiki/skills/setup/SKILL.md`
 
-- [ ] In `skills/ingest/SKILL.md` Pre-Ingest section, change `/wos:setup` → `/wiki:setup` (line 35).
-- [ ] In `skills/ingest/SKILL.md` Post-Ingest section, change `python` → `python3` for both script calls.
-- [ ] In `skills/setup/SKILL.md` step 5, change `python` → `python3` for the `update_preferences.py` call.
-- [ ] In `skills/setup/SKILL.md`, add step **2.8 — Initialize wiki infrastructure** between step 2 and step 3:
-  - Create `wiki/` directory if it does not exist
-  - Create `wiki/SCHEMA.md` from `references/wiki-schema-template.md` if it does not exist
-  - Create `wiki/_index.md` with an empty page inventory (header line `# Wiki Index` + empty table with `| Page | Description | File |` columns) if it does not exist
-  - Idempotent: skip any file that already exists; do not overwrite
-- [ ] In `skills/setup/SKILL.md`, update anti-pattern guard #1:
-  - Scope check to **tracked modified files only**: check `git diff --name-only HEAD` (not untracked files)
-  - Untracked-only state: advisory note, not a blocking gate
-  - When tracked modifications exist: suggest `git stash` as remediation; explain that setup writes AGENTS.md and CLAUDE.md, making the diff ambiguous and recovery harder if setup fails partway
-- [ ] Verify: `grep -n "wos:setup" plugins/wiki/skills/ingest/SKILL.md` → no matches
-- [ ] Verify: `grep -n "python " plugins/wiki/skills/setup/SKILL.md plugins/wiki/skills/ingest/SKILL.md` → no bare `python ` (only `python3`)
-- [ ] Verify: `grep -n "2.8" plugins/wiki/skills/setup/SKILL.md` → wiki init step present
-- [ ] Verify: `grep -n "git stash" plugins/wiki/skills/setup/SKILL.md` → remediation hint present
-- [ ] Commit: `fix: skill text fixes — typo, wiki init step, guard improvement, python3 refs (#265 #268 #270 #267)`
+- [x] In `skills/ingest/SKILL.md` Pre-Ingest section, change `/wos:setup` → `/wiki:setup` (line 35). <!-- sha:819d8eb -->
+- [x] In `skills/ingest/SKILL.md` Post-Ingest section, change `python` → `python3` for both script calls. <!-- sha:819d8eb -->
+- [x] In `skills/setup/SKILL.md` step 5, change `python` → `python3` for the `update_preferences.py` call. <!-- sha:819d8eb -->
+- [x] In `skills/setup/SKILL.md`, add step **2.8 — Initialize wiki infrastructure** between step 2 and step 3. <!-- sha:819d8eb -->
+- [x] In `skills/setup/SKILL.md`, update anti-pattern guard #1. <!-- sha:819d8eb -->
+- [x] Verify: `grep -n "wos:setup" plugins/wiki/skills/ingest/SKILL.md` → no matches <!-- sha:819d8eb -->
+- [x] Verify: `grep -n "python " plugins/wiki/skills/setup/SKILL.md plugins/wiki/skills/ingest/SKILL.md` → no bare `python ` (only `python3`) <!-- sha:819d8eb -->
+- [x] Verify: `grep -n "2.8" plugins/wiki/skills/setup/SKILL.md` → wiki init step present <!-- sha:819d8eb -->
+- [x] Verify: `grep -n "git stash" plugins/wiki/skills/setup/SKILL.md` → remediation hint present <!-- sha:819d8eb -->
+- [x] Commit: `fix: skill text fixes — typo, wiki init step, guard improvement, python3 refs (#265 #268 #270 #267)` <!-- sha:819d8eb -->
 
 ---
 
@@ -94,10 +87,10 @@ Fix all issues that require only SKILL.md changes. No code changes in this task.
 **Files:**
 - Modify: `plugins/wiki/scripts/_bootstrap.py`
 
-- [ ] After inserting `plugin_root` into sys.path, also insert `plugin_root / "src"` if it is a directory and not already in sys.path. Insert at position 0 (highest priority).
-- [ ] Verify: `cd plugins/wiki && python3 scripts/check_url.py --help` succeeds without `ModuleNotFoundError` (no editable install required — run in a fresh venv or after uninstalling the package)
-- [ ] Verify: `python -m pytest plugins/wiki/tests/test_script_syspath.py -v` passes
-- [ ] Commit: `fix: _bootstrap.py — add src/ to sys.path so scripts work without editable install (#267)`
+- [x] After inserting `plugin_root` into sys.path, also insert `plugin_root / "src"` if it is a directory and not already in sys.path. Insert at position 0 (highest priority). <!-- sha:bd28cc1 -->
+- [x] Verify: `cd plugins/wiki && python3 scripts/check_url.py --help` succeeds without `ModuleNotFoundError`. <!-- sha:bd28cc1 -->
+- [x] Verify: `python -m pytest plugins/wiki/tests/test_script_syspath.py -v` passes (2 pre-existing failures about `check` module, unrelated to this fix; 1 passes). <!-- sha:bd28cc1 -->
+- [x] Commit: `fix: _bootstrap.py — add src/ to sys.path so scripts work without editable install (#267)` <!-- sha:bd28cc1 -->
 
 ---
 
@@ -111,21 +104,11 @@ Add `extract_areas` function and make `areas` optional in `update_agents_md`. Wh
 
 **Depends on:** Task 2 (clean sys.path for test runner)
 
-- [ ] Add `extract_areas(content: str) -> List[Dict[str, str]]` to `agents_md.py`:
-  - Finds the `### Areas` table between WOS markers
-  - Skips the header row (`| Area | Path |`) and separator row (`|------|------|`)
-  - Parses each data row into `{"name": col1.strip(), "path": col2.strip()}`
-  - Returns empty list if no markers or no Areas table found
-- [ ] Change `areas` parameter in `update_agents_md` from `List[Dict[str, str]]` to `Optional[List[Dict[str, str]]]` with default `None`. When `None`, call `extract_areas(content)` to get existing areas.
-- [ ] Add tests in `test_agents_md.py`:
-  - `extract_areas` round-trip: render a WOS section with areas, extract them back, assert same name/path values
-  - `extract_areas` with human-written descriptions: areas table with description text in col1 (not path), verify they parse correctly
-  - `extract_areas` returns empty list when no markers
-  - `extract_areas` returns empty list when no Areas table
-  - `update_agents_md(content, areas=None)` preserves existing area descriptions without modification
-  - `update_agents_md(content, areas=None)` on content with no Areas table produces no Areas section
-- [ ] Verify: `python -m pytest plugins/wiki/tests/test_agents_md.py -v` — all pass including new tests
-- [ ] Commit: `feat: agents_md — add extract_areas, make areas optional in update_agents_md (#269)`
+- [x] Add `extract_areas(content: str) -> List[Dict[str, str]]` to `agents_md.py`. <!-- sha:bef3a16 -->
+- [x] Change `areas` parameter in `update_agents_md` to `Optional[List[Dict[str, str]]]` with default `None`. <!-- sha:bef3a16 -->
+- [x] Add tests in `test_agents_md.py` (round-trip, human descriptions, no markers, no table, areas=None). <!-- sha:bef3a16 -->
+- [x] Verify: `python -m pytest plugins/wiki/tests/test_agents_md.py -v` — 34 passed. <!-- sha:bef3a16 -->
+- [x] Commit: `feat: agents_md — add extract_areas, make areas optional in update_agents_md (#269)` <!-- sha:bef3a16 -->
 
 ---
 
@@ -139,15 +122,11 @@ Remove `discover_areas` call. After Task 3, passing `areas=None` preserves exist
 
 **Depends on:** Task 3
 
-- [ ] In `update_preferences.py`: remove `from wiki.agents_md import discover_areas` (keep `render_preferences` and `update_agents_md`). Remove the `areas = discover_areas(root)` call. Call `update_agents_md(content, preferences=rendered)` with no `areas` argument.
-- [ ] Update `test_update_preferences.py::TestUpdatePreferencesWritesAgentsMd::test_preserves_areas`:
-  - Setup: write an AGENTS.md that already has an Areas table with a human-written description (e.g., `| How agents plan tasks | docs/context/planning |`)
-  - Run `update_preferences.py --root . directness=blunt`
-  - Assert: the human-written description is still present; no new areas were added from disk
-  - Also add negative assertion: a directory that exists on disk but is NOT in the existing AGENTS.md areas table should NOT appear after running `update_preferences.py`
-- [ ] Verify: `python -m pytest plugins/wiki/tests/test_update_preferences.py -v` — all pass
-- [ ] Verify: `python -m pytest plugins/wiki/tests/ -v` — full suite passes
-- [ ] Commit: `fix: update_preferences.py — remove discover_areas side-effect, preserve existing areas (#269)`
+- [x] In `update_preferences.py`: remove `discover_areas` call; pass `areas=None` to `update_agents_md`. <!-- sha:1ee957d -->
+- [x] Update `test_preserves_areas` → `test_preserves_existing_area_descriptions` to assert correct behavior. <!-- sha:1ee957d -->
+- [x] Verify: `python -m pytest plugins/wiki/tests/test_update_preferences.py -v` — 4 passed. <!-- sha:1ee957d -->
+- [x] Verify: `python -m pytest plugins/wiki/tests/` — 233 pass (pre-existing lint/syspath failures unchanged). <!-- sha:1ee957d -->
+- [x] Commit: `fix: update_preferences.py — remove discover_areas side-effect, preserve existing areas (#269)` <!-- sha:1ee957d -->
 
 ---
 
@@ -161,24 +140,12 @@ Create a standalone script that creates `_index.md` files in all directories con
 
 **Depends on:** Task 3 (needs `extract_areas` and `update_agents_md(areas=...)`)
 
-- [ ] Create `plugins/wiki/scripts/reindex.py` with the following behavior:
-  - `--root` argument (default: `.`)
-  - Call `discover_areas(root)` to find all directories with `.md` files
-  - For each area directory, read each `.md` file (excluding `_index.md`) and extract `name` and `description` from frontmatter using a minimal stdlib frontmatter reader (can reuse `parse_frontmatter` from `wiki.document` or implement inline)
-  - Write `<dir>/_index.md`: heading `# <relative-path>`, then `| File | Description |` table with rows sorted by filename; `name` field from frontmatter as link text, `description` as description; fallback to stem if no `name` field
-  - If `AGENTS.md` exists at root, read it, call `extract_areas` to get existing descriptions, merge with discovered areas (prefer existing description when path matches), call `update_agents_md(content, areas=merged)`, write updated file
-  - Print summary: N directories indexed, AGENTS.md updated (or skipped)
-- [ ] `reindex.py` must NOT touch `wiki/_index.md` — that file is managed by ingest, not reindex
-- [ ] Create `test_reindex.py`:
-  - Creates `_index.md` in a directory with `.md` files
-  - `_index.md` content is a valid markdown table with file names and descriptions from frontmatter
-  - Directories with no `.md` files (other than `_index.md`) do not get `_index.md` created
-  - `wiki/` directory is not indexed (or if `wiki/` has non-index docs, its `_index.md` is created but `wiki/_index.md` as page inventory is a separate concern — verify this doesn't conflict)
-  - Existing area descriptions in AGENTS.md are preserved after reindex
-  - New areas discovered on disk but not in AGENTS.md get path as fallback description
-- [ ] Verify: `python -m pytest plugins/wiki/tests/test_reindex.py -v` — all pass
-- [ ] Verify: `python3 plugins/wiki/scripts/reindex.py --root .` runs without error in this repo (creates `_index.md` files in docs/ directories)
-- [ ] Commit: `feat: add reindex.py — create _index.md files and update areas table (#266)`
+- [x] Create `plugins/wiki/scripts/reindex.py` (scope limited to AGENTS.md areas table; docs/ fallback on first run). <!-- sha:e86f9f2 -->
+- [x] `reindex.py` does NOT index dirs outside the areas table; wiki/_index.md untouched. <!-- sha:e86f9f2 -->
+- [x] Create `test_reindex.py` (11 tests). <!-- sha:e86f9f2 -->
+- [x] Verify: `python -m pytest plugins/wiki/tests/test_reindex.py -v` — 11 passed. <!-- sha:e86f9f2 -->
+- [x] Verify: `python3 plugins/wiki/scripts/reindex.py --root .` indexes only 4 registered areas. <!-- sha:e86f9f2 -->
+- [x] Commit: `feat: add reindex.py — create _index.md for WOS-registered areas only (#266)` <!-- sha:e86f9f2 -->
 
 ---
 

--- a/docs/plans/2026-04-15-wiki-plugin-bugfix-batch.plan.md
+++ b/docs/plans/2026-04-15-wiki-plugin-bugfix-batch.plan.md
@@ -1,0 +1,213 @@
+---
+name: Wiki Plugin Bugfix Batch
+description: Fix 6 bugs in the wiki plugin covering broken scripts, missing wiki init, stale skill text, and silent data loss
+type: plan
+status: executing
+branch: fix/wiki-plugin-bugfix-batch
+related:
+  - docs/designs/2026-04-15-wiki-plugin-bugfix-batch.design.md
+---
+
+# Wiki Plugin Bugfix Batch
+
+## Goal
+
+Fix 6 bugs filed as issues #265–#270, all in the wiki plugin. The fixes restore correct behavior for `wiki:setup`, `wiki:ingest`, and the scripts backing them. Users following skill instructions verbatim should reach working state on a fresh project after these changes.
+
+## Scope
+
+Must have:
+- Fix `/wos:setup` typo in ingest SKILL.md (#265)
+- Create `scripts/reindex.py`; update SKILL.md refs from nonexistent `reindex.py` (#266)
+- Fix `_bootstrap.py` to add `src/` to sys.path; update skill text to say `python3` (#267)
+- Add wiki infrastructure creation step to setup SKILL.md (#268)
+- Add `extract_areas` to `agents_md.py`; make `areas` optional in `update_agents_md`; remove `discover_areas` from `update_preferences.py` (#269)
+- Improve uncommitted-changes guard in setup SKILL.md (#270)
+- All existing tests pass; new tests for `extract_areas`, `update_agents_md(areas=None)`, `reindex.py`
+
+Won't have:
+- `wiki/_index.md` regeneration during reindex (wiki page inventory is managed by ingest, not reindex)
+- Changes to `lint`, `research`, or any other skills
+- Changing AGENTS.md format or WOS section structure
+- Preserving human edits to `_index.md` files across reindex runs (first write wins)
+
+## Approach
+
+Six issues split across two tracks. Track 1 (task 1): skill text fixes to SKILL.md files only — typo, wiki init step, guard language, python3 refs. Track 2 (tasks 2–5): Python code fixes with tests. Task 6 closes the loop by updating SKILL.md references to the newly-created `reindex.py`. Tasks are ordered so code changes land before the skill text that references them: `extract_areas` added before `update_preferences.py` is changed to rely on it; `reindex.py` created before SKILL.md references it.
+
+## File Changes
+
+- Create: `plugins/wiki/scripts/reindex.py`
+- Create: `plugins/wiki/tests/test_reindex.py`
+- Create: `docs/designs/2026-04-15-wiki-plugin-bugfix-batch.design.md` (done)
+- Modify: `plugins/wiki/scripts/_bootstrap.py` (add `src/` to sys.path)
+- Modify: `plugins/wiki/scripts/update_preferences.py` (remove `discover_areas` call)
+- Modify: `plugins/wiki/src/wiki/agents_md.py` (add `extract_areas`; make `areas` optional)
+- Modify: `plugins/wiki/skills/setup/SKILL.md` (step 2.8, step 3 ref, guard #1, python3)
+- Modify: `plugins/wiki/skills/ingest/SKILL.md` (typo fix, post-ingest reindex ref, python3)
+- Modify: `plugins/wiki/tests/test_agents_md.py` (add extract_areas tests, areas=None tests)
+- Modify: `plugins/wiki/tests/test_update_preferences.py` (update test_preserves_areas)
+
+**Branch:** `fix/wiki-plugin-bugfix-batch`
+**PR:** TBD
+
+## Tasks
+
+---
+
+### Chunk 1: Skill Text Fixes
+
+### Task 1: Fix SKILL.md text issues (#265, #268, #270, #267 python3)
+
+Fix all issues that require only SKILL.md changes. No code changes in this task.
+
+**Files:**
+- Modify: `plugins/wiki/skills/ingest/SKILL.md`
+- Modify: `plugins/wiki/skills/setup/SKILL.md`
+
+- [ ] In `skills/ingest/SKILL.md` Pre-Ingest section, change `/wos:setup` → `/wiki:setup` (line 35).
+- [ ] In `skills/ingest/SKILL.md` Post-Ingest section, change `python` → `python3` for both script calls.
+- [ ] In `skills/setup/SKILL.md` step 5, change `python` → `python3` for the `update_preferences.py` call.
+- [ ] In `skills/setup/SKILL.md`, add step **2.8 — Initialize wiki infrastructure** between step 2 and step 3:
+  - Create `wiki/` directory if it does not exist
+  - Create `wiki/SCHEMA.md` from `references/wiki-schema-template.md` if it does not exist
+  - Create `wiki/_index.md` with an empty page inventory (header line `# Wiki Index` + empty table with `| Page | Description | File |` columns) if it does not exist
+  - Idempotent: skip any file that already exists; do not overwrite
+- [ ] In `skills/setup/SKILL.md`, update anti-pattern guard #1:
+  - Scope check to **tracked modified files only**: check `git diff --name-only HEAD` (not untracked files)
+  - Untracked-only state: advisory note, not a blocking gate
+  - When tracked modifications exist: suggest `git stash` as remediation; explain that setup writes AGENTS.md and CLAUDE.md, making the diff ambiguous and recovery harder if setup fails partway
+- [ ] Verify: `grep -n "wos:setup" plugins/wiki/skills/ingest/SKILL.md` → no matches
+- [ ] Verify: `grep -n "python " plugins/wiki/skills/setup/SKILL.md plugins/wiki/skills/ingest/SKILL.md` → no bare `python ` (only `python3`)
+- [ ] Verify: `grep -n "2.8" plugins/wiki/skills/setup/SKILL.md` → wiki init step present
+- [ ] Verify: `grep -n "git stash" plugins/wiki/skills/setup/SKILL.md` → remediation hint present
+- [ ] Commit: `fix: skill text fixes — typo, wiki init step, guard improvement, python3 refs (#265 #268 #270 #267)`
+
+---
+
+### Chunk 2: Code Fixes
+
+### Task 2: Fix _bootstrap.py sys.path (#267)
+
+`_bootstrap.py` inserts `plugin_root` (`plugins/wiki/`) into sys.path, but the `wiki` package lives at `plugins/wiki/src/wiki/`. Scripts fail with `ModuleNotFoundError` unless an editable install is active.
+
+**Files:**
+- Modify: `plugins/wiki/scripts/_bootstrap.py`
+
+- [ ] After inserting `plugin_root` into sys.path, also insert `plugin_root / "src"` if it is a directory and not already in sys.path. Insert at position 0 (highest priority).
+- [ ] Verify: `cd plugins/wiki && python3 scripts/check_url.py --help` succeeds without `ModuleNotFoundError` (no editable install required — run in a fresh venv or after uninstalling the package)
+- [ ] Verify: `python -m pytest plugins/wiki/tests/test_script_syspath.py -v` passes
+- [ ] Commit: `fix: _bootstrap.py — add src/ to sys.path so scripts work without editable install (#267)`
+
+---
+
+### Task 3: Add extract_areas and make areas optional in agents_md.py (#269)
+
+Add `extract_areas` function and make `areas` optional in `update_agents_md`. When `areas=None`, the function preserves existing table content by calling `extract_areas` internally.
+
+**Files:**
+- Modify: `plugins/wiki/src/wiki/agents_md.py`
+- Modify: `plugins/wiki/tests/test_agents_md.py`
+
+**Depends on:** Task 2 (clean sys.path for test runner)
+
+- [ ] Add `extract_areas(content: str) -> List[Dict[str, str]]` to `agents_md.py`:
+  - Finds the `### Areas` table between WOS markers
+  - Skips the header row (`| Area | Path |`) and separator row (`|------|------|`)
+  - Parses each data row into `{"name": col1.strip(), "path": col2.strip()}`
+  - Returns empty list if no markers or no Areas table found
+- [ ] Change `areas` parameter in `update_agents_md` from `List[Dict[str, str]]` to `Optional[List[Dict[str, str]]]` with default `None`. When `None`, call `extract_areas(content)` to get existing areas.
+- [ ] Add tests in `test_agents_md.py`:
+  - `extract_areas` round-trip: render a WOS section with areas, extract them back, assert same name/path values
+  - `extract_areas` with human-written descriptions: areas table with description text in col1 (not path), verify they parse correctly
+  - `extract_areas` returns empty list when no markers
+  - `extract_areas` returns empty list when no Areas table
+  - `update_agents_md(content, areas=None)` preserves existing area descriptions without modification
+  - `update_agents_md(content, areas=None)` on content with no Areas table produces no Areas section
+- [ ] Verify: `python -m pytest plugins/wiki/tests/test_agents_md.py -v` — all pass including new tests
+- [ ] Commit: `feat: agents_md — add extract_areas, make areas optional in update_agents_md (#269)`
+
+---
+
+### Task 4: Fix update_preferences.py (#269)
+
+Remove `discover_areas` call. After Task 3, passing `areas=None` preserves existing table content — no `discover_areas` side-effect.
+
+**Files:**
+- Modify: `plugins/wiki/scripts/update_preferences.py`
+- Modify: `plugins/wiki/tests/test_update_preferences.py`
+
+**Depends on:** Task 3
+
+- [ ] In `update_preferences.py`: remove `from wiki.agents_md import discover_areas` (keep `render_preferences` and `update_agents_md`). Remove the `areas = discover_areas(root)` call. Call `update_agents_md(content, preferences=rendered)` with no `areas` argument.
+- [ ] Update `test_update_preferences.py::TestUpdatePreferencesWritesAgentsMd::test_preserves_areas`:
+  - Setup: write an AGENTS.md that already has an Areas table with a human-written description (e.g., `| How agents plan tasks | docs/context/planning |`)
+  - Run `update_preferences.py --root . directness=blunt`
+  - Assert: the human-written description is still present; no new areas were added from disk
+  - Also add negative assertion: a directory that exists on disk but is NOT in the existing AGENTS.md areas table should NOT appear after running `update_preferences.py`
+- [ ] Verify: `python -m pytest plugins/wiki/tests/test_update_preferences.py -v` — all pass
+- [ ] Verify: `python -m pytest plugins/wiki/tests/ -v` — full suite passes
+- [ ] Commit: `fix: update_preferences.py — remove discover_areas side-effect, preserve existing areas (#269)`
+
+---
+
+### Task 5: Create reindex.py (#266)
+
+Create a standalone script that creates `_index.md` files in all directories containing `.md` files, and updates the AGENTS.md areas table using `extract_areas` to preserve existing descriptions.
+
+**Files:**
+- Create: `plugins/wiki/scripts/reindex.py`
+- Create: `plugins/wiki/tests/test_reindex.py`
+
+**Depends on:** Task 3 (needs `extract_areas` and `update_agents_md(areas=...)`)
+
+- [ ] Create `plugins/wiki/scripts/reindex.py` with the following behavior:
+  - `--root` argument (default: `.`)
+  - Call `discover_areas(root)` to find all directories with `.md` files
+  - For each area directory, read each `.md` file (excluding `_index.md`) and extract `name` and `description` from frontmatter using a minimal stdlib frontmatter reader (can reuse `parse_frontmatter` from `wiki.document` or implement inline)
+  - Write `<dir>/_index.md`: heading `# <relative-path>`, then `| File | Description |` table with rows sorted by filename; `name` field from frontmatter as link text, `description` as description; fallback to stem if no `name` field
+  - If `AGENTS.md` exists at root, read it, call `extract_areas` to get existing descriptions, merge with discovered areas (prefer existing description when path matches), call `update_agents_md(content, areas=merged)`, write updated file
+  - Print summary: N directories indexed, AGENTS.md updated (or skipped)
+- [ ] `reindex.py` must NOT touch `wiki/_index.md` — that file is managed by ingest, not reindex
+- [ ] Create `test_reindex.py`:
+  - Creates `_index.md` in a directory with `.md` files
+  - `_index.md` content is a valid markdown table with file names and descriptions from frontmatter
+  - Directories with no `.md` files (other than `_index.md`) do not get `_index.md` created
+  - `wiki/` directory is not indexed (or if `wiki/` has non-index docs, its `_index.md` is created but `wiki/_index.md` as page inventory is a separate concern — verify this doesn't conflict)
+  - Existing area descriptions in AGENTS.md are preserved after reindex
+  - New areas discovered on disk but not in AGENTS.md get path as fallback description
+- [ ] Verify: `python -m pytest plugins/wiki/tests/test_reindex.py -v` — all pass
+- [ ] Verify: `python3 plugins/wiki/scripts/reindex.py --root .` runs without error in this repo (creates `_index.md` files in docs/ directories)
+- [ ] Commit: `feat: add reindex.py — create _index.md files and update areas table (#266)`
+
+---
+
+### Task 6: Update SKILL.md references to reindex.py (#266)
+
+Update setup and ingest skills to call the now-existing `reindex.py`.
+
+**Files:**
+- Modify: `plugins/wiki/skills/setup/SKILL.md`
+- Modify: `plugins/wiki/skills/ingest/SKILL.md`
+
+**Depends on:** Task 5 (reindex.py must exist before SKILL.md references it)
+
+- [ ] In `skills/setup/SKILL.md` step 3, replace the `reindex.py` description with the correct invocation: `python3 <plugin-scripts-dir>/reindex.py --root <project-root>`. Update the description to reflect what the script actually does (creates `_index.md` files in directories with managed documents; updates AGENTS.md areas table).
+- [ ] In `skills/ingest/SKILL.md` Post-Ingest section, replace the `reindex.py` call with: `python3 <plugin-scripts-dir>/reindex.py --root <project-root>`.
+- [ ] Verify: `grep -n "reindex.py" plugins/wiki/skills/setup/SKILL.md plugins/wiki/skills/ingest/SKILL.md` → both reference it correctly
+- [ ] Verify: `python -m pytest plugins/wiki/tests/ -v` — full suite still passes (no regressions)
+- [ ] Commit: `fix: update SKILL.md refs to use reindex.py now that script exists (#266)`
+
+---
+
+## Validation
+
+- [ ] `python -m pytest plugins/wiki/tests/ -v` — all tests pass, including new ones for `extract_areas`, `update_agents_md(areas=None)`, and `reindex.py`
+- [ ] `python3 plugins/wiki/scripts/update_preferences.py --root . directness=blunt` (run in this repo) — `AGENTS.md` Preferences section updated; Areas table unchanged (verify with `git diff`)
+- [ ] `python3 plugins/wiki/scripts/reindex.py --root .` (run in this repo) — `_index.md` files created in `docs/context/`, `docs/plans/`, etc.; AGENTS.md updated; `wiki/_index.md` not created or touched
+- [ ] `grep "wos:setup" plugins/wiki/skills/ingest/SKILL.md` → no output
+- [ ] `grep "git stash" plugins/wiki/skills/setup/SKILL.md` → line present
+- [ ] `grep "2.8" plugins/wiki/skills/setup/SKILL.md` → wiki init step present
+
+## Notes
+<!-- Decisions made during execution, scope adjustments, lessons learned -->

--- a/docs/plans/2026-04-15-wiki-plugin-bugfix-batch.plan.md
+++ b/docs/plans/2026-04-15-wiki-plugin-bugfix-batch.plan.md
@@ -2,7 +2,7 @@
 name: Wiki Plugin Bugfix Batch
 description: Fix 6 bugs in the wiki plugin covering broken scripts, missing wiki init, stale skill text, and silent data loss
 type: plan
-status: executing
+status: completed
 branch: fix/wiki-plugin-bugfix-batch
 related:
   - docs/designs/2026-04-15-wiki-plugin-bugfix-batch.design.md
@@ -159,22 +159,22 @@ Update setup and ingest skills to call the now-existing `reindex.py`.
 
 **Depends on:** Task 5 (reindex.py must exist before SKILL.md references it)
 
-- [ ] In `skills/setup/SKILL.md` step 3, replace the `reindex.py` description with the correct invocation: `python3 <plugin-scripts-dir>/reindex.py --root <project-root>`. Update the description to reflect what the script actually does (creates `_index.md` files in directories with managed documents; updates AGENTS.md areas table).
-- [ ] In `skills/ingest/SKILL.md` Post-Ingest section, replace the `reindex.py` call with: `python3 <plugin-scripts-dir>/reindex.py --root <project-root>`.
-- [ ] Verify: `grep -n "reindex.py" plugins/wiki/skills/setup/SKILL.md plugins/wiki/skills/ingest/SKILL.md` → both reference it correctly
-- [ ] Verify: `python -m pytest plugins/wiki/tests/ -v` — full suite still passes (no regressions)
-- [ ] Commit: `fix: update SKILL.md refs to use reindex.py now that script exists (#266)`
+- [x] Update setup/SKILL.md step 3 description to reflect scoped behavior. <!-- sha:292f820 -->
+- [x] Update ingest/SKILL.md post-ingest confirmation message. <!-- sha:292f820 -->
+- [x] Verify: both SKILL.md files reference reindex.py correctly. <!-- sha:292f820 -->
+- [x] Verify: 244 tests pass (no regressions). <!-- sha:292f820 -->
+- [x] Commit: `fix: update SKILL.md refs to use reindex.py now that script exists (#266)` <!-- sha:292f820 -->
 
 ---
 
 ## Validation
 
-- [ ] `python -m pytest plugins/wiki/tests/ -v` — all tests pass, including new ones for `extract_areas`, `update_agents_md(areas=None)`, and `reindex.py`
-- [ ] `python3 plugins/wiki/scripts/update_preferences.py --root . directness=blunt` (run in this repo) — `AGENTS.md` Preferences section updated; Areas table unchanged (verify with `git diff`)
-- [ ] `python3 plugins/wiki/scripts/reindex.py --root .` (run in this repo) — `_index.md` files created in `docs/context/`, `docs/plans/`, etc.; AGENTS.md updated; `wiki/_index.md` not created or touched
-- [ ] `grep "wos:setup" plugins/wiki/skills/ingest/SKILL.md` → no output
-- [ ] `grep "git stash" plugins/wiki/skills/setup/SKILL.md` → line present
-- [ ] `grep "2.8" plugins/wiki/skills/setup/SKILL.md` → wiki init step present
+- [x] `python -m pytest plugins/wiki/tests/ -v` — 244 passed (pre-existing lint/syspath failures about missing `check` plugin unchanged). <!-- sha:292f820 -->
+- [x] `python3 plugins/wiki/scripts/update_preferences.py --root . directness=blunt` — Preferences updated; Areas table unchanged. <!-- sha:1ee957d -->
+- [x] `python3 plugins/wiki/scripts/reindex.py --root .` — indexes only 4 registered WOS areas; plugin/test dirs untouched. <!-- sha:e86f9f2 -->
+- [x] `grep "wos:setup" plugins/wiki/skills/ingest/SKILL.md` → no output. <!-- sha:819d8eb -->
+- [x] `grep "git stash" plugins/wiki/skills/setup/SKILL.md` → line present. <!-- sha:819d8eb -->
+- [x] `grep "2.8" plugins/wiki/skills/setup/SKILL.md` → wiki init step present. <!-- sha:819d8eb -->
 
 ## Notes
 <!-- Decisions made during execution, scope adjustments, lessons learned -->

--- a/plugins/wiki/scripts/_bootstrap.py
+++ b/plugins/wiki/scripts/_bootstrap.py
@@ -26,3 +26,6 @@ plugin_root: Path = (
 )
 if str(plugin_root) not in sys.path:
     sys.path.insert(0, str(plugin_root))
+_src = plugin_root / "src"
+if _src.is_dir() and str(_src) not in sys.path:
+    sys.path.insert(0, str(_src))

--- a/plugins/wiki/scripts/reindex.py
+++ b/plugins/wiki/scripts/reindex.py
@@ -3,11 +3,14 @@
 # requires-python = ">=3.9"
 # dependencies = []
 # ///
-"""Create _index.md files in directories containing managed documents.
+"""Create _index.md files for WOS-managed areas.
 
-For each directory that contains .md files (excluding _index.md itself),
-writes a <dir>/_index.md with a table of files and their descriptions.
-Also updates the AGENTS.md areas table, preserving existing descriptions.
+Reads directories from the AGENTS.md areas table and creates a
+<dir>/_index.md listing all managed documents with their descriptions.
+Also refreshes the AGENTS.md areas table, preserving existing descriptions.
+
+First-run fallback: if AGENTS.md has no areas table, scans the docs/
+subtree to discover directories.
 
 Usage:
     python3 scripts/reindex.py --root .
@@ -42,7 +45,6 @@ def _read_frontmatter_field(path: Path, field: str) -> str:
     for line in fm.splitlines():
         if line.startswith(f"{field}:"):
             value = line[len(field) + 1:].strip()
-            # Strip optional inline quotes
             if len(value) >= 2 and value[0] in ('"', "'") and value[-1] == value[0]:
                 value = value[1:-1]
             return value
@@ -73,14 +75,16 @@ def _write_index(directory: Path, root: Path) -> None:
         desc = _read_frontmatter_field(f, "description") or ""
         lines.append(f"| [{f.name}]({f.name}) | {desc} |")
 
-    index_path = directory / "_index.md"
-    index_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    (directory / "_index.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
-def discover_dirs(root: Path) -> list[Path]:
-    """Return directories under root that contain non-index .md files."""
+def _scan_docs_subtree(root: Path) -> list[Path]:
+    """Fallback: scan docs/ for directories that contain .md files."""
+    docs_root = root / "docs"
+    if not docs_root.is_dir():
+        return []
     dirs: list[Path] = []
-    for dirpath, dirnames, filenames in os.walk(root):
+    for dirpath, dirnames, filenames in os.walk(docs_root):
         dirnames[:] = sorted(
             d for d in dirnames
             if not d.startswith(".") and d not in _SKIP
@@ -92,7 +96,10 @@ def discover_dirs(root: Path) -> list[Path]:
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Create _index.md files and update AGENTS.md areas table.",
+        description=(
+            "Create _index.md files for WOS-managed areas and refresh "
+            "the AGENTS.md areas table."
+        ),
     )
     parser.add_argument(
         "--root",
@@ -101,32 +108,56 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    from wiki.agents_md import discover_areas, extract_areas, update_agents_md
+    from wiki.agents_md import extract_areas, update_agents_md
 
     root = Path(args.root).resolve()
+    agents_path = root / "AGENTS.md"
 
-    # Create _index.md files in every directory with managed docs
-    dirs = discover_dirs(root)
+    # Read existing areas (descriptions) from AGENTS.md
+    existing_desc: dict[str, str] = {}
+    agents_content: str = ""
+    if agents_path.is_file():
+        agents_content = agents_path.read_text(encoding="utf-8")
+        for area in extract_areas(agents_content):
+            existing_desc[area["path"]] = area["name"]
+
+    # Determine which directories to index
+    if existing_desc:
+        # Option B: only index directories already registered as WOS areas
+        dirs = [
+            root / rel for rel in existing_desc
+            if (root / rel).is_dir()
+        ]
+    else:
+        # First-run fallback: scan docs/ subtree
+        dirs = _scan_docs_subtree(root)
+        if not dirs:
+            print("No areas in AGENTS.md and no docs/ directory — nothing to reindex")
+            return
+
+    # Create _index.md for each area directory
     for d in dirs:
         _write_index(d, root)
 
-    # Update AGENTS.md areas table, preserving existing human descriptions
-    agents_path = root / "AGENTS.md"
+    # Refresh AGENTS.md areas table (preserving human descriptions)
     if agents_path.is_file():
-        content = agents_path.read_text(encoding="utf-8")
-        existing = {a["path"]: a["name"] for a in extract_areas(content)}
-        discovered = discover_areas(root)
-        # Prefer existing description; fall back to path for new areas
-        for area in discovered:
-            if area["path"] in existing:
-                area["name"] = existing[area["path"]]
-        updated = update_agents_md(content, areas=discovered)
+        refreshed: list[dict[str, str]] = []
+        for d in dirs:
+            try:
+                rel = str(d.relative_to(root))
+            except ValueError:
+                continue
+            name = existing_desc.get(rel, rel)
+            refreshed.append({"name": name, "path": rel})
+
+        updated = update_agents_md(agents_content, areas=refreshed)
         agents_path.write_text(updated, encoding="utf-8")
-        print(f"Updated {len(discovered)} area(s) in {agents_path}")
+        print(f"Updated {len(refreshed)} area(s) in {agents_path}")
     else:
         print(f"AGENTS.md not found at {agents_path} — skipping areas update")
 
-    print(f"Reindexed {len(dirs)} director{'y' if len(dirs) == 1 else 'ies'}")
+    n = len(dirs)
+    print(f"Reindexed {n} director{'y' if n == 1 else 'ies'}")
 
 
 if __name__ == "__main__":

--- a/plugins/wiki/scripts/reindex.py
+++ b/plugins/wiki/scripts/reindex.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.9"
+# dependencies = []
+# ///
+"""Create _index.md files in directories containing managed documents.
+
+For each directory that contains .md files (excluding _index.md itself),
+writes a <dir>/_index.md with a table of files and their descriptions.
+Also updates the AGENTS.md areas table, preserving existing descriptions.
+
+Usage:
+    python3 scripts/reindex.py --root .
+"""
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+import _bootstrap  # noqa: F401 — side effect: adds src/ to sys.path  # isort: skip
+
+
+_SKIP = frozenset({
+    "node_modules", "__pycache__", "venv", ".venv",
+    "dist", "build", ".tox", ".mypy_cache", ".pytest_cache",
+})
+
+
+def _read_frontmatter_field(path: Path, field: str) -> str:
+    """Read a single scalar field from YAML frontmatter (stdlib-only)."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return ""
+    if not text.startswith("---"):
+        return ""
+    end = text.find("---", 3)
+    if end == -1:
+        return ""
+    fm = text[3:end]
+    for line in fm.splitlines():
+        if line.startswith(f"{field}:"):
+            value = line[len(field) + 1:].strip()
+            # Strip optional inline quotes
+            if len(value) >= 2 and value[0] in ('"', "'") and value[-1] == value[0]:
+                value = value[1:-1]
+            return value
+    return ""
+
+
+def _write_index(directory: Path, root: Path) -> None:
+    """Write <directory>/_index.md listing all .md files with descriptions."""
+    md_files = sorted(
+        f for f in directory.iterdir()
+        if f.is_file() and f.suffix == ".md" and f.name != "_index.md"
+    )
+    if not md_files:
+        return
+
+    try:
+        rel_dir = str(directory.relative_to(root))
+    except ValueError:
+        rel_dir = str(directory)
+
+    lines = [
+        f"# {rel_dir}",
+        "",
+        "| File | Description |",
+        "|------|-------------|",
+    ]
+    for f in md_files:
+        desc = _read_frontmatter_field(f, "description") or ""
+        lines.append(f"| [{f.name}]({f.name}) | {desc} |")
+
+    index_path = directory / "_index.md"
+    index_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def discover_dirs(root: Path) -> list[Path]:
+    """Return directories under root that contain non-index .md files."""
+    dirs: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = sorted(
+            d for d in dirnames
+            if not d.startswith(".") and d not in _SKIP
+        )
+        if any(f.endswith(".md") and f != "_index.md" for f in filenames):
+            dirs.append(Path(dirpath))
+    return dirs
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Create _index.md files and update AGENTS.md areas table.",
+    )
+    parser.add_argument(
+        "--root",
+        default=".",
+        help="Project root directory (default: current directory)",
+    )
+    args = parser.parse_args()
+
+    from wiki.agents_md import discover_areas, extract_areas, update_agents_md
+
+    root = Path(args.root).resolve()
+
+    # Create _index.md files in every directory with managed docs
+    dirs = discover_dirs(root)
+    for d in dirs:
+        _write_index(d, root)
+
+    # Update AGENTS.md areas table, preserving existing human descriptions
+    agents_path = root / "AGENTS.md"
+    if agents_path.is_file():
+        content = agents_path.read_text(encoding="utf-8")
+        existing = {a["path"]: a["name"] for a in extract_areas(content)}
+        discovered = discover_areas(root)
+        # Prefer existing description; fall back to path for new areas
+        for area in discovered:
+            if area["path"] in existing:
+                area["name"] = existing[area["path"]]
+        updated = update_agents_md(content, areas=discovered)
+        agents_path.write_text(updated, encoding="utf-8")
+        print(f"Updated {len(discovered)} area(s) in {agents_path}")
+    else:
+        print(f"AGENTS.md not found at {agents_path} — skipping areas update")
+
+    print(f"Reindexed {len(dirs)} director{'y' if len(dirs) == 1 else 'ies'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/wiki/scripts/update_preferences.py
+++ b/plugins/wiki/scripts/update_preferences.py
@@ -36,7 +36,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    from wiki.agents_md import discover_areas, render_preferences, update_agents_md
+    from wiki.agents_md import render_preferences, update_agents_md
 
     root = Path(args.root).resolve()
 
@@ -48,7 +48,6 @@ def main() -> None:
         prefs[key] = value
 
     rendered = render_preferences(prefs)
-    areas = discover_areas(root)
 
     agents_path = root / "AGENTS.md"
     if agents_path.is_file():
@@ -56,7 +55,8 @@ def main() -> None:
     else:
         content = "# AGENTS.md\n"
 
-    updated = update_agents_md(content, areas, preferences=rendered)
+    # areas=None — preserve existing areas table instead of regenerating from disk
+    updated = update_agents_md(content, preferences=rendered)
     agents_path.write_text(updated, encoding="utf-8")
     print(f"Updated preferences in {agents_path}")
 

--- a/plugins/wiki/skills/ingest/SKILL.md
+++ b/plugins/wiki/skills/ingest/SKILL.md
@@ -32,7 +32,7 @@ Before editing any files, read the project's wiki context:
 1. **Read `wiki/_index.md`** — understand the existing page inventory (titles, descriptions, file paths)
 2. **Read `wiki/SCHEMA.md`** — learn the valid `type` values, `confidence` tiers, and relationship types for this project
 
-If either file is missing, stop and report: "wiki/_index.md not found" or "wiki/SCHEMA.md not found. Run `/wos:setup` to initialize wiki infrastructure."
+If either file is missing, stop and report: "wiki/_index.md not found" or "wiki/SCHEMA.md not found. Run `/wiki:setup` to initialize wiki infrastructure."
 
 ## Ingest Protocol
 
@@ -102,8 +102,8 @@ Existing prose in wiki pages is never removed or overwritten. Every `git diff` a
 After all page updates and creations, run both commands unconditionally:
 
 ```bash
-python <plugin-scripts-dir>/lint.py --root <project-root> --no-urls
-python <plugin-scripts-dir>/reindex.py --root <project-root>
+python3 <plugin-scripts-dir>/lint.py --root <project-root> --no-urls
+python3 <plugin-scripts-dir>/reindex.py --root <project-root>
 ```
 
 Report results to the user:

--- a/plugins/wiki/skills/ingest/SKILL.md
+++ b/plugins/wiki/skills/ingest/SKILL.md
@@ -108,7 +108,7 @@ python3 <plugin-scripts-dir>/reindex.py --root <project-root>
 
 Report results to the user:
 - If lint produces new issues, list them with severity
-- Confirm that `wiki/_index.md` was regenerated
+- Confirm that area `_index.md` files were refreshed
 
 Do not block on lint issues — report and continue.
 

--- a/plugins/wiki/skills/setup/SKILL.md
+++ b/plugins/wiki/skills/setup/SKILL.md
@@ -114,9 +114,26 @@ Based on the response, suggest a concrete WOS skill sequence:
 
 If the user declines or skips, move on without suggesting.
 
+### 2.8. Initialize wiki infrastructure
+
+Create the wiki directory and required seed files if they do not exist:
+
+1. Create the `wiki/` directory if missing.
+2. Create `wiki/SCHEMA.md` from `references/wiki-schema-template.md` if missing.
+3. Create `wiki/_index.md` with an empty page inventory if missing:
+
+```markdown
+# Wiki Index
+
+| Page | Description | File |
+|------|-------------|------|
+```
+
+Idempotent — skip any file that already exists. Never overwrite existing content.
+
 ### 3. Reindex
 
-Run: `python <plugin-scripts-dir>/reindex.py --root .`
+Run: `python3 <plugin-scripts-dir>/reindex.py --root .`
 
 This creates `_index.md` files in directories with managed documents and
 updates the AGENTS.md areas table if AGENTS.md exists.
@@ -150,7 +167,7 @@ Run the full capture workflow in `references/capture-workflow.md`:
 1. Ask the freeform communication style question
 2. Map response to dimensions
 3. Confirm with user
-4. Write to AGENTS.md via `python <plugin-scripts-dir>/update_preferences.py --root .`
+4. Write to AGENTS.md via `python3 <plugin-scripts-dir>/update_preferences.py --root .`
 
 **If preferences already exist:**
 
@@ -191,7 +208,7 @@ If everything was already set up, confirm: "WOS is up to date. No changes needed
 
 ## Anti-Pattern Guards
 
-1. **Running setup with uncommitted changes in the repo** — setup writes AGENTS.md and CLAUDE.md. If the working tree has uncommitted changes, the pre-setup state is ambiguous and harder to recover from if something goes wrong. Check for a clean working tree before proceeding; ask the user if changes are present.
+1. **Running setup with uncommitted changes in the repo** — setup writes AGENTS.md and CLAUDE.md. Check for tracked modified files (`git diff --name-only HEAD`) before proceeding. Untracked-only changes are advisory — note them but do not block. If tracked modifications exist, warn the user: setup writes to AGENTS.md and CLAUDE.md, making the diff ambiguous and recovery harder if setup fails partway. Suggest `git stash` as remediation and wait for the user to decide whether to stash, continue anyway, or abort.
 2. **Silent layout selection** — if no layout hint exists, always present the four layout options and wait for explicit selection. Applying a default layout without asking embeds a structural decision that is costly to reverse once docs have been created.
 3. **Overwriting content outside WOS markers** — only the section between `<!-- wos:begin -->` and `<!-- wos:end -->` markers is WOS-managed. Content written by the user outside these markers must not be touched. A full AGENTS.md rewrite is always wrong.
 4. **Skipping the current-state check** — setup is idempotent, but it must check what already exists before writing. Presenting layout options when a layout hint already exists confuses the user; showing the current layout and asking if it should change is the correct flow.

--- a/plugins/wiki/skills/setup/SKILL.md
+++ b/plugins/wiki/skills/setup/SKILL.md
@@ -135,8 +135,10 @@ Idempotent — skip any file that already exists. Never overwrite existing conte
 
 Run: `python3 <plugin-scripts-dir>/reindex.py --root .`
 
-This creates `_index.md` files in directories with managed documents and
-updates the AGENTS.md areas table if AGENTS.md exists.
+Creates `_index.md` files in each directory registered in the AGENTS.md
+areas table. On first run (no areas registered yet), scans the `docs/`
+subtree as a fallback. Also refreshes the AGENTS.md areas table,
+preserving any human-written area descriptions.
 
 ### 4. Update AGENTS.md
 

--- a/plugins/wiki/src/wiki/agents_md.py
+++ b/plugins/wiki/src/wiki/agents_md.py
@@ -379,12 +379,57 @@ def extract_preferences(content: str) -> List[str]:
     return prefs
 
 
+# ── Extract areas ────────────────────────────────────────────────
+
+
+def extract_areas(content: str) -> List[Dict[str, str]]:
+    """Extract area entries from an AGENTS.md WOS section.
+
+    Parses the ``### Areas`` table between WOS markers and returns the
+    list of area dicts with 'name' and 'path' keys.  Used to preserve
+    human-written area descriptions when rewriting the WOS section.
+
+    Args:
+        content: Full AGENTS.md file content.
+
+    Returns:
+        List of ``{"name": ..., "path": ...}`` dicts, or empty list if
+        no markers or no Areas table is found.
+    """
+    begin_idx = content.find(BEGIN_MARKER)
+    end_idx = content.find(END_MARKER)
+    if begin_idx == -1 or end_idx == -1:
+        return []
+
+    wos_section = content[begin_idx:end_idx]
+    lines = wos_section.split("\n")
+
+    in_areas = False
+    areas: List[Dict[str, str]] = []
+    for line in lines:
+        if line.strip() == "### Areas":
+            in_areas = True
+            continue
+        if in_areas:
+            if line.startswith("### ") or line.startswith("<!--"):
+                break
+            # Skip header and separator rows
+            if line.startswith("| Area") or line.startswith("|---"):
+                continue
+            if line.startswith("| "):
+                parts = [p.strip() for p in line.strip("|").split("|")]
+                if len(parts) >= 2:
+                    areas.append({"name": parts[0], "path": parts[1]})
+
+    return areas
+
+
 # ── Update ───────────────────────────────────────────────────────
 
 
 def update_agents_md(
     content: str,
-    areas: List[Dict[str, str]],
+    areas: Optional[List[Dict[str, str]]] = None,
     preferences: Optional[List[str]] = None,
     layout: Optional[str] = None,
 ) -> str:
@@ -395,16 +440,23 @@ def update_agents_md(
     Content outside markers is never touched.
 
     Preserves existing layout hint if no new layout is specified.
+    When ``areas`` is None, extracts existing areas from the current
+    content so human-written descriptions are not lost.
 
     Args:
         content: The existing AGENTS.md content.
-        areas: List of dicts with 'name' and 'path' keys.
+        areas: List of dicts with 'name' and 'path' keys.  If None,
+            the existing areas table is preserved via ``extract_areas``.
         preferences: Optional list of preference strings.
         layout: Optional layout pattern. If None, preserves existing.
 
     Returns:
         Updated AGENTS.md content with the new WOS section.
     """
+    # Preserve existing areas if not explicitly provided
+    if areas is None:
+        areas = extract_areas(content)
+
     # Preserve existing layout if not explicitly provided
     if layout is None:
         layout = read_layout_hint(content)

--- a/plugins/wiki/tests/test_agents_md.py
+++ b/plugins/wiki/tests/test_agents_md.py
@@ -311,3 +311,91 @@ class TestUpdatePreferencesPreserved:
         assert "- Use examples" in result
 
 
+# ── extract_areas ───────────────────────────────────────────────
+
+
+class TestExtractAreas:
+    def test_round_trip(self) -> None:
+        """Areas rendered then extracted produce identical name/path values."""
+        from wiki.agents_md import extract_areas, render_wos_section
+
+        areas = [
+            {"name": "How agents plan tasks", "path": "docs/context/planning"},
+            {"name": "API reference", "path": "docs/context/api"},
+        ]
+        content = f"# AGENTS.md\n\n{render_wos_section(areas)}"
+        result = extract_areas(content)
+        assert result == areas
+
+    def test_preserves_human_descriptions(self) -> None:
+        """Human-written descriptions (col1 != col2) are preserved as-is."""
+        from wiki.agents_md import BEGIN_MARKER, END_MARKER, extract_areas
+
+        content = (
+            f"{BEGIN_MARKER}\n"
+            "### Areas\n"
+            "| Area | Path |\n"
+            "|------|------|\n"
+            "| How LLM agents decompose tasks into steps | docs/context/planning |\n"
+            "| API endpoint reference | docs/context/api |\n"
+            f"{END_MARKER}\n"
+        )
+        result = extract_areas(content)
+        assert result == [
+            {
+                "name": "How LLM agents decompose tasks into steps",
+                "path": "docs/context/planning",
+            },
+            {"name": "API endpoint reference", "path": "docs/context/api"},
+        ]
+
+    def test_returns_empty_when_no_markers(self) -> None:
+        from wiki.agents_md import extract_areas
+
+        result = extract_areas("# AGENTS.md\n\nNo WOS section here.\n")
+        assert result == []
+
+    def test_returns_empty_when_no_areas_table(self) -> None:
+        from wiki.agents_md import extract_areas, render_wos_section
+
+        content = render_wos_section(areas=[])
+        result = extract_areas(content)
+        assert result == []
+
+
+class TestUpdateAgentsMdAreasNone:
+    def test_preserves_existing_area_descriptions(self) -> None:
+        """When areas=None, existing human-written descriptions survive."""
+        from wiki.agents_md import BEGIN_MARKER, END_MARKER, update_agents_md
+
+        content = (
+            "# AGENTS.md\n\n"
+            f"{BEGIN_MARKER}\n"
+            "### Areas\n"
+            "| Area | Path |\n"
+            "|------|------|\n"
+            "| How LLM agents decompose tasks | docs/context/planning |\n"
+            f"{END_MARKER}\n"
+        )
+        result = update_agents_md(content)  # areas=None by default
+        assert "| How LLM agents decompose tasks | docs/context/planning |" in result
+
+    def test_produces_no_areas_section_when_none_exist(self) -> None:
+        """When areas=None and no Areas table present, output has no Areas table."""
+        from wiki.agents_md import extract_areas, render_wos_section, update_agents_md
+
+        base = render_wos_section(areas=[])
+        content = f"# AGENTS.md\n\n{base}"
+        assert extract_areas(content) == []
+        result = update_agents_md(content)
+        assert "### Areas" not in result
+
+    def test_existing_callers_with_explicit_areas_unaffected(self) -> None:
+        """Passing areas explicitly still works as before."""
+        from wiki.agents_md import update_agents_md
+
+        areas = [{"name": "Backend", "path": "docs/context/backend"}]
+        result = update_agents_md("# AGENTS.md\n", areas=areas)
+        assert "| Backend | docs/context/backend |" in result
+
+

--- a/plugins/wiki/tests/test_reindex.py
+++ b/plugins/wiki/tests/test_reindex.py
@@ -1,0 +1,178 @@
+"""Tests for scripts/reindex.py."""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from wiki.agents_md import BEGIN_MARKER, END_MARKER
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+
+
+def _run(root: Path, *extra: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPTS_DIR / "reindex.py"), "--root", str(root), *extra],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _make_md(path: Path, name: str = "", description: str = "") -> None:
+    fm_lines = ["---", f"name: {name}", f"description: {description}", "---", "Body."]
+    path.write_text("\n".join(fm_lines) + "\n", encoding="utf-8")
+
+
+class TestReindexCreatesIndexFiles:
+    def test_creates_index_for_directory_with_md_files(self, tmp_path: Path) -> None:
+        docs = tmp_path / "docs" / "context"
+        docs.mkdir(parents=True)
+        _make_md(docs / "planning.md", name="Planning", description="How we plan")
+
+        result = _run(tmp_path)
+        assert result.returncode == 0
+
+        index = docs / "_index.md"
+        assert index.exists()
+        content = index.read_text()
+        assert "| [planning.md](planning.md) | How we plan |" in content
+
+    def test_index_header_uses_relative_path(self, tmp_path: Path) -> None:
+        docs = tmp_path / "docs" / "context"
+        docs.mkdir(parents=True)
+        _make_md(docs / "topic.md", name="Topic", description="A topic")
+
+        _run(tmp_path)
+
+        index = docs / "_index.md"
+        content = index.read_text()
+        assert "# docs/context" in content
+
+    def test_index_files_sorted_alphabetically(self, tmp_path: Path) -> None:
+        docs = tmp_path / "docs"
+        docs.mkdir(parents=True)
+        _make_md(docs / "zebra.md", name="Zebra", description="Last")
+        _make_md(docs / "alpha.md", name="Alpha", description="First")
+        _make_md(docs / "middle.md", name="Middle", description="Middle")
+
+        _run(tmp_path)
+
+        content = (docs / "_index.md").read_text()
+        z_pos = content.index("zebra.md")
+        a_pos = content.index("alpha.md")
+        m_pos = content.index("middle.md")
+        assert a_pos < m_pos < z_pos
+
+    def test_no_index_for_directory_without_md_files(self, tmp_path: Path) -> None:
+        empty = tmp_path / "empty_dir"
+        empty.mkdir()
+        (empty / "notes.txt").write_text("not a markdown file")
+
+        _run(tmp_path)
+
+        assert not (empty / "_index.md").exists()
+
+    def test_existing_index_not_counted_as_managed_doc(self, tmp_path: Path) -> None:
+        """A directory with only _index.md should not get a new _index.md."""
+        docs = tmp_path / "docs"
+        docs.mkdir(parents=True)
+        (docs / "_index.md").write_text("# existing index\n")
+        # No other .md files
+
+        _run(tmp_path)
+
+        # _index.md should not have been replaced with a table
+        content = (docs / "_index.md").read_text()
+        assert "# existing index" in content
+        assert "| File | Description |" not in content
+
+
+class TestReindexDoesNotTouchWikiIndex:
+    def test_wiki_index_untouched_when_wiki_has_only_index(
+        self, tmp_path: Path
+    ) -> None:
+        """wiki/_index.md is the page inventory; reindex must not overwrite it."""
+        wiki = tmp_path / "wiki"
+        wiki.mkdir()
+        wiki_index = wiki / "_index.md"
+        wiki_index.write_text("# Wiki Index\n\n| Page | Description | File |\n")
+
+        _run(tmp_path)
+
+        # wiki/_index.md should be unchanged (no other .md in wiki/)
+        expected = "# Wiki Index\n\n| Page | Description | File |\n"
+        assert wiki_index.read_text() == expected
+
+
+class TestReindexUpdatesAgentsMd:
+    def test_updates_areas_table_with_discovered_dirs(self, tmp_path: Path) -> None:
+        docs = tmp_path / "docs" / "context"
+        docs.mkdir(parents=True)
+        _make_md(docs / "topic.md", name="Topic", description="A topic")
+
+        agents = tmp_path / "AGENTS.md"
+        agents.write_text(f"# AGENTS.md\n\n{BEGIN_MARKER}\nold\n{END_MARKER}\n")
+
+        result = _run(tmp_path)
+        assert result.returncode == 0
+
+        content = agents.read_text()
+        assert "docs/context" in content
+
+    def test_preserves_existing_human_descriptions(self, tmp_path: Path) -> None:
+        docs = tmp_path / "docs" / "context"
+        docs.mkdir(parents=True)
+        _make_md(docs / "topic.md", name="Topic", description="A topic")
+
+        human_desc = "How LLM agents plan and execute tasks"
+        agents = tmp_path / "AGENTS.md"
+        agents.write_text(
+            f"# AGENTS.md\n\n"
+            f"{BEGIN_MARKER}\n"
+            f"### Areas\n"
+            f"| Area | Path |\n"
+            f"|------|------|\n"
+            f"| {human_desc} | docs/context |\n"
+            f"{END_MARKER}\n"
+        )
+
+        _run(tmp_path)
+
+        content = agents.read_text()
+        assert human_desc in content
+
+    def test_new_areas_get_path_as_fallback_description(self, tmp_path: Path) -> None:
+        docs = tmp_path / "docs" / "new-area"
+        docs.mkdir(parents=True)
+        _make_md(docs / "topic.md", name="Topic", description="A topic")
+
+        agents = tmp_path / "AGENTS.md"
+        agents.write_text(f"# AGENTS.md\n\n{BEGIN_MARKER}\nold\n{END_MARKER}\n")
+
+        _run(tmp_path)
+
+        content = agents.read_text()
+        # New area falls back to path as description
+        assert "docs/new-area" in content
+
+    def test_skips_agents_update_when_no_agents_md(self, tmp_path: Path) -> None:
+        docs = tmp_path / "docs"
+        docs.mkdir(parents=True)
+        _make_md(docs / "topic.md", name="Topic", description="A topic")
+
+        result = _run(tmp_path)
+        assert result.returncode == 0
+        assert "skipping areas update" in result.stdout
+        assert not (tmp_path / "AGENTS.md").exists()
+
+
+class TestReindexOutput:
+    def test_reports_count_of_indexed_directories(self, tmp_path: Path) -> None:
+        for name in ("alpha", "beta"):
+            d = tmp_path / "docs" / name
+            d.mkdir(parents=True)
+            _make_md(d / "doc.md", name="Doc", description="A doc")
+
+        result = _run(tmp_path)
+        assert result.returncode == 0
+        assert "2 director" in result.stdout  # "directories"

--- a/plugins/wiki/tests/test_reindex.py
+++ b/plugins/wiki/tests/test_reindex.py
@@ -23,11 +23,33 @@ def _make_md(path: Path, name: str = "", description: str = "") -> None:
     path.write_text("\n".join(fm_lines) + "\n", encoding="utf-8")
 
 
-class TestReindexCreatesIndexFiles:
-    def test_creates_index_for_directory_with_md_files(self, tmp_path: Path) -> None:
+def _agents_with_areas(
+    tmp_path: Path, areas: list[tuple[str, str]]
+) -> Path:
+    """Write AGENTS.md with a WOS section listing the given (desc, path) areas."""
+    rows = "\n".join(f"| {desc} | {path} |" for desc, path in areas)
+    content = (
+        f"# AGENTS.md\n\n"
+        f"{BEGIN_MARKER}\n"
+        f"### Areas\n"
+        f"| Area | Path |\n"
+        f"|------|------|\n"
+        f"{rows}\n"
+        f"{END_MARKER}\n"
+    )
+    p = tmp_path / "AGENTS.md"
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+class TestReindexFromAreasTable:
+    """When AGENTS.md has an areas table, only those dirs are indexed."""
+
+    def test_creates_index_for_registered_area(self, tmp_path: Path) -> None:
         docs = tmp_path / "docs" / "context"
         docs.mkdir(parents=True)
         _make_md(docs / "planning.md", name="Planning", description="How we plan")
+        _agents_with_areas(tmp_path, [("How we plan context", "docs/context")])
 
         result = _run(tmp_path)
         assert result.returncode == 0
@@ -37,15 +59,33 @@ class TestReindexCreatesIndexFiles:
         content = index.read_text()
         assert "| [planning.md](planning.md) | How we plan |" in content
 
+    def test_does_not_index_dirs_outside_areas_table(self, tmp_path: Path) -> None:
+        registered = tmp_path / "docs" / "context"
+        registered.mkdir(parents=True)
+        _make_md(registered / "doc.md", name="Doc", description="A doc")
+
+        unregistered = tmp_path / "plugins" / "src"
+        unregistered.mkdir(parents=True)
+        _make_md(unregistered / "skill.md", name="Skill", description="A skill")
+
+        _agents_with_areas(tmp_path, [("Context", "docs/context")])
+
+        _run(tmp_path)
+
+        # Registered area gets an index
+        assert (registered / "_index.md").exists()
+        # Unregistered directory does NOT get an index
+        assert not (unregistered / "_index.md").exists()
+
     def test_index_header_uses_relative_path(self, tmp_path: Path) -> None:
         docs = tmp_path / "docs" / "context"
         docs.mkdir(parents=True)
         _make_md(docs / "topic.md", name="Topic", description="A topic")
+        _agents_with_areas(tmp_path, [("Context", "docs/context")])
 
         _run(tmp_path)
 
-        index = docs / "_index.md"
-        content = index.read_text()
+        content = (docs / "_index.md").read_text()
         assert "# docs/context" in content
 
     def test_index_files_sorted_alphabetically(self, tmp_path: Path) -> None:
@@ -54,6 +94,7 @@ class TestReindexCreatesIndexFiles:
         _make_md(docs / "zebra.md", name="Zebra", description="Last")
         _make_md(docs / "alpha.md", name="Alpha", description="First")
         _make_md(docs / "middle.md", name="Middle", description="Middle")
+        _agents_with_areas(tmp_path, [("Docs", "docs")])
 
         _run(tmp_path)
 
@@ -63,101 +104,88 @@ class TestReindexCreatesIndexFiles:
         m_pos = content.index("middle.md")
         assert a_pos < m_pos < z_pos
 
-    def test_no_index_for_directory_without_md_files(self, tmp_path: Path) -> None:
-        empty = tmp_path / "empty_dir"
-        empty.mkdir()
-        (empty / "notes.txt").write_text("not a markdown file")
-
-        _run(tmp_path)
-
-        assert not (empty / "_index.md").exists()
-
-    def test_existing_index_not_counted_as_managed_doc(self, tmp_path: Path) -> None:
-        """A directory with only _index.md should not get a new _index.md."""
-        docs = tmp_path / "docs"
-        docs.mkdir(parents=True)
-        (docs / "_index.md").write_text("# existing index\n")
-        # No other .md files
-
-        _run(tmp_path)
-
-        # _index.md should not have been replaced with a table
-        content = (docs / "_index.md").read_text()
-        assert "# existing index" in content
-        assert "| File | Description |" not in content
-
-
-class TestReindexDoesNotTouchWikiIndex:
-    def test_wiki_index_untouched_when_wiki_has_only_index(
+    def test_no_index_for_area_dir_with_only_index_file(
         self, tmp_path: Path
     ) -> None:
-        """wiki/_index.md is the page inventory; reindex must not overwrite it."""
-        wiki = tmp_path / "wiki"
-        wiki.mkdir()
-        wiki_index = wiki / "_index.md"
-        wiki_index.write_text("# Wiki Index\n\n| Page | Description | File |\n")
+        """A registered area dir that has only _index.md should not be overwritten."""
+        docs = tmp_path / "docs"
+        docs.mkdir(parents=True)
+        existing = docs / "_index.md"
+        existing.write_text("# hand-written\n")
+        _agents_with_areas(tmp_path, [("Docs", "docs")])
 
         _run(tmp_path)
 
-        # wiki/_index.md should be unchanged (no other .md in wiki/)
-        expected = "# Wiki Index\n\n| Page | Description | File |\n"
-        assert wiki_index.read_text() == expected
+        # No other .md files → _write_index does nothing → hand-written is preserved
+        assert existing.read_text() == "# hand-written\n"
 
 
-class TestReindexUpdatesAgentsMd:
-    def test_updates_areas_table_with_discovered_dirs(self, tmp_path: Path) -> None:
+class TestReindexFirstRunFallback:
+    """When AGENTS.md has no areas, fall back to scanning docs/."""
+
+    def test_scans_docs_subtree_when_no_areas(self, tmp_path: Path) -> None:
         docs = tmp_path / "docs" / "context"
         docs.mkdir(parents=True)
         _make_md(docs / "topic.md", name="Topic", description="A topic")
 
-        agents = tmp_path / "AGENTS.md"
-        agents.write_text(f"# AGENTS.md\n\n{BEGIN_MARKER}\nold\n{END_MARKER}\n")
+        # AGENTS.md exists but has no areas table
+        (tmp_path / "AGENTS.md").write_text(
+            f"# AGENTS.md\n\n{BEGIN_MARKER}\nno areas here\n{END_MARKER}\n"
+        )
 
         result = _run(tmp_path)
         assert result.returncode == 0
+        assert (docs / "_index.md").exists()
 
-        content = agents.read_text()
-        assert "docs/context" in content
+    def test_reports_nothing_when_no_areas_and_no_docs(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "AGENTS.md").write_text(
+            f"# AGENTS.md\n\n{BEGIN_MARKER}\nno areas\n{END_MARKER}\n"
+        )
+        result = _run(tmp_path)
+        assert result.returncode == 0
+        assert "nothing to reindex" in result.stdout
 
+
+class TestReindexDoesNotTouchWikiInventory:
+    def test_wiki_index_untouched_when_wiki_is_not_a_registered_area(
+        self, tmp_path: Path
+    ) -> None:
+        """wiki/_index.md (page inventory) must not be overwritten by reindex."""
+        wiki = tmp_path / "wiki"
+        wiki.mkdir()
+        wiki_index = wiki / "_index.md"
+        expected = "# Wiki Index\n\n| Page | Description | File |\n"
+        wiki_index.write_text(expected)
+
+        # wiki/ is not in the areas table
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        _make_md(docs / "topic.md", name="Topic", description="A topic")
+        _agents_with_areas(tmp_path, [("Docs", "docs")])
+
+        _run(tmp_path)
+
+        assert wiki_index.read_text() == expected
+
+
+class TestReindexUpdatesAgentsMd:
     def test_preserves_existing_human_descriptions(self, tmp_path: Path) -> None:
         docs = tmp_path / "docs" / "context"
         docs.mkdir(parents=True)
         _make_md(docs / "topic.md", name="Topic", description="A topic")
 
         human_desc = "How LLM agents plan and execute tasks"
-        agents = tmp_path / "AGENTS.md"
-        agents.write_text(
-            f"# AGENTS.md\n\n"
-            f"{BEGIN_MARKER}\n"
-            f"### Areas\n"
-            f"| Area | Path |\n"
-            f"|------|------|\n"
-            f"| {human_desc} | docs/context |\n"
-            f"{END_MARKER}\n"
-        )
+        agents = _agents_with_areas(tmp_path, [(human_desc, "docs/context")])
 
         _run(tmp_path)
 
-        content = agents.read_text()
-        assert human_desc in content
+        assert human_desc in agents.read_text()
 
-    def test_new_areas_get_path_as_fallback_description(self, tmp_path: Path) -> None:
-        docs = tmp_path / "docs" / "new-area"
-        docs.mkdir(parents=True)
-        _make_md(docs / "topic.md", name="Topic", description="A topic")
-
-        agents = tmp_path / "AGENTS.md"
-        agents.write_text(f"# AGENTS.md\n\n{BEGIN_MARKER}\nold\n{END_MARKER}\n")
-
-        _run(tmp_path)
-
-        content = agents.read_text()
-        # New area falls back to path as description
-        assert "docs/new-area" in content
-
-    def test_skips_agents_update_when_no_agents_md(self, tmp_path: Path) -> None:
+    def test_skips_areas_update_when_no_agents_md(self, tmp_path: Path) -> None:
         docs = tmp_path / "docs"
-        docs.mkdir(parents=True)
+        docs.mkdir()
         _make_md(docs / "topic.md", name="Topic", description="A topic")
 
         result = _run(tmp_path)
@@ -172,6 +200,10 @@ class TestReindexOutput:
             d = tmp_path / "docs" / name
             d.mkdir(parents=True)
             _make_md(d / "doc.md", name="Doc", description="A doc")
+        _agents_with_areas(
+            tmp_path,
+            [("Alpha", "docs/alpha"), ("Beta", "docs/beta")],
+        )
 
         result = _run(tmp_path)
         assert result.returncode == 0

--- a/plugins/wiki/tests/test_update_preferences.py
+++ b/plugins/wiki/tests/test_update_preferences.py
@@ -52,17 +52,25 @@ class TestUpdatePreferencesWritesAgentsMd:
         assert BEGIN_MARKER in content
         assert END_MARKER in content
 
-    def test_preserves_areas(self, tmp_path: Path) -> None:
-        # Set up project with an area containing a managed doc
-        area_dir = tmp_path / "docs" / "context" / "api"
-        area_dir.mkdir(parents=True)
-        (area_dir / "endpoints.md").write_text(
-            "---\nname: Endpoints\ndescription: API endpoints\n---\n"
-        )
-
+    def test_preserves_existing_area_descriptions(self, tmp_path: Path) -> None:
+        # AGENTS.md already has a human-written Areas table
+        existing_area_desc = "How agents plan tasks and decompose work"
         agents_path = tmp_path / "AGENTS.md"
         agents_path.write_text(
-            f"# AGENTS.md\n\n{BEGIN_MARKER}\nold\n{END_MARKER}\n"
+            f"# AGENTS.md\n\n"
+            f"{BEGIN_MARKER}\n"
+            f"### Areas\n"
+            f"| Area | Path |\n"
+            f"|------|------|\n"
+            f"| {existing_area_desc} | docs/context/planning |\n"
+            f"{END_MARKER}\n"
+        )
+
+        # A directory exists on disk that is NOT in the existing AGENTS.md
+        extra_dir = tmp_path / "docs" / "context" / "api"
+        extra_dir.mkdir(parents=True)
+        (extra_dir / "endpoints.md").write_text(
+            "---\nname: Endpoints\ndescription: API endpoints\n---\n"
         )
 
         result = subprocess.run(
@@ -77,8 +85,11 @@ class TestUpdatePreferencesWritesAgentsMd:
         assert result.returncode == 0
 
         content = agents_path.read_text()
-        assert "docs/context/api" in content
+        # Human-written description preserved
+        assert existing_area_desc in content
         assert "**Directness:**" in content
+        # Directory on disk that wasn't in AGENTS.md should NOT be added
+        assert "docs/context/api" not in content
 
     def test_creates_agents_md_if_missing(self, tmp_path: Path) -> None:
         docs_dir = tmp_path / "docs" / "context"


### PR DESCRIPTION
## Summary

Fixes 6 bugs in the wiki plugin — 4 root-caused in Python code, 2 in skill text only.

- **#265** `wiki:ingest` error message referenced `/wos:setup` instead of `/wiki:setup`
- **#266** `wiki:setup` step 3 referenced `reindex.py` which did not exist — created it; scoped to AGENTS.md-registered areas only (docs/ fallback on first run)
- **#267** Plugin scripts failed with `ModuleNotFoundError` — `_bootstrap.py` now adds `src/` to sys.path
- **#268** `wiki:setup` never created `wiki/SCHEMA.md` or `wiki/_index.md` — added step 2.8 to setup skill
- **#269** `update_preferences.py` silently destroyed curated Areas table descriptions — added `extract_areas()` to `agents_md.py`, made `areas` optional in `update_agents_md`, removed `discover_areas` side-effect from `update_preferences.py`
- **#270** Uncommitted-changes guard gave no actionable resolution — now scopes to tracked files only and suggests `git stash`

## Files changed

- `plugins/wiki/scripts/_bootstrap.py` — sys.path fix
- `plugins/wiki/scripts/update_preferences.py` — remove `discover_areas` side-effect
- `plugins/wiki/scripts/reindex.py` — new script
- `plugins/wiki/src/wiki/agents_md.py` — `extract_areas()` + optional `areas` param
- `plugins/wiki/skills/setup/SKILL.md` — step 2.8, guard #1, python3 refs
- `plugins/wiki/skills/ingest/SKILL.md` — typo fix, post-ingest ref, python3 refs
- `plugins/wiki/tests/test_agents_md.py` — new tests for `extract_areas` and `areas=None`
- `plugins/wiki/tests/test_update_preferences.py` — updated to assert correct behavior
- `plugins/wiki/tests/test_reindex.py` — new test file (11 tests)

## Test plan

- [x] `python3 -m pytest plugins/wiki/tests/` — 244 pass (15 pre-existing failures from missing `plugins/check` plugin, unchanged)
- [x] `update_preferences.py --root . directness=blunt` — preferences written, area descriptions preserved
- [x] `reindex.py --root .` — indexes only 4 registered WOS areas, plugin/test dirs untouched
- [x] Typo and guard text verified via grep

Closes #265, #266, #267, #268, #269, #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)