### PR TITLE
fix: replace all /wos:X skill invocations with correct /plugin:X namespaces

### DIFF
--- a/docs/designs/2026-04-15-stale-wos-namespace-sweep.design.md
+++ b/docs/designs/2026-04-15-stale-wos-namespace-sweep.design.md
@@ -1,0 +1,75 @@
+---
+name: Stale wos: Namespace Sweep
+description: Replace all /wos:X skill invocations across plugins/ with correct /plugin:X namespaces
+type: design
+status: draft
+related: []
+---
+
+# Stale wos: Namespace Sweep
+
+## Purpose
+
+The toolkit was migrated from a monolithic `wos` namespace to per-plugin
+namespaces (`wiki:`, `work:`, `build:`). Skill SKILL.md files still contain
+invocation references using the old `/wos:X` form. These produce wrong routing
+at invocation time and mislead users reading the skills.
+
+## Behavior
+
+Each stale `/wos:X` reference is replaced with the correct `/plugin:X` form.
+No logic changes — mechanical find-and-replace only.
+
+## Replacement Mapping
+
+| Old | New |
+|-----|-----|
+| `/wos:setup` | `/wiki:setup` |
+| `/wos:research` | `/wiki:research` |
+| `/wos:ingest` | `/wiki:ingest` |
+| `/wos:scope-work` | `/work:scope-work` |
+| `/wos:plan-work` | `/work:plan-work` |
+| `/wos:start-work` | `/work:start-work` |
+| `/wos:finish-work` | `/work:finish-work` |
+| `/wos:check-work` | `/work:verify-work` |
+| `/wos:build-skill` | `/build:build-skill` |
+| `/wos:build-rule` | `/build:build-rule` |
+| `/wos:build-hook` | `/build:build-hook` |
+| `/wos:build-subagent` | `/build:build-subagent` |
+| `/wos:check-hook` | `/build:check-hook` |
+| `/wos:check-rule` | `/build:check-rule` |
+| `/wos:check-subagent` | `/build:check-subagent` |
+| `/wos:retrospective` | *(remove sentence)* |
+
+## Files Affected
+
+| File | Changes |
+|------|---------|
+| `plugins/wiki/skills/lint/SKILL.md` | `/wos:setup` ×3 |
+| `plugins/wiki/skills/ingest/SKILL.md` | `/wos:research` ×1 |
+| `plugins/wiki/skills/setup/SKILL.md` | `/wos:research`, `/wos:ingest`, `/wos:scope-work` ×2, `/wos:plan-work`, `/wos:start-work` |
+| `plugins/work/skills/plan-work/SKILL.md` | `wos:scope-work` ×1, `/wos:start-work` ×1 |
+| `plugins/work/skills/scope-work/SKILL.md` | `/wos:plan-work` ×1 |
+| `plugins/work/skills/start-work/SKILL.md` | `/wos:check-work` ×2, `/wos:finish-work` ×1 |
+| `plugins/work/skills/finish-work/SKILL.md` | `/wos:retrospective` — remove sentence |
+| `plugins/build/skills/build-subagent/SKILL.md` | `/wos:build-skill` ×2 |
+| `plugins/build/skills/check-subagent/SKILL.md` | `/wos:build-subagent` ×1 |
+| `plugins/build/skills/check-rule/SKILL.md` | `/wos:check-rule` ×2 (self-references in header/examples) |
+| `plugins/build/skills/build-hook/SKILL.md` | `/wos:build-skill`, `/wos:build-rule`, `/wos:check-hook` |
+| `plugins/build/skills/check-skill-chain/SKILL.md` | `/wos:start-work`, `/wos:build-skill` |
+| `plugins/build/skills/build-skill/SKILL.md` | `/wos:build-hook`, `/wos:build-rule`, `/wos:build-subagent` |
+| `plugins/build/skills/build-rule/SKILL.md` | `/wos:build-hook`, `/wos:build-skill` |
+
+## Out of Scope
+
+- `<!-- wos:begin -->`, `<!-- wos:end -->`, `<!-- wos:layout: ... -->` — structural
+  markers written into user AGENTS.md files. Renaming these breaks existing projects.
+- Prose references to "WOS" as a product/system name (not invocations).
+
+## Acceptance Criteria
+
+- `grep -r "wos:" plugins/ --include="SKILL.md"` returns only structural marker
+  references (`<!-- wos:begin -->`, `<!-- wos:end -->`, `<!-- wos:layout:`) — zero
+  `/wos:X` skill invocations
+- All 14 affected files read correctly with updated references
+- No changes to skill logic, workflow steps, or non-invocation content

