### PR TITLE
fix(scope-work): improve intent, diverge, and exploration guards (#279–#282)

### DIFF
--- a/plugins/work/.claude-plugin/plugin.json
+++ b/plugins/work/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "work",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Skills for the full work lifecycle — scope, plan, start, verify, finish, audit, and retro.",
   "author": {
     "name": "Brandon Beidel"

--- a/plugins/work/.claude-plugin/plugin.json
+++ b/plugins/work/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "work",
   "version": "0.1.1",
-  "description": "Skills for the full work lifecycle — scope, plan, start, verify, finish, audit, and retro.",
+  "description": "Skills for the full work lifecycle — scope-work, plan-work, start-work, verify-work, and finish-work.",
   "author": {
     "name": "Brandon Beidel"
   }

--- a/plugins/work/skills/scope-work/SKILL.md
+++ b/plugins/work/skills/scope-work/SKILL.md
@@ -33,7 +33,15 @@ is the deliverable at this stage — not code, not a plan.
 - Assess scope: if the request describes multiple independent subsystems,
   flag this immediately. Don't refine details of a project that needs
   decomposition first. Each sub-project gets its own scope-work → plan-work cycle.
+- When untracked directories are present, read their contents — at minimum
+  a directory listing — before deciding whether to include, exclude, defer,
+  or flag them for separate scoping.
+- Before flagging any file as needing modification, read its current content
+  to confirm the change is actually required. Do not assume from filenames
+  or context alone.
 - Ask clarifying questions one at a time, multiple-choice preferred.
+  Ask at least one question that surfaces timing (why now?), motivation,
+  or downstream dependencies before moving to approach proposals.
   Establish what and why before how.
 
 ### 2. Diverge
@@ -42,6 +50,10 @@ is the deliverable at this stage — not code, not a plan.
 - Lead with your recommendation and reasoning.
 - Do not converge prematurely — if only one approach is proposed,
   divergence was skipped.
+- Each option must be a genuine trade-off: real costs, real benefits.
+  Before presenting, verify that no option exists solely to make another
+  look better (straw man). If you cannot identify 2-3 distinct trade-off
+  pairs, say so explicitly rather than padding with a weak third option.
 
 See [Exploration Patterns](references/exploration-patterns.md) for question
 templates and approach comparison format.


### PR DESCRIPTION
## Summary

- **#279** — Read file content before flagging it as needing modification; don't assume from filename or context alone
- **#280** — Require at least one question surfacing timing, motivation, or downstream dependencies before moving to approach proposals
- **#281** — Active straw-man check in the Diverge step: each option must be a genuine trade-off; say so explicitly if fewer than 2-3 real options exist
- **#282** — Read untracked directory contents (at minimum a listing) before making include/exclude/defer scoping decisions

## Test plan

- [ ] All 260 existing tests pass
- [ ] Manually verify scope-work skill text reads correctly and guards are actionable

🤖 Generated with [Claude Code](https://claude.com/claude-code)