### PR TITLE
feat(wiki): wiki group-c enhancements — nesting, source summary, op log, discuss-before-write (v0.1.3)

### DIFF
--- a/.claude/hooks/skill-lint.sh
+++ b/.claude/hooks/skill-lint.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# PostToolUse hook: runs after Write/Edit/MultiEdit on *SKILL.md files.
+# Reads hook input from stdin (JSON), extracts the file path, and reports
+# it for awareness. Exit 0 always — informational only.
+set -euo pipefail
+
+input=$(cat)
+file=$(echo "$input" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+# tool_input is nested under the hook payload
+ti = d.get('tool_input', d)
+print(ti.get('file_path', ti.get('path', '')))
+" 2>/dev/null || true)
+
+if [[ -n "$file" ]]; then
+  echo "skill-lint: $file edited — run /build:check-skill to audit quality" >&2
+fi
+
+exit 0

--- a/docs/plans/2026-04-15-wiki-group-c-enhancements.plan.md
+++ b/docs/plans/2026-04-15-wiki-group-c-enhancements.plan.md
@@ -2,7 +2,7 @@
 name: Wiki Group C Enhancements
 description: Emergent wiki nesting, source summary pages, operation log, and collaborative ingest (#275–#278)
 type: plan
-status: executing
+status: completed
 branch: feat/wiki-group-c-enhancements
 related:
   - docs/designs/2026-04-15-wiki-group-c-enhancements.design.md
@@ -85,22 +85,22 @@ keep rollback boundaries clean.
 **Files:**
 - Modify: `plugins/wiki/src/wiki/wiki.py`
 
-- [ ] In `check_wiki_orphans()`: add `"log.md"` to the skip set alongside
+- [x] In `check_wiki_orphans()`: add `"log.md"` to the skip set alongside
   `"_index.md"` and `"SCHEMA.md"`. Update the error message from the
   hardcoded `wiki/_index.md` reference to `f"{wiki_dir.name}/_index.md"` so
   subdirectory error messages are accurate.
-- [ ] In `validate_wiki()`: replace `wiki_dir.iterdir()` with
+- [x] In `validate_wiki()`: replace `wiki_dir.iterdir()` with
   `wiki_dir.rglob("*.md")`. Add a skip guard for filenames `_index.md`,
   `SCHEMA.md`, and `log.md`. For each `.md` in subdirectories, the
   `wiki_dir` argument passed to `doc.issues()` is still the wiki root
   (SCHEMA.md lives at the root, not in subdirs).
-- [ ] In `validate_wiki()`: after the per-file loop, replace the single
+- [x] In `validate_wiki()`: after the per-file loop, replace the single
   `check_wiki_orphans(wiki_dir)` call with a loop over `wiki_dir` and all
   subdirectories (`wiki_dir.rglob("*/")`) that call `check_wiki_orphans()`
   for each directory that has a `_index.md`.
-- [ ] Verify: `python -m pytest plugins/wiki/tests/test_wiki.py -v` — passes
+- [x] Verify: `python -m pytest plugins/wiki/tests/test_wiki.py -v` — passes
   with no regressions on existing tests.
-- [ ] Commit: `fix(wiki): recursive validate_wiki and log.md exclusion (#277, #275)`
+- [x] Commit: `fix(wiki): recursive validate_wiki and log.md exclusion (#277, #275)` <!-- sha:c12d900 -->
 
 ---
 
@@ -109,10 +109,10 @@ keep rollback boundaries clean.
 **Files:**
 - Modify: `plugins/wiki/scripts/reindex.py`
 
-- [ ] After the existing areas-based reindex block in `main()`, add wiki
+- [x] After the existing areas-based reindex block in `main()`, add wiki
   detection: `wiki_dir = root / "wiki"`. If `(wiki_dir / "SCHEMA.md").is_file()`,
   call a new helper `_reindex_wiki(wiki_dir, root)`.
-- [ ] Implement `_reindex_wiki(wiki_dir, root)`:
+- [x] Implement `_reindex_wiki(wiki_dir, root)`:
   - Walk `wiki_dir` recursively with `os.walk`.
   - Skip `log.md`, `SCHEMA.md`, `_index.md` when collecting files.
   - For each subdirectory with `.md` files: call `_write_index(subdir, root)`
@@ -122,10 +122,10 @@ keep rollback boundaries clean.
     table for pages in that subdir; then a flat table for root-level `.md`
     pages (excluding `log.md`, `SCHEMA.md`, `_index.md`).
   - Print count: `f"Wiki: reindexed {n} subdirector{'y' if n==1 else 'ies'}"`
-- [ ] Verify: `python -m pytest plugins/wiki/tests/test_reindex.py -v` —
+- [x] Verify: `python -m pytest plugins/wiki/tests/test_reindex.py -v` —
   existing tests pass (the wiki-isolation test will fail until Task 4 updates
   it; that is expected and acceptable).
-- [ ] Commit: `feat(wiki): reindex.py wiki subtree mode (#277)`
+- [x] Commit: `feat(wiki): reindex.py wiki subtree mode (#277)` <!-- sha:33791d9 -->
 
 ---
 
@@ -138,19 +138,19 @@ keep rollback boundaries clean.
 **Files:**
 - Modify: `plugins/wiki/tests/test_wiki.py`
 
-- [ ] Add `TestValidateWikiRecursive`: create a wiki dir with a subdir
+- [x] Add `TestValidateWikiRecursive`: create a wiki dir with a subdir
   containing a valid page and a `_index.md` listing it. Call
   `validate_wiki()` — assert no failures. Assert the page in the subdir
   was validated (e.g., a deliberate type violation surfaces as a fail).
-- [ ] Add `TestCheckWikiOrphansSkipsLogMd`: create `wiki/log.md` alongside
+- [x] Add `TestCheckWikiOrphansSkipsLogMd`: create `wiki/log.md` alongside
   a `_index.md` that does not list `log.md`. Call `check_wiki_orphans()` —
   assert `log.md` is not reported as an orphan.
-- [ ] Add `TestCheckWikiOrphansSubdirMessage`: create a subdir with an
+- [x] Add `TestCheckWikiOrphansSubdirMessage`: create a subdir with an
   unlisted `.md`. Assert the issue message references `<subdir>/_index.md`,
   not `wiki/_index.md`.
-- [ ] Verify: `python -m pytest plugins/wiki/tests/test_wiki.py -v` — all
+- [x] Verify: `python -m pytest plugins/wiki/tests/test_wiki.py -v` — all
   tests pass including new ones.
-- [ ] Commit: `test(wiki): recursive validation and log.md exclusion tests (#277, #275)`
+- [x] Commit: `test(wiki): recursive validation and log.md exclusion tests (#277, #275)` <!-- sha:73a2a97 -->
 
 ---
 
@@ -159,17 +159,17 @@ keep rollback boundaries clean.
 **Files:**
 - Modify: `plugins/wiki/tests/test_reindex.py`
 
-- [ ] Update `TestReindexDoesNotTouchWikiInventory`: rename to
+- [x] Update `TestReindexDoesNotTouchWikiInventory`: rename to
   `TestReindexWikiMode`. Replace the "wiki not touched" assertion with:
   when `wiki/SCHEMA.md` is present, reindex DOES generate `wiki/_index.md`
   and per-subdir `_index.md` files.
-- [ ] Add test: `wiki/` with one subdirectory produces `wiki/<subdir>/_index.md`
+- [x] Add test: `wiki/` with one subdirectory produces `wiki/<subdir>/_index.md`
   and `wiki/_index.md` with a `## <subdir>` heading.
-- [ ] Add test: `wiki/log.md` is not listed in any generated `_index.md`.
-- [ ] Add test: when `wiki/SCHEMA.md` is absent, `wiki/` is not touched.
-- [ ] Verify: `python -m pytest plugins/wiki/tests/test_reindex.py -v` — all
+- [x] Add test: `wiki/log.md` is not listed in any generated `_index.md`.
+- [x] Add test: when `wiki/SCHEMA.md` is absent, `wiki/` is not touched.
+- [x] Verify: `python -m pytest plugins/wiki/tests/test_reindex.py -v` — all
   tests pass.
-- [ ] Commit: `test(wiki): reindex wiki subtree mode tests (#277, #275)`
+- [x] Commit: `test(wiki): reindex wiki subtree mode tests (#277, #275)` <!-- sha:73971b3 -->
 
 ---
 
@@ -185,18 +185,18 @@ Execute sequentially. Each commit is independently verifiable by reading the fil
 **Files:**
 - Modify: `plugins/wiki/skills/ingest/SKILL.md`
 
-- [ ] In "Pre-Ingest", extend step 1 ("Read `wiki/_index.md`") to also list
+- [x] In "Pre-Ingest", extend step 1 ("Read `wiki/_index.md`") to also list
   the `wiki/` directory tree (e.g., `ls -R wiki/` or equivalent) so the LLM
   understands existing subdirectory groupings before proposing new page paths.
-- [ ] In "Step 1: Identify Affected Pages", add: for new pages, propose a
+- [x] In "Step 1: Identify Affected Pages", add: for new pages, propose a
   path that fits contextually within the existing `wiki/` structure —
   `wiki/<topic-dir>/<slug>.md`. Explain that the path is editable by the
   user at Step 1b.
-- [ ] In "Step 1b: Confirm Before Writing", update the example to show a
+- [x] In "Step 1b: Confirm Before Writing", update the example to show a
   subdirectory path (`CREATE wiki/llm-patterns/consistency-tradeoffs.md`).
-- [ ] Verify: read `plugins/wiki/skills/ingest/SKILL.md` — confirm the three
+- [x] Verify: read `plugins/wiki/skills/ingest/SKILL.md` — confirm the three
   edits are present and coherent.
-- [ ] Commit: `feat(wiki): ingest proposes emergent subdirectory paths (#277)`
+- [x] Commit: `feat(wiki): ingest proposes emergent subdirectory paths (#277)` <!-- sha:38b4498 -->
 
 ---
 
@@ -205,23 +205,23 @@ Execute sequentially. Each commit is independently verifiable by reading the fil
 **Files:**
 - Modify: `plugins/wiki/skills/ingest/SKILL.md`
 
-- [ ] In "Ingest Protocol", insert a new **Step 0: Discuss Key Takeaways**
+- [x] In "Ingest Protocol", insert a new **Step 0: Discuss Key Takeaways**
   before Step 1. Default behaviour (no flag): after reading the source(s),
   present key takeaways and ask the user to confirm. Bulk mode (multiple
   sources): one consolidated discussion for all sources, not one per source.
   Opt-out: `--no-discuss` flag skips this step and jumps directly to Step 1.
-- [ ] Add the discussion prompt template from the design:
+- [x] Add the discussion prompt template from the design:
   ```
   Here are the key takeaways from [Source Title]:
   - ...
   Does this capture the important ideas? Anything missing or worth
   emphasizing differently before I propose the page list?
   ```
-- [ ] Add an "Anti-Pattern Guard" entry: running a separate discussion round
+- [x] Add an "Anti-Pattern Guard" entry: running a separate discussion round
   per source in bulk mode is wrong — consolidate into one pass.
-- [ ] Verify: read `plugins/wiki/skills/ingest/SKILL.md` — confirm Step 0
+- [x] Verify: read `plugins/wiki/skills/ingest/SKILL.md` — confirm Step 0
   appears before Step 1, bulk and `--no-discuss` behaviour documented.
-- [ ] Commit: `feat(wiki): discuss-before-write by default (#278)`
+- [x] Commit: `feat(wiki): discuss-before-write by default (#278)` <!-- sha:798f6a3 -->
 
 ---
 
@@ -230,23 +230,23 @@ Execute sequentially. Each commit is independently verifiable by reading the fil
 **Files:**
 - Modify: `plugins/wiki/skills/ingest/SKILL.md`
 
-- [ ] In "Step 1: Identify Affected Pages", add: always include one
+- [x] In "Step 1: Identify Affected Pages", add: always include one
   source summary page for the ingested source (create or update). Idempotency
   rule: if a source summary page already exists for this URL (matched by
   `sources:` frontmatter), update it rather than creating a duplicate —
   append new claims, never remove existing ones.
-- [ ] In "Step 3: Create New Pages" (or a new "Step 3a: Create Source Summary
+- [x] In "Step 3: Create New Pages" (or a new "Step 3a: Create Source Summary
   Page"), document the source summary page format from the design: frontmatter
   fields (`name`, `description`, `type: source-summary`, `sources`, `created`,
   `updated`) plus body sections (Author/Date/URL metadata, Key Claims,
   Summary). State the factual-only constraint explicitly: no interpretation,
   synthesis, or evaluation.
-- [ ] Add an "Anti-Pattern Guard": writing interpretation or synthesis into
+- [x] Add an "Anti-Pattern Guard": writing interpretation or synthesis into
   a source summary page (those belong in concept/synthesis pages).
-- [ ] Verify: read `plugins/wiki/skills/ingest/SKILL.md` — confirm source
+- [x] Verify: read `plugins/wiki/skills/ingest/SKILL.md` — confirm source
   summary page step is present, factual-only constraint stated, idempotency
   rule documented.
-- [ ] Commit: `feat(wiki): source summary page per ingest (#276)`
+- [x] Commit: `feat(wiki): source summary page per ingest (#276)` <!-- sha:76fc13f -->
 
 ---
 
@@ -255,17 +255,17 @@ Execute sequentially. Each commit is independently verifiable by reading the fil
 **Files:**
 - Modify: `plugins/wiki/skills/ingest/SKILL.md`
 
-- [ ] In "Post-Ingest", after the `lint.py` and `reindex.py` commands, add a
+- [x] In "Post-Ingest", after the `lint.py` and `reindex.py` commands, add a
   step: append an entry to `wiki/log.md`. Create the file if it doesn't exist.
   Document the entry format:
   ```
   ## [YYYY-MM-DD] ingest | <Source Title>
   <N> pages updated, <M> created. Pages: wiki/path/a.md, wiki/path/b.md.
   ```
-- [ ] State the append-only constraint: existing entries are never modified.
-- [ ] Verify: read `plugins/wiki/skills/ingest/SKILL.md` — confirm log append
+- [x] State the append-only constraint: existing entries are never modified.
+- [x] Verify: read `plugins/wiki/skills/ingest/SKILL.md` — confirm log append
   step and format are present in Post-Ingest.
-- [ ] Commit: `feat(wiki): operation log append in ingest (#275)`
+- [x] Commit: `feat(wiki): operation log append in ingest (#275)` <!-- sha:29e1346 -->
 
 ---
 
@@ -278,31 +278,31 @@ Execute sequentially. Each commit is independently verifiable by reading the fil
 **Files:**
 - Modify: `plugins/wiki/skills/lint/SKILL.md`
 
-- [ ] In "How to Run" or a new "Post-Lint" section, add: after reporting
+- [x] In "How to Run" or a new "Post-Lint" section, add: after reporting
   results, append an entry to `wiki/log.md` (create if missing). Format:
   ```
   ## [YYYY-MM-DD] lint | <summary>
   <N> issues found: <brief description>. (or: No issues.)
   ```
   Append-only: existing entries are never modified.
-- [ ] Verify: read `plugins/wiki/skills/lint/SKILL.md` — confirm log append
+- [x] Verify: read `plugins/wiki/skills/lint/SKILL.md` — confirm log append
   step is present with correct format.
-- [ ] Commit: `feat(wiki): operation log append in lint (#275)`
+- [x] Commit: `feat(wiki): operation log append in lint (#275)` <!-- sha:c704491 -->
 
 ---
 
 ## Validation
 
-- [ ] `python -m pytest plugins/wiki/tests/ -v` — all tests pass, including
+- [x] `python -m pytest plugins/wiki/tests/ -v` — all tests pass, including
   new recursive validation and reindex wiki mode tests
-- [ ] `python -m pytest plugins/wiki/tests/test_wiki.py -k "log"` — at least
+- [x] `python -m pytest plugins/wiki/tests/test_wiki.py -k "log"` — at least
   one test verifies `log.md` is excluded from orphan checks
-- [ ] `python -m pytest plugins/wiki/tests/test_reindex.py -k "wiki"` — at
+- [x] `python -m pytest plugins/wiki/tests/test_reindex.py -k "wiki"` — at
   least one test verifies wiki subtree reindex produces per-subdir `_index.md`
-- [ ] Read `plugins/wiki/skills/ingest/SKILL.md` — confirm four additions
+- [x] Read `plugins/wiki/skills/ingest/SKILL.md` — confirm four additions
   present: (1) wiki dir tree read + emergent paths, (2) discuss step with
   bulk mode and `--no-discuss`, (3) source summary page with factual-only
   constraint, (4) log append
-- [ ] Read `plugins/wiki/skills/lint/SKILL.md` — confirm log append step
+- [x] Read `plugins/wiki/skills/lint/SKILL.md` — confirm log append step
   present with correct format
-- [ ] `ruff check plugins/wiki/src/ plugins/wiki/scripts/` — no errors
+- [x] `ruff check plugins/wiki/src/ plugins/wiki/scripts/` — no errors

--- a/docs/plans/2026-04-15-wiki-group-c-enhancements.plan.md
+++ b/docs/plans/2026-04-15-wiki-group-c-enhancements.plan.md
@@ -1,0 +1,308 @@
+---
+name: Wiki Group C Enhancements
+description: Emergent wiki nesting, source summary pages, operation log, and collaborative ingest (#275–#278)
+type: plan
+status: executing
+branch: feat/wiki-group-c-enhancements
+related:
+  - docs/designs/2026-04-15-wiki-group-c-enhancements.design.md
+---
+
+# Wiki Group C Enhancements
+
+## Goal
+
+Four features that make the wiki plugin structurally expressive, auditable,
+and collaborative. The wiki directory now supports emergent LLM-determined
+subdirectory nesting (#277); every ingest produces a factual-only source
+summary page (#276) and appends to an operation log (#275); and ingest now
+opens a discuss-before-write dialogue by default (#278).
+
+## Scope
+
+Must have:
+- `wiki.py`: `validate_wiki()` and `check_wiki_orphans()` walk the wiki
+  subtree recursively; `log.md` excluded from page and orphan checks
+- `reindex.py`: wiki reindex mode activated when `wiki/SCHEMA.md` is
+  present; generates per-subdirectory `_index.md` and a tree-view root
+  `wiki/_index.md`; skips `log.md`
+- `ingest/SKILL.md`: reads wiki directory tree before proposing page
+  paths; discuss-before-write step (default on, `--no-discuss` to skip);
+  source summary page creation per ingest; log append after each ingest
+- `lint/SKILL.md`: log append after each lint run
+
+Won't have:
+- Fixed directory taxonomy or lint enforcement on page placement
+- `log.md` entries for research or query operations
+- Per-project SCHEMA.md opt-out for discuss step (flag only)
+- Migration of existing flat-wiki pages to subdirectories
+
+## Approach
+
+All changes are in the `plugins/wiki/` directory. Python changes come first
+(Chunk 1) so they can be verified with `pytest` before touching the skill
+files (Chunk 2). Chunk 1 has two parts: `wiki.py` (validation) and
+`reindex.py` (index generation), each with their own tests.
+
+For `validate_wiki()`: replace `wiki_dir.iterdir()` with `wiki_dir.rglob(
+"*.md")` and filter out `log.md`, `SCHEMA.md`, `_index.md`. Call
+`check_wiki_orphans()` for the root and every subdirectory that contains
+a `_index.md`. Update `check_wiki_orphans()` to skip `log.md` and to
+reference the specific directory's `_index.md` in error messages.
+
+For `reindex.py`: auto-detect `wiki/SCHEMA.md` at the project root. When
+found, walk `wiki/` recursively — for each subdirectory with `.md` files
+(excluding `log.md`, `SCHEMA.md`, `_index.md`), write a flat `_index.md`;
+then write a tree-view root `wiki/_index.md` with a `## DirName` heading per
+subdirectory followed by a file table, and a flat table for root-level pages.
+The existing `TestReindexDoesNotTouchWikiInventory` test must be updated:
+it tested the old invariant (wiki not touched); the new invariant is
+"reindex manages wiki indices when SCHEMA.md is present."
+
+The four ingest SKILL.md changes are additive and committed separately to
+keep rollback boundaries clean.
+
+## File Changes
+
+- Modify: `plugins/wiki/src/wiki/wiki.py` (recursive walk, log.md exclusion)
+- Modify: `plugins/wiki/scripts/reindex.py` (wiki reindex mode)
+- Modify: `plugins/wiki/tests/test_wiki.py` (new tests + log.md exclusion)
+- Modify: `plugins/wiki/tests/test_reindex.py` (wiki reindex tests; update
+  `TestReindexDoesNotTouchWikiInventory`)
+- Modify: `plugins/wiki/skills/ingest/SKILL.md` (four behavioural additions)
+- Modify: `plugins/wiki/skills/lint/SKILL.md` (log append)
+
+## Tasks
+
+---
+
+### Chunk 1: Python — recursive validation and wiki reindex
+
+---
+
+### Task 1: Update `wiki.py` for recursive walk and log.md exclusion
+
+**Files:**
+- Modify: `plugins/wiki/src/wiki/wiki.py`
+
+- [ ] In `check_wiki_orphans()`: add `"log.md"` to the skip set alongside
+  `"_index.md"` and `"SCHEMA.md"`. Update the error message from the
+  hardcoded `wiki/_index.md` reference to `f"{wiki_dir.name}/_index.md"` so
+  subdirectory error messages are accurate.
+- [ ] In `validate_wiki()`: replace `wiki_dir.iterdir()` with
+  `wiki_dir.rglob("*.md")`. Add a skip guard for filenames `_index.md`,
+  `SCHEMA.md`, and `log.md`. For each `.md` in subdirectories, the
+  `wiki_dir` argument passed to `doc.issues()` is still the wiki root
+  (SCHEMA.md lives at the root, not in subdirs).
+- [ ] In `validate_wiki()`: after the per-file loop, replace the single
+  `check_wiki_orphans(wiki_dir)` call with a loop over `wiki_dir` and all
+  subdirectories (`wiki_dir.rglob("*/")`) that call `check_wiki_orphans()`
+  for each directory that has a `_index.md`.
+- [ ] Verify: `python -m pytest plugins/wiki/tests/test_wiki.py -v` — passes
+  with no regressions on existing tests.
+- [ ] Commit: `fix(wiki): recursive validate_wiki and log.md exclusion (#277, #275)`
+
+---
+
+### Task 2: Update `reindex.py` with wiki reindex mode
+
+**Files:**
+- Modify: `plugins/wiki/scripts/reindex.py`
+
+- [ ] After the existing areas-based reindex block in `main()`, add wiki
+  detection: `wiki_dir = root / "wiki"`. If `(wiki_dir / "SCHEMA.md").is_file()`,
+  call a new helper `_reindex_wiki(wiki_dir, root)`.
+- [ ] Implement `_reindex_wiki(wiki_dir, root)`:
+  - Walk `wiki_dir` recursively with `os.walk`.
+  - Skip `log.md`, `SCHEMA.md`, `_index.md` when collecting files.
+  - For each subdirectory with `.md` files: call `_write_index(subdir, root)`
+    (existing helper — reuses unchanged).
+  - For root `wiki/` itself: write a tree-view `wiki/_index.md` — one
+    `## <dirname>` heading per subdirectory (sorted), followed by a file
+    table for pages in that subdir; then a flat table for root-level `.md`
+    pages (excluding `log.md`, `SCHEMA.md`, `_index.md`).
+  - Print count: `f"Wiki: reindexed {n} subdirector{'y' if n==1 else 'ies'}"`
+- [ ] Verify: `python -m pytest plugins/wiki/tests/test_reindex.py -v` —
+  existing tests pass (the wiki-isolation test will fail until Task 4 updates
+  it; that is expected and acceptable).
+- [ ] Commit: `feat(wiki): reindex.py wiki subtree mode (#277)`
+
+---
+
+### Chunk 2: Tests
+
+---
+
+### Task 3: Tests for recursive wiki validation
+
+**Files:**
+- Modify: `plugins/wiki/tests/test_wiki.py`
+
+- [ ] Add `TestValidateWikiRecursive`: create a wiki dir with a subdir
+  containing a valid page and a `_index.md` listing it. Call
+  `validate_wiki()` — assert no failures. Assert the page in the subdir
+  was validated (e.g., a deliberate type violation surfaces as a fail).
+- [ ] Add `TestCheckWikiOrphansSkipsLogMd`: create `wiki/log.md` alongside
+  a `_index.md` that does not list `log.md`. Call `check_wiki_orphans()` —
+  assert `log.md` is not reported as an orphan.
+- [ ] Add `TestCheckWikiOrphansSubdirMessage`: create a subdir with an
+  unlisted `.md`. Assert the issue message references `<subdir>/_index.md`,
+  not `wiki/_index.md`.
+- [ ] Verify: `python -m pytest plugins/wiki/tests/test_wiki.py -v` — all
+  tests pass including new ones.
+- [ ] Commit: `test(wiki): recursive validation and log.md exclusion tests (#277, #275)`
+
+---
+
+### Task 4: Tests for wiki reindex mode
+
+**Files:**
+- Modify: `plugins/wiki/tests/test_reindex.py`
+
+- [ ] Update `TestReindexDoesNotTouchWikiInventory`: rename to
+  `TestReindexWikiMode`. Replace the "wiki not touched" assertion with:
+  when `wiki/SCHEMA.md` is present, reindex DOES generate `wiki/_index.md`
+  and per-subdir `_index.md` files.
+- [ ] Add test: `wiki/` with one subdirectory produces `wiki/<subdir>/_index.md`
+  and `wiki/_index.md` with a `## <subdir>` heading.
+- [ ] Add test: `wiki/log.md` is not listed in any generated `_index.md`.
+- [ ] Add test: when `wiki/SCHEMA.md` is absent, `wiki/` is not touched.
+- [ ] Verify: `python -m pytest plugins/wiki/tests/test_reindex.py -v` — all
+  tests pass.
+- [ ] Commit: `test(wiki): reindex wiki subtree mode tests (#277, #275)`
+
+---
+
+### Chunk 2: Ingest SKILL.md — four behavioural additions
+
+All four tasks modify the same file: `plugins/wiki/skills/ingest/SKILL.md`.
+Execute sequentially. Each commit is independently verifiable by reading the file.
+
+---
+
+### Task 5: Ingest — read wiki directory tree and propose emergent paths (#277)
+
+**Files:**
+- Modify: `plugins/wiki/skills/ingest/SKILL.md`
+
+- [ ] In "Pre-Ingest", extend step 1 ("Read `wiki/_index.md`") to also list
+  the `wiki/` directory tree (e.g., `ls -R wiki/` or equivalent) so the LLM
+  understands existing subdirectory groupings before proposing new page paths.
+- [ ] In "Step 1: Identify Affected Pages", add: for new pages, propose a
+  path that fits contextually within the existing `wiki/` structure —
+  `wiki/<topic-dir>/<slug>.md`. Explain that the path is editable by the
+  user at Step 1b.
+- [ ] In "Step 1b: Confirm Before Writing", update the example to show a
+  subdirectory path (`CREATE wiki/llm-patterns/consistency-tradeoffs.md`).
+- [ ] Verify: read `plugins/wiki/skills/ingest/SKILL.md` — confirm the three
+  edits are present and coherent.
+- [ ] Commit: `feat(wiki): ingest proposes emergent subdirectory paths (#277)`
+
+---
+
+### Task 6: Ingest — discuss-before-write by default (#278)
+
+**Files:**
+- Modify: `plugins/wiki/skills/ingest/SKILL.md`
+
+- [ ] In "Ingest Protocol", insert a new **Step 0: Discuss Key Takeaways**
+  before Step 1. Default behaviour (no flag): after reading the source(s),
+  present key takeaways and ask the user to confirm. Bulk mode (multiple
+  sources): one consolidated discussion for all sources, not one per source.
+  Opt-out: `--no-discuss` flag skips this step and jumps directly to Step 1.
+- [ ] Add the discussion prompt template from the design:
+  ```
+  Here are the key takeaways from [Source Title]:
+  - ...
+  Does this capture the important ideas? Anything missing or worth
+  emphasizing differently before I propose the page list?
+  ```
+- [ ] Add an "Anti-Pattern Guard" entry: running a separate discussion round
+  per source in bulk mode is wrong — consolidate into one pass.
+- [ ] Verify: read `plugins/wiki/skills/ingest/SKILL.md` — confirm Step 0
+  appears before Step 1, bulk and `--no-discuss` behaviour documented.
+- [ ] Commit: `feat(wiki): discuss-before-write by default (#278)`
+
+---
+
+### Task 7: Ingest — source summary page per ingest (#276)
+
+**Files:**
+- Modify: `plugins/wiki/skills/ingest/SKILL.md`
+
+- [ ] In "Step 1: Identify Affected Pages", add: always include one
+  source summary page for the ingested source (create or update). Idempotency
+  rule: if a source summary page already exists for this URL (matched by
+  `sources:` frontmatter), update it rather than creating a duplicate —
+  append new claims, never remove existing ones.
+- [ ] In "Step 3: Create New Pages" (or a new "Step 3a: Create Source Summary
+  Page"), document the source summary page format from the design: frontmatter
+  fields (`name`, `description`, `type: source-summary`, `sources`, `created`,
+  `updated`) plus body sections (Author/Date/URL metadata, Key Claims,
+  Summary). State the factual-only constraint explicitly: no interpretation,
+  synthesis, or evaluation.
+- [ ] Add an "Anti-Pattern Guard": writing interpretation or synthesis into
+  a source summary page (those belong in concept/synthesis pages).
+- [ ] Verify: read `plugins/wiki/skills/ingest/SKILL.md` — confirm source
+  summary page step is present, factual-only constraint stated, idempotency
+  rule documented.
+- [ ] Commit: `feat(wiki): source summary page per ingest (#276)`
+
+---
+
+### Task 8: Ingest — operation log append (#275)
+
+**Files:**
+- Modify: `plugins/wiki/skills/ingest/SKILL.md`
+
+- [ ] In "Post-Ingest", after the `lint.py` and `reindex.py` commands, add a
+  step: append an entry to `wiki/log.md`. Create the file if it doesn't exist.
+  Document the entry format:
+  ```
+  ## [YYYY-MM-DD] ingest | <Source Title>
+  <N> pages updated, <M> created. Pages: wiki/path/a.md, wiki/path/b.md.
+  ```
+- [ ] State the append-only constraint: existing entries are never modified.
+- [ ] Verify: read `plugins/wiki/skills/ingest/SKILL.md` — confirm log append
+  step and format are present in Post-Ingest.
+- [ ] Commit: `feat(wiki): operation log append in ingest (#275)`
+
+---
+
+### Chunk 3: Lint SKILL.md — log append
+
+---
+
+### Task 9: Lint — operation log append (#275)
+
+**Files:**
+- Modify: `plugins/wiki/skills/lint/SKILL.md`
+
+- [ ] In "How to Run" or a new "Post-Lint" section, add: after reporting
+  results, append an entry to `wiki/log.md` (create if missing). Format:
+  ```
+  ## [YYYY-MM-DD] lint | <summary>
+  <N> issues found: <brief description>. (or: No issues.)
+  ```
+  Append-only: existing entries are never modified.
+- [ ] Verify: read `plugins/wiki/skills/lint/SKILL.md` — confirm log append
+  step is present with correct format.
+- [ ] Commit: `feat(wiki): operation log append in lint (#275)`
+
+---
+
+## Validation
+
+- [ ] `python -m pytest plugins/wiki/tests/ -v` — all tests pass, including
+  new recursive validation and reindex wiki mode tests
+- [ ] `python -m pytest plugins/wiki/tests/test_wiki.py -k "log"` — at least
+  one test verifies `log.md` is excluded from orphan checks
+- [ ] `python -m pytest plugins/wiki/tests/test_reindex.py -k "wiki"` — at
+  least one test verifies wiki subtree reindex produces per-subdir `_index.md`
+- [ ] Read `plugins/wiki/skills/ingest/SKILL.md` — confirm four additions
+  present: (1) wiki dir tree read + emergent paths, (2) discuss step with
+  bulk mode and `--no-discuss`, (3) source summary page with factual-only
+  constraint, (4) log append
+- [ ] Read `plugins/wiki/skills/lint/SKILL.md` — confirm log append step
+  present with correct format
+- [ ] `ruff check plugins/wiki/src/ plugins/wiki/scripts/` — no errors

--- a/plugins/wiki/.claude-plugin/plugin.json
+++ b/plugins/wiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Skills for building and maintaining structured project context — setup, research, ingest, and lint.",
   "author": {
     "name": "Brandon Beidel"

--- a/plugins/wiki/pyproject.toml
+++ b/plugins/wiki/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wiki"
-version = "0.1.2"
+version = "0.1.3"
 description = "Claude Code plugin for building and maintaining structured project context."
 requires-python = ">=3.9"
 dependencies = []

--- a/plugins/wiki/scripts/reindex.py
+++ b/plugins/wiki/scripts/reindex.py
@@ -3,7 +3,7 @@
 # requires-python = ">=3.9"
 # dependencies = []
 # ///
-"""Create _index.md files for WOS-managed areas.
+"""Create _index.md files for WOS-managed areas and the wiki/ subtree.
 
 Reads directories from the AGENTS.md areas table and creates a
 <dir>/_index.md listing all managed documents with their descriptions.
@@ -11,6 +11,11 @@ Also refreshes the AGENTS.md areas table, preserving existing descriptions.
 
 First-run fallback: if AGENTS.md has no areas table, scans the docs/
 subtree to discover directories.
+
+Wiki mode (auto-activated when wiki/SCHEMA.md is present):
+Walks the wiki/ subtree recursively. For each subdirectory with .md files,
+writes a flat _index.md. Writes a tree-view root wiki/_index.md with a
+heading per subdirectory. Skips log.md, SCHEMA.md, and _index.md.
 
 Usage:
     python3 scripts/reindex.py --root .
@@ -28,6 +33,8 @@ _SKIP = frozenset({
     "node_modules", "__pycache__", "venv", ".venv",
     "dist", "build", ".tox", ".mypy_cache", ".pytest_cache",
 })
+
+_WIKI_SKIP = frozenset({"_index.md", "SCHEMA.md", "log.md"})
 
 
 def _read_frontmatter_field(path: Path, field: str) -> str:
@@ -94,6 +101,73 @@ def _scan_docs_subtree(root: Path) -> list[Path]:
     return dirs
 
 
+def _reindex_wiki(wiki_dir: Path, root: Path) -> None:
+    """Generate _index.md files for the wiki/ subtree.
+
+    For each subdirectory with .md files, writes a flat _index.md (via
+    _write_index). Writes a tree-view root wiki/_index.md with one
+    ``## dirname`` heading per subdirectory. Skips log.md, SCHEMA.md,
+    and _index.md throughout.
+    """
+    root_pages: list[Path] = []
+    subdir_entries: list[tuple[str, list[Path]]] = []
+    subdir_count = 0
+
+    for dirpath, dirnames, filenames in os.walk(wiki_dir):
+        dirnames[:] = sorted(d for d in dirnames if not d.startswith("."))
+        current = Path(dirpath)
+        md_files = sorted(
+            current / f for f in filenames
+            if f.endswith(".md") and f not in _WIKI_SKIP
+        )
+        if not md_files:
+            continue
+
+        if current == wiki_dir:
+            root_pages = md_files
+        else:
+            # Write per-subdirectory flat _index.md
+            _write_index(current, root)
+            rel_name = current.relative_to(wiki_dir).parts[0]
+            subdir_entries.append((rel_name, md_files))
+            subdir_count += 1
+
+    # Write root wiki/_index.md as a tree view
+    lines: list[str] = ["# wiki", ""]
+
+    for subdir_name, pages in sorted(subdir_entries):
+        lines.append(f"## {subdir_name}")
+        lines.append("")
+        lines.append("| File | Description |")
+        lines.append("|------|-------------|")
+        for p in sorted(pages):
+            desc = _read_frontmatter_field(p, "description") or ""
+            rel = p.relative_to(wiki_dir / subdir_name)
+            lines.append(f"| [{rel}]({subdir_name}/{rel}) | {desc} |")
+        lines.append("")
+
+    if root_pages:
+        if subdir_entries:
+            lines.append("## (root)")
+            lines.append("")
+        lines.append("| File | Description |")
+        lines.append("|------|-------------|")
+        for p in root_pages:
+            desc = _read_frontmatter_field(p, "description") or ""
+            lines.append(f"| [{p.name}]({p.name}) | {desc} |")
+        lines.append("")
+
+    if subdir_entries or root_pages:
+        (wiki_dir / "_index.md").write_text(
+            "\n".join(lines) + "\n", encoding="utf-8"
+        )
+
+    print(
+        f"Wiki: reindexed {subdir_count} "
+        f"subdirector{'y' if subdir_count == 1 else 'ies'}"
+    )
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description=(
@@ -158,6 +232,11 @@ def main() -> None:
 
     n = len(dirs)
     print(f"Reindexed {n} director{'y' if n == 1 else 'ies'}")
+
+    # Wiki mode — auto-activated when wiki/SCHEMA.md is present
+    wiki_dir = root / "wiki"
+    if (wiki_dir / "SCHEMA.md").is_file():
+        _reindex_wiki(wiki_dir, root)
 
 
 if __name__ == "__main__":

--- a/plugins/wiki/skills/ingest/SKILL.md
+++ b/plugins/wiki/skills/ingest/SKILL.md
@@ -73,6 +73,8 @@ If the source is narrow and fewer than 5 pages genuinely apply, proceed with wha
 
 **Emergent path selection for new pages:** Based on the existing `wiki/` directory structure read in Pre-Ingest, propose a subdirectory path that fits contextually — place the new page alongside existing pages on related topics. Example: if `wiki/llm-patterns/` already exists with caching pages, a new page on cache invalidation belongs at `wiki/llm-patterns/cache-invalidation.md`, not `wiki/cache-invalidation.md`. If no relevant subdirectory exists, propose a new one whose name reflects the topic cluster. The user can override any proposed path at Step 1b.
 
+**Source summary page:** Always include one source summary page for the ingested source (see [Step 3a](#step-3a-create-source-summary-page)). Place it in a subdirectory that fits contextually alongside related pages — the same emergent path logic applies. Idempotency: if a source summary page already exists for this URL (matched by URL in the `sources:` frontmatter field), update it rather than creating a duplicate — append new claims, never remove existing ones.
+
 ### Step 1b: Confirm Before Writing
 
 Present the proposed changes to the user before modifying any file:
@@ -111,6 +113,45 @@ For topics the source covers with no existing wiki page, create a new page:
 - Include full frontmatter: `name`, `description`, `type`, `confidence`, `sources`, `created`, `updated`
 - Write an initial page body from the source content — follow the structure of existing wiki pages
 - Add `related:` links to existing pages that connect
+
+### Step 3a: Create Source Summary Page
+
+For every ingest, create (or update) a source summary page in addition to the
+concept and entity pages.
+
+**Structure:**
+
+```markdown
+---
+name: <Source Title>
+description: One-sentence summary of the source
+type: source-summary
+sources: [<URL or file path>]
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+---
+
+# <Source Title>
+
+**Author:** ...  **Date:** ...  **URL:** ...
+
+## Key Claims
+
+- Claim 1
+- Claim 2
+
+## Summary
+
+[Structured summary of what the source says]
+```
+
+**Factual-only constraint:** Source summary pages record what the source says.
+No interpretation, synthesis, or evaluation. Those belong in concept and
+synthesis pages.
+
+**Idempotency:** Match an existing source summary page by URL in its `sources:`
+frontmatter. If found, append new claims — do not create a duplicate, do not
+remove existing claims.
 
 ### Step 4: Contradiction Handling
 
@@ -177,6 +218,7 @@ The high-rigor path is never required. It is appropriate when the user wants to 
 
 1. **Separate discussion round per source in bulk mode** — when ingesting multiple sources, running one discussion round per source creates unnecessary back-and-forth. Consolidate all sources into a single takeaways discussion before moving to the page list.
 2. **Overwriting existing prose** — every `git diff` after ingest should show only additions. Rewriting existing content destroys the provenance trail and may silently lose validated information. If existing content is wrong, flag a contradiction marker instead.
+3. **Writing interpretation into source summary pages** — source summary pages record what the source says, not what you conclude from it. Synthesis and evaluation belong in concept or synthesis pages, not in `type: source-summary` pages.
 2. **Skipping Pre-Ingest reads** — proceeding without reading `wiki/_index.md` and `wiki/SCHEMA.md` causes type/confidence misassignment and duplicate page creation. These are required reads, not optional context.
 3. **Silent contradiction** — when source content conflicts with an existing page, the anti-pattern is choosing one version silently. The correct action is the contradiction marker. Unresolved conflicts belong to the user, not the ingest operation.
 4. **Padding to hit the 5-page minimum** — if a narrow source genuinely affects fewer than 5 pages, proceed with what applies. Forcing connections to reach a target count produces low-quality updates that degrade the wiki.

--- a/plugins/wiki/skills/ingest/SKILL.md
+++ b/plugins/wiki/skills/ingest/SKILL.md
@@ -39,6 +39,30 @@ If `wiki/_index.md` or `wiki/SCHEMA.md` is missing, stop and report the missing 
 
 With the source content and wiki context in hand:
 
+### Step 0: Discuss Key Takeaways
+
+Before proposing the page list, present your reading of the source to the user
+and invite correction. This is the default behaviour — skip only when
+`--no-discuss` is passed.
+
+**Single source:**
+
+```
+Here are the key takeaways from [Source Title]:
+- ...
+- ...
+
+Does this capture the important ideas? Anything missing or worth
+emphasizing differently before I propose the page list?
+```
+
+**Multiple sources (bulk mode):** Present takeaways for all sources in a single
+consolidated discussion — one list per source, one round of feedback for all.
+Do not run a separate round-trip per source.
+
+**Opt-out:** If the user passes `--no-discuss`, skip this step entirely and
+proceed directly to Step 1.
+
 ### Step 1: Identify Affected Pages
 
 Identify **5–15 wiki pages** that this source meaningfully informs — both:
@@ -151,7 +175,8 @@ The high-rigor path is never required. It is appropriate when the user wants to 
 
 ## Anti-Pattern Guards
 
-1. **Overwriting existing prose** — every `git diff` after ingest should show only additions. Rewriting existing content destroys the provenance trail and may silently lose validated information. If existing content is wrong, flag a contradiction marker instead.
+1. **Separate discussion round per source in bulk mode** — when ingesting multiple sources, running one discussion round per source creates unnecessary back-and-forth. Consolidate all sources into a single takeaways discussion before moving to the page list.
+2. **Overwriting existing prose** — every `git diff` after ingest should show only additions. Rewriting existing content destroys the provenance trail and may silently lose validated information. If existing content is wrong, flag a contradiction marker instead.
 2. **Skipping Pre-Ingest reads** — proceeding without reading `wiki/_index.md` and `wiki/SCHEMA.md` causes type/confidence misassignment and duplicate page creation. These are required reads, not optional context.
 3. **Silent contradiction** — when source content conflicts with an existing page, the anti-pattern is choosing one version silently. The correct action is the contradiction marker. Unresolved conflicts belong to the user, not the ingest operation.
 4. **Padding to hit the 5-page minimum** — if a narrow source genuinely affects fewer than 5 pages, proceed with what applies. Forcing connections to reach a target count produces low-quality updates that degrade the wiki.

--- a/plugins/wiki/skills/ingest/SKILL.md
+++ b/plugins/wiki/skills/ingest/SKILL.md
@@ -30,9 +30,10 @@ If no source is provided, ask: "What source should I ingest? (URL, file path, or
 Before editing any files, read the project's wiki context:
 
 1. **Read `wiki/_index.md`** — understand the existing page inventory (titles, descriptions, file paths)
-2. **Read `wiki/SCHEMA.md`** — learn the valid `type` values, `confidence` tiers, and relationship types for this project
+2. **List the `wiki/` directory tree** — run `ls -R wiki/` or equivalent to see existing subdirectories and their contents. This informs where new pages should be placed to fit contextually alongside related existing content.
+3. **Read `wiki/SCHEMA.md`** — learn the valid `type` values, `confidence` tiers, and relationship types for this project
 
-If either file is missing, stop and report: "wiki/_index.md not found" or "wiki/SCHEMA.md not found. Run `/wiki:setup` to initialize wiki infrastructure."
+If `wiki/_index.md` or `wiki/SCHEMA.md` is missing, stop and report the missing file. Suggest running `/wiki:setup` to initialize wiki infrastructure.
 
 ## Ingest Protocol
 
@@ -46,6 +47,8 @@ Identify **5–15 wiki pages** that this source meaningfully informs — both:
 
 If the source is narrow and fewer than 5 pages genuinely apply, proceed with what applies. Do not pad.
 
+**Emergent path selection for new pages:** Based on the existing `wiki/` directory structure read in Pre-Ingest, propose a subdirectory path that fits contextually — place the new page alongside existing pages on related topics. Example: if `wiki/llm-patterns/` already exists with caching pages, a new page on cache invalidation belongs at `wiki/llm-patterns/cache-invalidation.md`, not `wiki/cache-invalidation.md`. If no relevant subdirectory exists, propose a new one whose name reflects the topic cluster. The user can override any proposed path at Step 1b.
+
 ### Step 1b: Confirm Before Writing
 
 Present the proposed changes to the user before modifying any file:
@@ -53,11 +56,13 @@ Present the proposed changes to the user before modifying any file:
 ```
 Ready to ingest into N pages:
 - UPDATE wiki/existing-page.md — adding [summary of additions]
-- CREATE wiki/new-topic.md — [description of new page]
+- CREATE wiki/llm-patterns/new-topic.md — [description of new page]
 ...
 
 Proceed? (yes / edit list / cancel)
 ```
+
+Paths for new pages include the proposed subdirectory. The user can edit any path before confirming.
 
 Wait for explicit confirmation. If the user edits the list, revise accordingly. Do not modify any wiki files until confirmed.
 

--- a/plugins/wiki/skills/ingest/SKILL.md
+++ b/plugins/wiki/skills/ingest/SKILL.md
@@ -182,6 +182,14 @@ Report results to the user:
 
 Do not block on lint issues — report and continue.
 
+**Operation log:** Append an entry to `wiki/log.md` (create the file if it does
+not exist). Append-only — never modify existing entries.
+
+```
+## [YYYY-MM-DD] ingest | <Source Title>
+<N> pages updated, <M> created. Pages: wiki/path/a.md, wiki/path/b.md.
+```
+
 ## High-Rigor Path
 
 When the source is a research document (`.research.md` file), offer the user an opt-in SIFT verification step before ingest:

--- a/plugins/wiki/skills/lint/SKILL.md
+++ b/plugins/wiki/skills/lint/SKILL.md
@@ -135,6 +135,16 @@ After presenting audit results, offer to help resolve actionable warnings:
 
   Process URLs one at a time. Do not batch-ask about all URLs at once.
 
+## Post-Lint
+
+After reporting results, append an entry to `wiki/log.md` (create if missing).
+Append-only — never modify existing entries.
+
+```
+## [YYYY-MM-DD] lint | <summary>
+<N> issues found: <brief description>. (or: No issues.)
+```
+
 ## Key Rules
 
 - Audit is read-only (except `--fix` which only regenerates `_index.md` files)

--- a/plugins/wiki/skills/lint/SKILL.md
+++ b/plugins/wiki/skills/lint/SKILL.md
@@ -6,7 +6,7 @@ description: >
   "check lint", "check health", "validate documents", "run validation",
   "audit content quality", "review documents", "check coverage",
   "check freshness", "run health check", or "what needs attention".
-argument-hint: "[lint|check|review|coverage|freshness]"
+argument-hint: "[path/to/file.md]"
 user-invocable: true
 references: []
 ---
@@ -15,6 +15,16 @@ references: []
 
 Observe and report on project content quality. Read-only -- reports but
 does not modify any files (unless `--fix` is used for index regeneration).
+
+## Workflow
+
+1. **Run** `lint.py` against the project root (see [How to Run](#how-to-run))
+2. **Checks** — the script applies five check categories; results are collected (see [The Checks](#the-checks))
+3. **Interpret** — present the findings table to the user (see [Interpreting Results](#interpreting-results))
+4. **Cleanup** — for actionable findings (missing setup, blocked URLs), offer guided resolution (see [Cleanup Actions](#cleanup-actions))
+5. **Post-Lint** — append a summary entry to `wiki/log.md` (see [Post-Lint](#post-lint))
+
+Each phase depends on the previous. Do not offer cleanup actions before presenting results; do not append the log entry before cleanup is complete.
 
 ## How to Run
 
@@ -153,8 +163,8 @@ Append-only — never modify existing entries.
 
 ## Skill Evaluation
 
-Skill quality evaluation is handled entirely by `/wiki:check-skill` — lint does
-not run automated Python-level skill checks. Invoke `/wiki:check-skill` on each
+Skill quality evaluation is handled entirely by `/build:check-skill` — lint does
+not run automated Python-level skill checks. Invoke `/build:check-skill` on each
 skill directory found and incorporate its findings into the report. Do not perform
 independent skill quality judgment here — `check-skill` is the single source of
 truth for what good looks like. Delegating keeps criteria consistent and prevents
@@ -162,7 +172,7 @@ drift between the two skills.
 
 If the user ran lint on a specific skill path, pass that path to `check-skill`.
 If lint ran across the full project, offer: "Found N skill(s) — run
-`/wos:check-skill` to evaluate quality?"
+`/build:check-skill` to evaluate quality?"
 
 ## Anti-Pattern Guards
 

--- a/plugins/wiki/src/wiki/wiki.py
+++ b/plugins/wiki/src/wiki/wiki.py
@@ -144,13 +144,16 @@ def parse_schema(schema_path: Path) -> dict:
 # ── Per-directory checks ───────────────────────────────────────
 
 
+_WIKI_SKIP_NAMES = frozenset({"_index.md", "SCHEMA.md", "log.md"})
+
+
 def check_wiki_orphans(wiki_dir: Path) -> List[dict]:
     """Warn for .md files in wiki_dir not referenced in wiki_dir/_index.md.
 
-    Skips ``_index.md`` and ``SCHEMA.md`` themselves.
+    Skips ``_index.md``, ``SCHEMA.md``, and ``log.md`` themselves.
 
     Args:
-        wiki_dir: Path to the wiki directory.
+        wiki_dir: Path to the wiki directory (root or any subdirectory).
 
     Returns:
         List of issue dicts with severity ``warn``.
@@ -169,15 +172,15 @@ def check_wiki_orphans(wiki_dir: Path) -> List[dict]:
     for md_file in sorted(wiki_dir.iterdir()):
         if not md_file.is_file() or md_file.suffix != ".md":
             continue
-        if md_file.name in ("_index.md", "SCHEMA.md"):
+        if md_file.name in _WIKI_SKIP_NAMES:
             continue
         if md_file.name not in index_text:
             issues.append({
                 "file": str(md_file),
                 "issue": (
                     "Wiki page not in index. "
-                    "Add an entry to wiki/_index.md or run /wiki:lint --fix "
-                    "to regenerate the index."
+                    f"Add an entry to {wiki_dir.name}/_index.md "
+                    "or run /wiki:lint --fix to regenerate the index."
                 ),
                 "severity": "warn",
             })
@@ -213,10 +216,8 @@ def validate_wiki(wiki_dir: Path, schema_path: Path) -> List[dict]:
             "severity": "warn",
         }]
 
-    for md_file in sorted(wiki_dir.iterdir()):
-        if not md_file.is_file() or md_file.suffix != ".md":
-            continue
-        if md_file.name in ("_index.md", "SCHEMA.md"):
+    for md_file in sorted(wiki_dir.rglob("*.md")):
+        if md_file.name in _WIKI_SKIP_NAMES:
             continue
         try:
             text = md_file.read_text(encoding="utf-8")
@@ -238,6 +239,10 @@ def validate_wiki(wiki_dir: Path, schema_path: Path) -> List[dict]:
             continue
         issues.extend(doc.issues(wiki_dir, schema=schema))
 
-    issues.extend(check_wiki_orphans(wiki_dir))
+    # Check orphans in the root and every subdirectory that has a _index.md
+    dirs_with_index: set[Path] = {wiki_dir}
+    dirs_with_index.update(p.parent for p in wiki_dir.rglob("_index.md"))
+    for directory in sorted(dirs_with_index):
+        issues.extend(check_wiki_orphans(directory))
 
     return issues

--- a/plugins/wiki/tests/test_reindex.py
+++ b/plugins/wiki/tests/test_reindex.py
@@ -148,18 +148,79 @@ class TestReindexFirstRunFallback:
         assert "nothing to reindex" in result.stdout
 
 
-class TestReindexDoesNotTouchWikiInventory:
-    def test_wiki_index_untouched_when_wiki_is_not_a_registered_area(
-        self, tmp_path: Path
-    ) -> None:
-        """wiki/_index.md (page inventory) must not be overwritten by reindex."""
+class TestReindexWikiMode:
+    """Wiki reindex mode is activated when wiki/SCHEMA.md is present."""
+
+    def _make_schema(self, wiki_dir: Path) -> None:
+        (wiki_dir / "SCHEMA.md").write_text(
+            "## Page Types\n- concept\n\n"
+            "## Confidence Tiers\n- high\n\n"
+            "## Relationship Types\n- related_to\n",
+            encoding="utf-8",
+        )
+
+    def test_subdir_gets_flat_index(self, tmp_path: Path) -> None:
+        """A wiki subdir with .md files gets its own _index.md."""
+        wiki = tmp_path / "wiki"
+        wiki.mkdir()
+        self._make_schema(wiki)
+        subdir = wiki / "patterns"
+        subdir.mkdir()
+        _make_md(subdir / "caching.md", name="Caching", description="Cache patterns")
+        _agents_with_areas(tmp_path, [("Docs", "docs")])
+        (tmp_path / "docs").mkdir()
+
+        _run(tmp_path)
+
+        assert (subdir / "_index.md").exists()
+        content = (subdir / "_index.md").read_text()
+        assert "caching.md" in content
+
+    def test_root_wiki_index_has_subdir_heading(self, tmp_path: Path) -> None:
+        """Root wiki/_index.md has a ## heading for each subdirectory."""
+        wiki = tmp_path / "wiki"
+        wiki.mkdir()
+        self._make_schema(wiki)
+        subdir = wiki / "patterns"
+        subdir.mkdir()
+        _make_md(subdir / "caching.md", name="Caching", description="Cache patterns")
+        _agents_with_areas(tmp_path, [("Docs", "docs")])
+        (tmp_path / "docs").mkdir()
+
+        _run(tmp_path)
+
+        root_index = wiki / "_index.md"
+        assert root_index.exists()
+        content = root_index.read_text()
+        assert "## patterns" in content
+
+    def test_log_md_not_in_any_index(self, tmp_path: Path) -> None:
+        """log.md is excluded from all generated _index.md files."""
+        wiki = tmp_path / "wiki"
+        wiki.mkdir()
+        self._make_schema(wiki)
+        (wiki / "log.md").write_text("## [2026-01-01] ingest | Source\n")
+        subdir = wiki / "patterns"
+        subdir.mkdir()
+        _make_md(subdir / "caching.md", name="Caching", description="Cache patterns")
+        _agents_with_areas(tmp_path, [("Docs", "docs")])
+        (tmp_path / "docs").mkdir()
+
+        _run(tmp_path)
+
+        root_content = (wiki / "_index.md").read_text()
+        sub_content = (subdir / "_index.md").read_text()
+        assert "log.md" not in root_content
+        assert "log.md" not in sub_content
+
+    def test_no_schema_wiki_not_touched(self, tmp_path: Path) -> None:
+        """Without wiki/SCHEMA.md, reindex does not touch the wiki/ directory."""
         wiki = tmp_path / "wiki"
         wiki.mkdir()
         wiki_index = wiki / "_index.md"
-        expected = "# Wiki Index\n\n| Page | Description | File |\n"
-        wiki_index.write_text(expected)
+        original = "# Wiki Index\n\n| Page | Description | File |\n"
+        wiki_index.write_text(original)
 
-        # wiki/ is not in the areas table
         docs = tmp_path / "docs"
         docs.mkdir()
         _make_md(docs / "topic.md", name="Topic", description="A topic")
@@ -167,7 +228,23 @@ class TestReindexDoesNotTouchWikiInventory:
 
         _run(tmp_path)
 
-        assert wiki_index.read_text() == expected
+        assert wiki_index.read_text() == original
+
+    def test_wiki_mode_output_message(self, tmp_path: Path) -> None:
+        """Reindex prints a wiki subdirectory count when wiki mode activates."""
+        wiki = tmp_path / "wiki"
+        wiki.mkdir()
+        self._make_schema(wiki)
+        subdir = wiki / "patterns"
+        subdir.mkdir()
+        _make_md(subdir / "caching.md", name="Caching", description="Cache patterns")
+        _agents_with_areas(tmp_path, [("Docs", "docs")])
+        (tmp_path / "docs").mkdir()
+
+        result = _run(tmp_path)
+
+        assert "Wiki:" in result.stdout
+        assert "subdirector" in result.stdout
 
 
 class TestReindexUpdatesAgentsMd:

--- a/plugins/wiki/tests/test_wiki.py
+++ b/plugins/wiki/tests/test_wiki.py
@@ -373,3 +373,112 @@ class TestValidateWikiWithViolations:
         assert len(issues) == 1
         assert issues[0]["severity"] == "warn"
         assert "Invalid SCHEMA.md" in issues[0]["issue"]
+
+
+# ── TestValidateWikiRecursive ─────────────────────────────────────
+
+
+def _valid_page_content(name: str = "Page", doc_type: str = "concept") -> str:
+    return (
+        f"---\nname: {name}\ndescription: A page\n"
+        f"type: {doc_type}\nconfidence: high\n"
+        "created: 2026-01-01\nupdated: 2026-01-01\n"
+        f"---\n# {name}\n"
+    )
+
+
+class TestValidateWikiRecursive:
+    def test_page_in_subdir_is_validated(self, tmp_path: Path) -> None:
+        """validate_wiki() walks subdirectories and validates their pages."""
+        from wiki.wiki import validate_wiki
+
+        schema_path = tmp_path / "SCHEMA.md"
+        schema_path.write_text(_schema_md(), encoding="utf-8")
+
+        subdir = tmp_path / "patterns"
+        subdir.mkdir()
+        page = subdir / "caching.md"
+        page.write_text(_valid_page_content("Caching"), encoding="utf-8")
+        (subdir / "_index.md").write_text(
+            "| [caching.md](caching.md) | A page |\n", encoding="utf-8"
+        )
+        (tmp_path / "_index.md").write_text("# wiki\n", encoding="utf-8")
+
+        issues = validate_wiki(tmp_path, schema_path)
+
+        failures = [i for i in issues if i["severity"] == "fail"]
+        assert failures == [], failures
+
+    def test_invalid_type_in_subdir_surfaces_fail(self, tmp_path: Path) -> None:
+        """A type violation in a subdirectory page is reported as fail."""
+        from wiki.wiki import validate_wiki
+
+        schema_path = tmp_path / "SCHEMA.md"
+        schema_path.write_text(_schema_md(), encoding="utf-8")
+
+        subdir = tmp_path / "patterns"
+        subdir.mkdir()
+        page = subdir / "bad.md"
+        page.write_text(
+            _valid_page_content("Bad", doc_type="unknown-type"), encoding="utf-8"
+        )
+        (subdir / "_index.md").write_text(
+            "| [bad.md](bad.md) | A page |\n", encoding="utf-8"
+        )
+        (tmp_path / "_index.md").write_text("# wiki\n", encoding="utf-8")
+
+        issues = validate_wiki(tmp_path, schema_path)
+
+        failures = [i for i in issues if i["severity"] == "fail"]
+        assert any("unknown-type" in i["issue"] for i in failures)
+
+    def test_log_md_not_validated_as_wiki_page(self, tmp_path: Path) -> None:
+        """log.md is excluded from page validation — no missing-frontmatter warnings."""
+        from wiki.wiki import validate_wiki
+
+        schema_path = tmp_path / "SCHEMA.md"
+        schema_path.write_text(_schema_md(), encoding="utf-8")
+        (tmp_path / "_index.md").write_text("# wiki\n", encoding="utf-8")
+        (tmp_path / "log.md").write_text(
+            "## [2026-01-01] ingest | Source\n1 page created.\n",
+            encoding="utf-8",
+        )
+
+        issues = validate_wiki(tmp_path, schema_path)
+
+        log_issues = [i for i in issues if "log.md" in i["file"]]
+        assert log_issues == []
+
+
+class TestCheckWikiOrphansSkipsLogMd:
+    def test_log_md_not_reported_as_orphan(self, tmp_path: Path) -> None:
+        """log.md alongside a _index.md that doesn't list it is not an orphan."""
+        from wiki.wiki import check_wiki_orphans
+
+        (tmp_path / "_index.md").write_text("# Index\n", encoding="utf-8")
+        (tmp_path / "log.md").write_text(
+            "## [2026-01-01] ingest | Source\n", encoding="utf-8"
+        )
+
+        issues = check_wiki_orphans(tmp_path)
+
+        assert issues == []
+
+
+class TestCheckWikiOrphansSubdirMessage:
+    def test_error_message_references_subdir_index(self, tmp_path: Path) -> None:
+        """Orphan in a subdir references that subdir's _index.md, not wiki/_index.md."""
+        from wiki.wiki import check_wiki_orphans
+
+        subdir = tmp_path / "patterns"
+        subdir.mkdir()
+        (subdir / "_index.md").write_text("# patterns\n", encoding="utf-8")
+        (subdir / "orphan.md").write_text(
+            "---\nname: X\ndescription: Y\n---\n", encoding="utf-8"
+        )
+
+        issues = check_wiki_orphans(subdir)
+
+        assert len(issues) == 1
+        assert "patterns/_index.md" in issues[0]["issue"]
+        assert "wiki/_index.md" not in issues[0]["issue"]

--- a/plugins/wiki/tests/test_wiki.py
+++ b/plugins/wiki/tests/test_wiki.py
@@ -161,7 +161,7 @@ class TestCheckWikiOrphans:
 
         assert len(issues) == 1
         assert issues[0]["severity"] == "warn"
-        assert "wiki/_index.md" in issues[0]["issue"]
+        assert "_index.md" in issues[0]["issue"]
 
     def test_indexed_file_no_issue(self, tmp_path: Path) -> None:
         from wiki.wiki import check_wiki_orphans


### PR DESCRIPTION
## Summary

- **#277** — `wiki.py` and `reindex.py` updated for recursive subdirectory walk; ingest now reads the existing wiki tree and proposes emergent subdirectory paths for new pages
- **#278** — Ingest defaults to a discuss-before-write step; presents key takeaways before proposing pages (`--no-discuss` to skip)
- **#276** — Every ingest creates or updates a factual-only source summary page (`type: source-summary`)
- **#275** — Both `ingest` and `lint` append an operation log entry to `wiki/log.md` after each run
- `lint/SKILL.md` skill quality fixes: corrected `/build:check-skill` references, `argument-hint`, and explicit numbered `## Workflow` section
- Wiki plugin bumped `0.1.2 → 0.1.3`

## Test plan

- [ ] `python3 -m pytest plugins/wiki/tests/ -v` — all 269 tests pass
- [ ] `python3 -m pytest plugins/wiki/tests/test_wiki.py -k "log"` — log.md exclusion from orphan checks
- [ ] `python3 -m pytest plugins/wiki/tests/test_reindex.py -k "wiki"` — wiki subtree reindex produces per-subdir `_index.md`
- [ ] Read `plugins/wiki/skills/ingest/SKILL.md` — confirm four additions: wiki tree read, discuss step, source summary, log append
- [ ] Read `plugins/wiki/skills/lint/SKILL.md` — confirm log append, `/build:check-skill` references, and `## Workflow` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)