### PR TITLE
chore: remove check plugin from marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,11 +10,6 @@
       "description": "Skills for creating and refining Claude Code skills, rules, hooks, and subagents."
     },
     {
-      "name": "check",
-      "source": "./plugins/check",
-      "description": "Skills for auditing Claude Code skills, rules, hooks, and subagents for quality issues."
-    },
-    {
       "name": "wiki",
       "source": "./plugins/wiki",
       "description": "Skills for building and maintaining structured project context — setup, research, ingest, and lint."
@@ -36,12 +31,12 @@
       "plugins": ["wiki"]
     },
     "build-tooling": {
-      "description": "Create, audit, and maintain Claude Code skills and rules.",
-      "plugins": ["build", "check"]
+      "description": "Create and maintain Claude Code skills and rules.",
+      "plugins": ["build"]
     },
     "full-suite": {
       "description": "Complete toolkit for AI-assisted project work.",
-      "plugins": ["build", "check", "wiki", "work", "consider"]
+      "plugins": ["build", "wiki", "work", "consider"]
     }
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,13 +17,12 @@ Documents put key insights first and last; supplemental detail in the middle.
 | Plugin | Path | Skills |
 |--------|------|--------|
 | `build` | `plugins/build/` | `build-skill`, `build-rule`, `build-hook`, `build-subagent`, `refine-prompt` |
-| `check` | `plugins/check/` | `check-skill`, `check-rule`, `check-hook`, `check-subagent`, `check-skill-chain` |
 | `wiki` | `plugins/wiki/` | `setup`, `research`, `ingest`, `lint` |
 | `work` | `plugins/work/` | `scope-work`, `plan-work`, `start-work`, `verify-work`, `finish-work` |
 | `consider` | `plugins/consider/` | 16 mental models + meta |
 
 Each plugin's skills live at `plugins/<plugin>/skills/<name>/SKILL.md`.
-Python packages: `plugins/wiki/wiki/` and `plugins/check/check/` (editable installs).
+Python package: `plugins/wiki/src/wiki/` (editable install).
 Shared scripts: `plugins/wiki/scripts/`.
 
 ### Areas

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,12 +10,12 @@ the tools, not using them.
 Install plugin packages and dev dependencies:
 
 ```bash
-pip install -e plugins/wiki -e plugins/check -e ".[dev]"
+pip install -e plugins/wiki -e ".[dev]"
 ```
 
 Run tests:
 ```bash
-python -m pytest plugins/wiki/tests/ plugins/check/tests/ -v
+python -m pytest plugins/wiki/tests/ -v
 ```
 
 Lint:
@@ -45,8 +45,8 @@ Note: `ruff` may not be installed locally; CI runs it via GitHub Actions.
 - **Script path convention:** Scripts use `Path(__file__).parent.parent` (2 levels)
   to reach plugin root. Per-skill scripts go deeper. No marker-based walk-up —
   it finds the user's project root, not the plugin root.
-- **`work`/`build` scripts:** No Python package — rely on editable installs of
-  `wiki`/`check`. Do not add sys.path manipulation to these scripts.
+- **`work`/`build` scripts:** No Python package — rely on editable install of
+  `wiki`. Do not add sys.path manipulation to these scripts.
 - **Per-plugin versioning:** A version bump updates the plugin's `pyproject.toml`
   and `.claude-plugin/plugin.json`. See CONTRIBUTING.md.
 - Python 3.9 — use `from __future__ import annotations` for type hints

--- a/README.md
+++ b/README.md
@@ -9,13 +9,12 @@ with AI-assisted research, source verification, and quality validation.
 
 ## Plugins
 
-Five self-contained plugins, each independently installable:
+Four self-contained plugins, each independently installable:
 
 | Plugin | Install | Skills |
 |--------|---------|--------|
 | `wiki` | `claude plugin install bcbeidel/toolkit --plugin wiki` | `setup`, `research`, `ingest`, `lint` |
 | `build` | `claude plugin install bcbeidel/toolkit --plugin build` | `build-skill`, `build-rule`, `build-hook`, `build-subagent`, `refine-prompt` |
-| `check` | `claude plugin install bcbeidel/toolkit --plugin check` | `check-skill`, `check-rule`, `check-hook`, `check-subagent`, `check-skill-chain` |
 | `work` | `claude plugin install bcbeidel/toolkit --plugin work` | `scope-work`, `plan-work`, `start-work`, `verify-work`, `finish-work` |
 | `consider` | `claude plugin install bcbeidel/toolkit --plugin consider` | 16 mental models + meta |
 
@@ -26,17 +25,15 @@ Five self-contained plugins, each independently installable:
 claude plugin install bcbeidel/toolkit --plugin wiki
 ```
 
-**Build tooling** — create and audit Claude Code skills and rules:
+**Build tooling** — create and maintain Claude Code skills and rules:
 ```bash
 claude plugin install bcbeidel/toolkit --plugin build
-claude plugin install bcbeidel/toolkit --plugin check
 ```
 
 **Full suite** — complete toolkit for AI-assisted project work:
 ```bash
 claude plugin install bcbeidel/toolkit --plugin wiki
 claude plugin install bcbeidel/toolkit --plugin build
-claude plugin install bcbeidel/toolkit --plugin check
 claude plugin install bcbeidel/toolkit --plugin work
 claude plugin install bcbeidel/toolkit --plugin consider
 ```
@@ -59,7 +56,6 @@ ruff check plugins/
 ```
 plugins/
   build/               # Plugin: create skills, rules, hooks, subagents
-  check/               # Plugin: audit skills, rules, hooks, subagents
   wiki/                # Plugin: setup, research, ingest, lint
     wiki/              # Python package
     scripts/           # Shared CLI scripts


### PR DESCRIPTION
`plugins/check` no longer exists in this repo. Removes all references from:

- `.claude-plugin/marketplace.json` — removed from plugins list and recommended groupings
- `README.md` — removed from plugin table, install commands, and project structure
- `CLAUDE.md` — removed from install and test commands
- `AGENTS.md` — removed from Plugin Structure table; corrected Python package path

🤖 Generated with [Claude Code](https://claude.com/claude-code)