--- a/docs/plans/2026-04-15-stale-wos-namespace-sweep.plan.md
+++ b/docs/plans/2026-04-15-stale-wos-namespace-sweep.plan.md
@@ -1,0 +1,279 @@
+---
+name: Stale wos: Namespace Sweep
+description: Replace all /wos:X skill invocations in plugins/ SKILL.md files with correct /plugin:X namespaces
+type: plan
+status: completed
+branch: fix/stale-wos-namespace-sweep
+related:
+  - docs/designs/2026-04-15-stale-wos-namespace-sweep.design.md
+---
+
+# Stale wos: Namespace Sweep
+
+## Goal
+
+Replace every `/wos:X` skill invocation across all SKILL.md files with the
+correct `/plugin:X` namespace. Fourteen files affected; one removal
+(`/wos:retrospective`). No logic changes — mechanical find-and-replace only.
+
+## Scope
+
+Must have:
+- All `/wos:X` invocations updated per the replacement mapping below
+- `/wos:check-work` → `/work:verify-work` (skill was renamed, not just re-namespaced)
+- Sentence invoking `/wos:retrospective` removed from `finish-work/SKILL.md`
+
+Won't have:
+- Changes to `<!-- wos:begin -->`, `<!-- wos:end -->`, `<!-- wos:layout: ... -->` structural markers
+- Changes to prose that mentions "WOS" as a product/system name (non-invocation)
+- Any changes to skill logic, workflow steps, or Python code
+
+## Approach
+
+Work plugin-by-plugin: wiki → work → build. Each chunk is a single commit.
+All changes are in SKILL.md files only. The acceptance gate is a grep that
+returns zero `/wos:` skill invocations across all SKILL.md files.
+
+**Replacement mapping:**
+
+| Old | New |
+|-----|-----|
+| `/wos:setup` | `/wiki:setup` |
+| `/wos:research` | `/wiki:research` |
+| `/wos:ingest` | `/wiki:ingest` |
+| `/wos:scope-work` | `/work:scope-work` |
+| `/wos:plan-work` | `/work:plan-work` |
+| `/wos:start-work` | `/work:start-work` |
+| `/wos:finish-work` | `/work:finish-work` |
+| `/wos:check-work` | `/work:verify-work` |
+| `/wos:build-skill` | `/build:build-skill` |
+| `/wos:build-rule` | `/build:build-rule` |
+| `/wos:build-hook` | `/build:build-hook` |
+| `/wos:build-subagent` | `/build:build-subagent` |
+| `/wos:check-hook` | `/build:check-hook` |
+| `/wos:check-rule` | `/build:check-rule` |
+| `/wos:check-subagent` | `/build:check-subagent` |
+| `/wos:retrospective` | *(remove sentence entirely)* |
+
+## File Changes
+
+- Modify: `plugins/wiki/skills/lint/SKILL.md`
+- Modify: `plugins/wiki/skills/ingest/SKILL.md`
+- Modify: `plugins/wiki/skills/setup/SKILL.md`
+- Modify: `plugins/work/skills/plan-work/SKILL.md`
+- Modify: `plugins/work/skills/scope-work/SKILL.md`
+- Modify: `plugins/work/skills/start-work/SKILL.md`
+- Modify: `plugins/work/skills/finish-work/SKILL.md`
+- Modify: `plugins/build/skills/build-subagent/SKILL.md`
+- Modify: `plugins/build/skills/check-subagent/SKILL.md`
+- Modify: `plugins/build/skills/check-rule/SKILL.md`
+- Modify: `plugins/build/skills/build-hook/SKILL.md`
+- Modify: `plugins/build/skills/check-skill-chain/SKILL.md`
+- Modify: `plugins/build/skills/build-skill/SKILL.md`
+- Modify: `plugins/build/skills/build-rule/SKILL.md`
+
+## Tasks
+
+---
+
+### Chunk 1: wiki plugin
+
+---
+
+### Task 1: Fix wiki/skills/lint/SKILL.md
+
+Replace all three `/wos:setup` references with `/wiki:setup`.
+
+**Occurrences (3):**
+- Line ~120: `Offer to run /wos:setup to initialize`
+- Line ~122: `Offer to run /wos:setup to add`
+- Line ~161: `Use /wos:setup to initialize missing project structure`
+
+- [ ] Replace all three `/wos:setup` → `/wiki:setup`
+- [ ] Verify: `grep "wos:" plugins/wiki/skills/lint/SKILL.md` returns no skill invocations
+- [ ] Commit: `fix(wiki): update stale wos: invocations in lint skill`
+
+---
+
+### Task 2: Fix wiki/skills/ingest/SKILL.md
+
+Replace one `/wos:research` reference with `/wiki:research`.
+
+**Occurrence (1):**
+- Line ~200: `Invoke /wos:research with the document to validate sources`
+
+- [ ] Replace `/wos:research` → `/wiki:research`
+- [ ] Verify: `grep "wos:" plugins/wiki/skills/ingest/SKILL.md` returns no skill invocations
+- [ ] Commit: `fix(wiki): update stale wos: invocations in ingest skill`
+
+---
+
+### Task 3: Fix wiki/skills/setup/SKILL.md
+
+Replace six invocation references across the file.
+
+**Occurrences (6):**
+- `/wos:research` → `/wiki:research` (×1, line ~109)
+- `/wos:ingest` → `/wiki:ingest` (×1, line ~109)
+- `/wos:scope-work` → `/work:scope-work` (×2, lines ~111, ~113)
+- `/wos:plan-work` → `/work:plan-work` (×1, line ~111)
+- `/wos:start-work` → `/work:start-work` (×1, line ~111)
+
+- [ ] Apply all six replacements
+- [ ] Verify: `grep "wos:" plugins/wiki/skills/setup/SKILL.md` returns only structural marker lines (`<!-- wos:begin -->`, `<!-- wos:end -->`, `<!-- wos:layout: -->`) — zero `/wos:X` skill invocations
+- [ ] Commit: `fix(wiki): update stale wos: invocations in setup skill`
+
+---
+
+### Chunk 2: work plugin
+
+---
+
+### Task 4: Fix work/skills/plan-work/SKILL.md
+
+**Occurrences (2):**
+- `wos:scope-work` → `/work:scope-work` (×1, line ~79, missing leading slash)
+- `/wos:start-work` → `/work:start-work` (×1, line ~111)
+
+- [ ] Apply both replacements
+- [ ] Verify: `grep "wos:" plugins/work/skills/plan-work/SKILL.md` returns only structural marker lines — zero skill invocations
+- [ ] Commit: `fix(work): update stale wos: invocations in plan-work skill`
+
+---
+
+### Task 5: Fix work/skills/scope-work/SKILL.md
+
+**Occurrences (2):**
+- `/wos:plan-work` → `/work:plan-work` (×1, line ~90)
+- `<!-- wos:layout: ... -->` — structural marker, do NOT change
+
+- [ ] Replace `/wos:plan-work` → `/work:plan-work`
+- [ ] Verify: `grep "wos:" plugins/work/skills/scope-work/SKILL.md` returns only structural marker lines — zero skill invocations
+- [ ] Commit: `fix(work): update stale wos: invocations in scope-work skill`
+
+---
+
+### Task 6: Fix work/skills/start-work/SKILL.md
+
+**Occurrences (3):**
+- `/wos:check-work` → `/work:verify-work` (×2, lines ~105, ~109) — note: skill was renamed
+- `/wos:finish-work` → `/work:finish-work` (×1, line ~116)
+
+- [ ] Apply all three replacements, using `/work:verify-work` (not `/work:check-work`)
+- [ ] Verify: `grep "wos:" plugins/work/skills/start-work/SKILL.md` returns no skill invocations
+- [ ] Commit: `fix(work): update stale wos: invocations in start-work skill`
+
+---
+
+### Task 7: Fix work/skills/finish-work/SKILL.md
+
+**Occurrences (2):**
+- `/wos:retrospective` (×2, lines ~121, ~123) — remove the sentence(s) that invoke it
+
+The two lines to remove are:
+```
+> "Work is integrated. Would you like to run a retrospective? Invoke `/wos:retrospective` to review this session."
+
+Do not embed the retrospective workflow here — it lives in `/wos:retrospective`.
+```
+
+Remove the retrospective offer block entirely. The step should end after "After integration completes, offer:" with no follow-on content, or the step itself can be removed if it has no remaining content.
+
+- [ ] Remove retrospective offer block
+- [ ] Verify: `grep "wos:" plugins/work/skills/finish-work/SKILL.md` returns no skill invocations
+- [ ] Commit: `fix(work): remove stale wos:retrospective from finish-work skill`
+
+---
+
+### Chunk 3: build plugin
+
+---
+
+### Task 8: Fix build/skills/build-subagent/SKILL.md
+
+**Occurrences (2):**
+- `/wos:build-skill` → `/build:build-skill` (×2, lines ~39, ~224)
+
+- [ ] Replace both occurrences
+- [ ] Verify: `grep "wos:" plugins/build/skills/build-subagent/SKILL.md` returns no skill invocations
+- [ ] Commit: `fix(build): update stale wos: invocations in build-subagent skill`
+
+---
+
+### Task 9: Fix build/skills/check-subagent/SKILL.md
+
+**Occurrences (1):**
+- `/wos:build-subagent` → `/build:build-subagent` (×1, line ~234)
+
+- [ ] Replace the occurrence
+- [ ] Verify: `grep "wos:" plugins/build/skills/check-subagent/SKILL.md` returns no skill invocations
+- [ ] Commit: `fix(build): update stale wos: invocations in check-subagent skill`
+
+---
+
+### Task 10: Fix build/skills/check-rule/SKILL.md
+
+**Occurrences (2):**
+- `# /wos:check-rule` → `# /build:check-rule` (header, line ~11)
+- `/wos:check-rule` in example (line ~121)
+
+- [ ] Replace both occurrences
+- [ ] Verify: `grep "wos:" plugins/build/skills/check-rule/SKILL.md` returns no skill invocations
+- [ ] Commit: `fix(build): update stale wos: invocations in check-rule skill`
+
+---
+
+### Task 11: Fix build/skills/build-hook/SKILL.md
+
+**Occurrences (3):**
+- `/wos:build-skill` → `/build:build-skill` (×1, line ~29)
+- `/wos:build-rule` → `/build:build-rule` (×1, line ~31)
+- `/wos:check-hook` → `/build:check-hook` (×1, line ~354)
+
+- [ ] Apply all three replacements
+- [ ] Verify: `grep "wos:" plugins/build/skills/build-hook/SKILL.md` returns no skill invocations
+- [ ] Commit: `fix(build): update stale wos: invocations in build-hook skill`
+
+---
+
+### Task 12: Fix build/skills/check-skill-chain/SKILL.md
+
+**Occurrences (2):**
+- `/wos:start-work` → `/work:start-work` (×1, line ~39)
+- `/wos:build-skill` → `/build:build-skill` (×1, line ~60)
+
+- [ ] Apply both replacements
+- [ ] Verify: `grep "wos:" plugins/build/skills/check-skill-chain/SKILL.md` returns no skill invocations
+- [ ] Commit: `fix(build): update stale wos: invocations in check-skill-chain skill`
+
+---
+
+### Task 13: Fix build/skills/build-skill/SKILL.md
+
+**Occurrences (3):**
+- `/wos:build-hook` → `/build:build-hook` (×1, line ~67)
+- `/wos:build-rule` → `/build:build-rule` (×1, line ~68)
+- `/wos:build-subagent` → `/build:build-subagent` (×1, line ~69)
+
+- [ ] Apply all three replacements
+- [ ] Verify: `grep "wos:" plugins/build/skills/build-skill/SKILL.md` returns no skill invocations
+- [ ] Commit: `fix(build): update stale wos: invocations in build-skill skill`
+
+---
+
+### Task 14: Fix build/skills/build-rule/SKILL.md
+
+**Occurrences (2):**
+- `/wos:build-hook` → `/build:build-hook` (×1, line ~29)
+- `/wos:build-skill` → `/build:build-skill` (×1, line ~30)
+
+- [ ] Apply both replacements
+- [ ] Verify: `grep "wos:" plugins/build/skills/build-rule/SKILL.md` returns no skill invocations
+- [ ] Commit: `fix(build): update stale wos: invocations in build-rule skill`
+
+---
+
+## Validation
+
+- [ ] `grep -r "wos:" plugins/ --include="SKILL.md" -n` — output contains only structural marker lines (`<!-- wos:begin -->`, `<!-- wos:end -->`, `<!-- wos:layout:`); zero `/wos:X` skill invocations remain
+- [ ] `python3 -m pytest plugins/wiki/tests/ -v` — all tests pass (no skill files touched by Python tests, but confirms no regressions)

