### PR TITLE
docs: check-* skills are now in the build plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -31,7 +31,7 @@
       "plugins": ["wiki"]
     },
     "build-tooling": {
-      "description": "Create and maintain Claude Code skills and rules.",
+      "description": "Create, audit, and maintain Claude Code skills and rules.",
       "plugins": ["build"]
     },
     "full-suite": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Documents put key insights first and last; supplemental detail in the middle.
 
 | Plugin | Path | Skills |
 |--------|------|--------|
-| `build` | `plugins/build/` | `build-skill`, `build-rule`, `build-hook`, `build-subagent`, `refine-prompt` |
+| `build` | `plugins/build/` | `build-skill`, `build-rule`, `build-hook`, `build-subagent`, `refine-prompt`, `check-skill`, `check-rule`, `check-hook`, `check-subagent`, `check-skill-chain` |
 | `wiki` | `plugins/wiki/` | `setup`, `research`, `ingest`, `lint` |
 | `work` | `plugins/work/` | `scope-work`, `plan-work`, `start-work`, `verify-work`, `finish-work` |
 | `consider` | `plugins/consider/` | 16 mental models + meta |

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Four self-contained plugins, each independently installable:
 | Plugin | Install | Skills |
 |--------|---------|--------|
 | `wiki` | `claude plugin install bcbeidel/toolkit --plugin wiki` | `setup`, `research`, `ingest`, `lint` |
-| `build` | `claude plugin install bcbeidel/toolkit --plugin build` | `build-skill`, `build-rule`, `build-hook`, `build-subagent`, `refine-prompt` |
+| `build` | `claude plugin install bcbeidel/toolkit --plugin build` | `build-skill`, `build-rule`, `build-hook`, `build-subagent`, `refine-prompt`, `check-skill`, `check-rule`, `check-hook`, `check-subagent`, `check-skill-chain` |
 | `work` | `claude plugin install bcbeidel/toolkit --plugin work` | `scope-work`, `plan-work`, `start-work`, `verify-work`, `finish-work` |
 | `consider` | `claude plugin install bcbeidel/toolkit --plugin consider` | 16 mental models + meta |
 
@@ -25,7 +25,7 @@ Four self-contained plugins, each independently installable:
 claude plugin install bcbeidel/toolkit --plugin wiki
 ```
 
-**Build tooling** — create and maintain Claude Code skills and rules:
+**Build tooling** — create, audit, and maintain Claude Code skills and rules:
 ```bash
 claude plugin install bcbeidel/toolkit --plugin build
 ```


### PR DESCRIPTION
`check-skill`, `check-rule`, `check-hook`, `check-subagent`, and `check-skill-chain` are now part of the `build` plugin.

Updates:
- `AGENTS.md` — build row in Plugin Structure table
- `README.md` — build row in plugin table; build-tooling description restored
- `.claude-plugin/marketplace.json` — build-tooling description restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)