--- a/plugins/build/.claude-plugin/plugin.json
+++ b/plugins/build/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "build",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Skills for creating and refining Claude Code skills, rules, hooks, and subagents.",
   "author": {
     "name": "Brandon Beidel"

--- a/plugins/build/pyproject.toml
+++ b/plugins/build/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "check"
-version = "0.1.0"
+version = "0.1.1"
 description = "Claude Code plugin for auditing Claude Code skills and rules for quality issues."
 requires-python = ">=3.9"
 dependencies = []

--- a/plugins/build/skills/build-hook/SKILL.md
+++ b/plugins/build/skills/build-hook/SKILL.md
@@ -26,9 +26,9 @@ Determine whether a hook is the right primitive before asking hook-specific ques
 - **Goal is an unconditional permanent block** (never allow tool X, no conditions, ever) →
   suggest `settings.json` `permissions.deny` instead. No logic, no script, cannot be bypassed by exit codes.
 - **Goal is advisory guidance or procedural instruction** (prefer X, follow this convention) →
-  suggest CLAUDE.md or `/wos:build-skill` instead. Hooks enforce mandatory behavior regardless of LLM judgment — not preferences.
+  suggest CLAUDE.md or `/build:build-skill` instead. Hooks enforce mandatory behavior regardless of LLM judgment — not preferences.
 - **Goal is a semantic judgment on file content** (convention too nuanced for grep) →
-  suggest `/wos:build-rule` instead. Rules use LLM evaluation; hooks use shell scripts.
+  suggest `/build:build-rule` instead. Rules use LLM evaluation; hooks use shell scripts.
 - **Goal has a specific lifecycle trigger and must fire regardless of LLM judgment** →
   proceed to Elicit.
 
@@ -351,7 +351,7 @@ the hook.
 
 After testing, offer:
 
-> "Run `/wos:check-hook` to audit the configuration for coverage gaps,
+> "Run `/build:check-hook` to audit the configuration for coverage gaps,
 > misconfigurations, and safety issues?"
 
 ## Anti-Pattern Guards

--- a/plugins/build/skills/build-rule/SKILL.md
+++ b/plugins/build/skills/build-rule/SKILL.md
@@ -9,7 +9,7 @@ references:
   - ../../_shared/references/primitive-routing.md
 ---
 
-# /wos:build-rule
+# /build:build-rule
 
 Create semantic enforcement rules that Claude evaluates for compliance.
 Rules capture conventions too nuanced for traditional linters — architectural
@@ -26,8 +26,8 @@ Before proceeding, confirm a rule is the right mechanism. Full decision matrix: 
 
 **Not right — redirect instead:**
 - Check is shell-expressible (grep, file existence, regex) → recommend a hook or linter
-- Enforcement must fire at a lifecycle event (pre-commit, pre-tool-use) → redirect to `/wos:build-hook`
-- Convention is procedural (multi-step workflow Claude should follow) → redirect to CLAUDE.md or `/wos:build-skill`
+- Enforcement must fire at a lifecycle event (pre-commit, pre-tool-use) → redirect to `/build:build-hook`
+- Convention is procedural (multi-step workflow Claude should follow) → redirect to CLAUDE.md or `/build:build-skill`
 
 **A rule is right when:** enforcement requires LLM judgment on static file content and the convention is too nuanced for grep or an AST linter. Proceed only when this holds.
 

--- a/plugins/build/skills/build-skill/SKILL.md
+++ b/plugins/build/skills/build-skill/SKILL.md
@@ -64,9 +64,9 @@ It's OK to briefly explain terms if you're in doubt, and feel free to clarify te
 Before eliciting, confirm a skill is the right artifact. Full decision matrix: [primitive-routing.md](../../_shared/references/primitive-routing.md).
 
 Ask: "Building this as a **skill** (triggered instruction set) — right primitive?" Redirect if:
-- Must fire at a lifecycle event regardless of LLM judgment → `/wos:build-hook`
-- Evaluates static file content for semantic compliance → `/wos:build-rule`
-- Needs context isolation or different tool permissions → `/wos:build-subagent`
+- Must fire at a lifecycle event regardless of LLM judgment → `/build:build-hook`
+- Evaluates static file content for semantic compliance → `/build:build-rule`
+- Needs context isolation or different tool permissions → `/build:build-subagent`
 - Is advisory always-on context (not a procedure) → CLAUDE.md section
 
 Proceed without a gate if intent is unambiguous; ask one clarifying question if uncertain.

--- a/plugins/build/skills/build-subagent/SKILL.md
+++ b/plugins/build/skills/build-subagent/SKILL.md
@@ -36,7 +36,7 @@ A subagent is justified only when at least one holds:
 
 If none apply, recommend a skill instead:
 
-> "A skill may be more appropriate here — lower overhead, same-context execution, no fork required. Use `/wos:build-skill` instead?"
+> "A skill may be more appropriate here — lower overhead, same-context execution, no fork required. Use `/build:build-skill` instead?"
 
 Do not proceed to intake until the user confirms a subagent is the right primitive.
 
@@ -221,7 +221,7 @@ was written.
 ## Key Instructions
 
 - **Won't write the definition file until the user explicitly approves the draft** — Step 6 is a hard gate; no file is written before it passes
-- **Won't proceed to intake if a skill would suffice** — Step 1 justification check is mandatory; redirect to `/wos:build-skill` if none of the three justification conditions hold
+- **Won't proceed to intake if a skill would suffice** — Step 1 justification check is mandatory; redirect to `/build:build-skill` if none of the three justification conditions hold
 
 ## Anti-Pattern Guards
 

--- a/plugins/build/skills/check-rule/SKILL.md
+++ b/plugins/build/skills/check-rule/SKILL.md
@@ -8,7 +8,7 @@ references:
   - references/repair-playbook.md
 ---
 
-# /wos:check-rule
+# /build:check-rule
 
 Evaluate the quality of an existing rule library. Checks format validity
 deterministically, then evaluates six semantic quality dimensions per rule
@@ -118,7 +118,7 @@ Close with a summary line:
 ## Example
 
 <example>
-User: `/wos:check-rule docs/rules/`
+User: `/build:check-rule docs/rules/`
 
 Step 1 — Discovers 3 rules: staging-layer-purity.rule.md, api-input-validation.rule.md, naming-conventions.rule.md
 

--- a/plugins/build/skills/check-skill-chain/SKILL.md
+++ b/plugins/build/skills/check-skill-chain/SKILL.md
@@ -36,7 +36,7 @@ skill-chain manifest for structural and contract correctness with an opt-in repa
    - Frontmatter: `name`, `description`, `type: chain`, `goal`, `negative-scope`
    - Body: `## Steps` pipe table — `| Step | Skill | Input Contract | Output Contract | Gate |`
 4. **Hard gate** — present for user review. State: "This is a design artifact — invoke
-   `/wos:start-work` or run each skill manually to execute." Do not invoke any step.
+   `/work:start-work` or run each skill manually to execute." Do not invoke any step.
 
 ### Manifest Mode
 
@@ -57,7 +57,7 @@ skill-chain manifest for structural and contract correctness with an opt-in repa
    For each selected finding:
    - Manifest fix: propose targeted edit, show diff, apply on confirmation
    - SKILL.md fix: propose targeted edit, show diff, apply on confirmation
-   - Missing skill (step references a skill that doesn't exist): invoke `/wos:build-skill`
+   - Missing skill (step references a skill that doesn't exist): invoke `/build:build-skill`
      inline to create it, then re-check existence
 5. **Re-verify** — after each applied fix, re-run `scripts/lint.py` and re-run
    cross-reference on affected steps. Return to findings presentation.

--- a/plugins/build/skills/check-subagent/SKILL.md
+++ b/plugins/build/skills/check-subagent/SKILL.md
@@ -231,7 +231,7 @@ Audited N agent(s): N ok, N warn, N fail
 
 If any issues were found, add a one-sentence recommendation, e.g.:
 
-> "3 agents have over-permissioned tool sets — run `/wos:build-subagent`
+> "3 agents have over-permissioned tool sets — run `/build:build-subagent`
 > to rebuild with least-privilege tool selection."
 
 ## Anti-Pattern Guards

--- a/plugins/wiki/.claude-plugin/plugin.json
+++ b/plugins/wiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Skills for building and maintaining structured project context — setup, research, ingest, and lint.",
   "author": {
     "name": "Brandon Beidel"

--- a/plugins/wiki/pyproject.toml
+++ b/plugins/wiki/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wiki"
-version = "0.1.3"
+version = "0.1.4"
 description = "Claude Code plugin for building and maintaining structured project context."
 requires-python = ">=3.9"
 dependencies = []

--- a/plugins/wiki/skills/ingest/SKILL.md
+++ b/plugins/wiki/skills/ingest/SKILL.md
@@ -197,7 +197,7 @@ When the source is a research document (`.research.md` file), offer the user an 
 > "This source is a research document. Would you like to run SIFT verification before ingesting? (default: skip)"
 
 - **Skip (default):** Proceed directly to the Ingest Protocol
-- **Verify:** Invoke `/wos:research` with the document to validate sources, then ingest the verified findings
+- **Verify:** Invoke `/wiki:research` with the document to validate sources, then ingest the verified findings
 
 The high-rigor path is never required. It is appropriate when the user wants to confirm source credibility before committing findings to the wiki.
 

--- a/plugins/wiki/skills/lint/SKILL.md
+++ b/plugins/wiki/skills/lint/SKILL.md
@@ -117,9 +117,9 @@ All checks passed.
 
 After presenting audit results, offer to help resolve actionable warnings:
 
-- **Missing AGENTS.md or CLAUDE.md:** Offer to run `/wos:setup` to
+- **Missing AGENTS.md or CLAUDE.md:** Offer to run `/wiki:setup` to
   initialize. Confirm with the user before writing any files.
-- **AGENTS.md missing WOS markers:** Offer to run `/wos:setup` to add
+- **AGENTS.md missing WOS markers:** Offer to run `/wiki:setup` to add
   the WOS-managed section. Confirm before modifying existing content.
 - **CLAUDE.md missing @AGENTS.md reference:** Offer to add the reference.
   Do not rewrite CLAUDE.md contents — only add the `@AGENTS.md` line.
@@ -158,7 +158,7 @@ Append-only — never modify existing entries.
 ## Key Rules
 
 - Audit is read-only (except `--fix` which only regenerates `_index.md` files)
-- Use `/wos:setup` to initialize missing project structure
+- Use `/wiki:setup` to initialize missing project structure
 - Empty project (no `docs/` directory) exits 0 with no issues
 
 ## Skill Evaluation

--- a/plugins/wiki/skills/setup/SKILL.md
+++ b/plugins/wiki/skills/setup/SKILL.md
@@ -106,11 +106,11 @@ After scaffolding is complete, ask:
 Based on the response, suggest a concrete WOS skill sequence:
 
 - **Research-oriented** (exploring a domain, comparing options, investigating):
-  `/wos:research` → `/wos:ingest`
+  `/wiki:research` → `/wiki:ingest`
 - **Implementation-oriented** (building a feature, fixing something, clear goal):
-  `/wos:scope-work` → `/wos:plan-work` → `/wos:start-work`
+  `/work:scope-work` → `/work:plan-work` → `/work:start-work`
 - **Exploratory / unsure**:
-  Start with `/wos:scope-work` to clarify the problem space
+  Start with `/work:scope-work` to clarify the problem space
 
 If the user declines or skips, move on without suggesting.
 

--- a/plugins/work/.claude-plugin/plugin.json
+++ b/plugins/work/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "work",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Skills for the full work lifecycle — scope-work, plan-work, start-work, verify-work, and finish-work.",
   "author": {
     "name": "Brandon Beidel"

--- a/plugins/work/skills/finish-work/SKILL.md
+++ b/plugins/work/skills/finish-work/SKILL.md
@@ -114,15 +114,6 @@ Summary:
   confirmation, update plan status to `abandoned` if plan exists, delete
   branch, clean up worktree.
 
-### 6. Optional Retrospective
-
-After integration completes, offer:
-
-> "Work is integrated. Would you like to run a retrospective? Invoke `/wos:retrospective` to review this session."
-
-Do not embed the retrospective workflow here — it lives in `/wos:retrospective`.
-If the user declines, close out without further action.
-
 ## Key Instructions
 
 - **Won't present integration options until tests pass** — the hard gate in Step 1 enforces this; failing tests must be fixed before continuing

--- a/plugins/work/skills/plan-work/SKILL.md
+++ b/plugins/work/skills/plan-work/SKILL.md
@@ -76,7 +76,7 @@ full format, user options, and revision-vs-supersede decision tree.
 
 Present the user with three options:
 
-1. **Return to scope-work** — invoke `wos:scope-work` with this feedback
+1. **Return to scope-work** — invoke `/work:scope-work` with this feedback
    to revise the design. Follow the "supersede, don't edit" pattern.
 2. **Proceed with modified scope** — revise the plan in-place: update
    Must/Won't boundaries, adjust or remove affected tasks, and document
@@ -108,7 +108,7 @@ When the user approves, set `status: approved` in the plan's frontmatter.
 
 ### 7. Hand Off
 
-Present to user: "Plan approved. Ready to invoke `/wos:start-work` to
+Present to user: "Plan approved. Ready to invoke `/work:start-work` to
 begin implementation — proceed?"
 
 Wait for user confirmation before invoking the skill. The plan should be

--- a/plugins/work/skills/scope-work/SKILL.md
+++ b/plugins/work/skills/scope-work/SKILL.md
@@ -87,7 +87,7 @@ conventions and examples.
 
 ### 6. Hand Off
 
-- Present to user: "Design approved. Ready to invoke `/wos:plan-work`
+- Present to user: "Design approved. Ready to invoke `/work:plan-work`
   to turn this into an implementation plan — proceed?"
 - Wait for user confirmation before invoking the skill.
 - The plan should reference this design doc via its `related` field,

--- a/plugins/work/skills/start-work/SKILL.md
+++ b/plugins/work/skills/start-work/SKILL.md
@@ -102,18 +102,18 @@ On failure, consult [recovery patterns](references/recovery-patterns.md).
 ### 6. Validate
 
 When all tasks are checked, present to user: "All tasks complete. Ready
-to invoke `/wos:check-work` to verify the plan succeeded — proceed?"
+to invoke `/work:verify-work` to verify the plan succeeded — proceed?"
 
 Wait for user confirmation before invoking the skill.
 
-- **User confirms** — invoke `/wos:check-work`, which runs validation
+- **User confirms** — invoke `/work:verify-work`, which runs validation
   and handles the `status: completed` transition on success.
 - **User declines** — update frontmatter to `status: completed` directly.
   The user accepts responsibility for skipping plan-level validation.
 
 ### 7. Finish
 
-Present to user: "Validation passed. Ready to invoke `/wos:finish-work`
+Present to user: "Validation passed. Ready to invoke `/work:finish-work`
 to integrate — proceed?"
 
 Wait for user confirmation before invoking the skill.


### PR DESCRIPTION
## Summary

- Replaced all `/wos:X` skill invocations across 14 SKILL.md files with correct `/plugin:X` namespaces (wiki:, work:, build:)
- `/wos:check-work` → `/work:verify-work` (skill was renamed, not just re-namespaced)
- Removed stale `/wos:retrospective` reference from `finish-work/SKILL.md` (skill does not exist)
- Bumped patch versions: wiki `0.1.3→0.1.4`, work `0.1.1→0.1.2`, build `0.1.0→0.1.1`

**Out of scope:** `<!-- wos:begin -->`, `<!-- wos:end -->`, `<!-- wos:layout: -->` structural markers in AGENTS.md files — renaming these breaks existing projects.

## Test plan

- [ ] `grep -r "wos:" plugins/ --include="SKILL.md" | grep -v "<!--"` — returns zero results
- [ ] `python3 -m pytest plugins/wiki/tests/ -v` — all 269 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)