### PR TITLE
fix: metadata correctness and lint accuracy batch (#291-#295)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ Pre-restructure releases used a single version. Post-restructure, each plugin
 
 ## [Unreleased]
 
+## [wiki-0.1.5, consider-0.1.1, work-0.1.3, build-0.1.2] - 2026-04-16
+
+### Fixed
+
+- **`wiki:lint` false positives on test fixtures (#292).** Added `"tests"` to
+  the `Document.scan()` skip list so fixture files under `tests/` are never
+  evaluated as live content. Running lint on the toolkit root now exits clean.
+
+- **`consider` plugin: all 17 skills missing required frontmatter (#293).**
+  Added `name:` and `user-invocable: true` to every skill in
+  `plugins/consider/skills/`. Skills now surface correctly in discovery indexes
+  and pass `Document.parse()` validation.
+
+- **`work:verify-work` name mismatch (#294).** Corrected frontmatter
+  `name: check-work` → `name: verify-work` and updated `start-work` Handoff
+  `Chainable to:` reference to match. `/work:verify-work` is now reachable via
+  its registered name.
+
+- **`build:build-rule` test file placement ambiguous for Claude Code format
+  (#295).** Replaced the single co-located path instruction in Step 8 with a
+  format-specific table covering WOS, Cursor, and Claude Code formats.
+
+- **`build:check-skill` broken static-check script path (#291).** Fixed
+  hardcoded `scripts/lint.py` → `<plugin-scripts-dir>/../../src/check/lint.py`,
+  `python` → `python3`, and added an install prerequisite note
+  (`pip install -e plugins/build`).
+
 ### Changed
 
 - **Restructured `wos` monorepo into `toolkit` plugin marketplace.** Five

--- a/docs/designs/2026-04-16-metadata-correctness-lint-accuracy.design.md
+++ b/docs/designs/2026-04-16-metadata-correctness-lint-accuracy.design.md
@@ -1,0 +1,69 @@
+---
+name: Metadata Correctness and Lint Accuracy Batch Fix
+description: Fix five open bugs causing skill enumeration failures, false-positive lint results, a broken skill chain reference, and unusable static-check tooling.
+type: design
+status: approved
+related:
+  - docs/context/
+---
+
+# Metadata Correctness and Lint Accuracy Batch Fix
+
+## Purpose
+
+Fix five open bugs that cause skill enumeration failures, false-positive lint results, a broken skill chain reference, and unusable static-check tooling. All fixes are surgical — no new abstractions or tooling.
+
+## Fixes in Scope
+
+### #291 — build:check-skill references non-existent scripts/lint.py
+
+**File:** `plugins/build/skills/check-skill/SKILL.md`
+
+- Replace hardcoded `scripts/lint.py` with `<plugin-scripts-dir>/../../src/check/lint.py`
+- Replace `python` with `python3`
+- Add install prerequisite note (`pip install -e plugins/build`)
+
+### #292 — wiki:lint false positives on test fixtures
+
+**File:** `plugins/wiki/src/wiki/document.py`
+
+- Add `"tests"` to the `_SKIP` frozenset in `Document.scan()`
+
+### #293 — consider plugin: all 17 skills missing required frontmatter fields
+
+**Files:** `plugins/consider/skills/*/SKILL.md` (all 17 files)
+
+- Add `name: <directory-name>` frontmatter field to each skill
+- Add `user-invocable: true` frontmatter field to each skill
+
+### #294 — work plugin: verify-work name mismatch
+
+**Files:**
+- `plugins/work/skills/verify-work/SKILL.md` — change `name: check-work` → `name: verify-work`
+- `plugins/work/skills/start-work/SKILL.md` — change `Chainable to: check-work` → `Chainable to: verify-work`
+
+### #295 — build:build-rule test file placement ambiguous for Claude Code format
+
+**File:** `plugins/build/skills/build-rule/SKILL.md`
+
+Replace the single co-located test file instruction in Step 8 with a format-specific path table:
+
+| Format | Test file location |
+|--------|--------------------|
+| WOS | `docs/rules/<slug>.tests.md` |
+| Cursor | `.cursor/rules/<slug>.tests.md` |
+| Claude Code | `docs/rules/<slug>.tests.md` |
+
+## Won't Do
+
+- No new entry points, wrappers, or scripts
+- No regression tests (separate concern, separate issue)
+- No renaming of the verify-work directory
+
+## Acceptance Criteria
+
+- `/wiki:lint` on the toolkit root reports 0 findings from `tests/fixtures/`
+- `Document.parse()` succeeds on all consider `SKILL.md` files
+- `/work:verify-work` is reachable via its registered name; start-work Handoff references `verify-work`
+- `check-skill` SKILL.md references a valid, `python3`-compatible script path with install prerequisite documented
+- `build-rule` Step 8 unambiguously defines test file location for all three formats

--- a/docs/plans/2026-04-16-metadata-correctness-lint-accuracy.plan.md
+++ b/docs/plans/2026-04-16-metadata-correctness-lint-accuracy.plan.md
@@ -1,0 +1,217 @@
+---
+name: Metadata Correctness and Lint Accuracy Batch Fix
+description: Fix five open bugs causing skill enumeration failures, false-positive lint results, a broken skill chain reference, and unusable static-check tooling.
+type: plan
+status: executing
+branch: fix/metadata-correctness-lint-accuracy
+related:
+  - docs/designs/2026-04-16-metadata-correctness-lint-accuracy.design.md
+---
+
+# Metadata Correctness and Lint Accuracy Batch Fix
+
+## Goal
+
+Fix five open bugs (#291–#295) that cause skill enumeration failures, false-positive lint output, a broken skill chain reference, and an unusable static-check step. All changes are surgical edits to existing files — no new files, no new abstractions.
+
+## Scope
+
+Must have:
+- Add `"tests"` to `_SKIP` in `Document.scan()` so `wiki:lint` ignores test fixtures (#292)
+- Add `name:` and `user-invocable: true` to all 17 consider skill SKILL.md files (#293)
+- Fix `name: check-work` → `name: verify-work` in verify-work frontmatter; fix `Chainable to: check-work` → `Chainable to: verify-work` in start-work Handoff (#294)
+- Replace single co-located test file instruction in build-rule Step 8 with a format-specific path table (#295)
+- Fix check-skill SKILL.md: correct script path to `<plugin-scripts-dir>/../../src/check/lint.py`, `python` → `python3`, add install prerequisite (#291)
+
+Won't have:
+- New entry points, wrappers, or scripts
+- Regression tests for frontmatter completeness
+- Renaming the verify-work directory
+
+## Approach
+
+Five independent fixes, ordered from Python source (safest to verify with existing tests) to SKILL.md text edits. No cross-task dependencies — each task is a standalone commit. Task 1 is the only Python change; tasks 2–5 are Markdown-only.
+
+## File Changes
+
+- Modify: `plugins/wiki/src/wiki/document.py` (add `"tests"` to `_SKIP`)
+- Modify: `plugins/consider/skills/10-10-10/SKILL.md`
+- Modify: `plugins/consider/skills/5-whys/SKILL.md`
+- Modify: `plugins/consider/skills/circle-of-competence/SKILL.md`
+- Modify: `plugins/consider/skills/consider/SKILL.md`
+- Modify: `plugins/consider/skills/eisenhower-matrix/SKILL.md`
+- Modify: `plugins/consider/skills/first-principles/SKILL.md`
+- Modify: `plugins/consider/skills/hanlons-razor/SKILL.md`
+- Modify: `plugins/consider/skills/inversion/SKILL.md`
+- Modify: `plugins/consider/skills/map-vs-territory/SKILL.md`
+- Modify: `plugins/consider/skills/occams-razor/SKILL.md`
+- Modify: `plugins/consider/skills/one-thing/SKILL.md`
+- Modify: `plugins/consider/skills/opportunity-cost/SKILL.md`
+- Modify: `plugins/consider/skills/pareto/SKILL.md`
+- Modify: `plugins/consider/skills/reversibility/SKILL.md`
+- Modify: `plugins/consider/skills/second-order/SKILL.md`
+- Modify: `plugins/consider/skills/swot/SKILL.md`
+- Modify: `plugins/consider/skills/via-negativa/SKILL.md`
+- Modify: `plugins/work/skills/verify-work/SKILL.md`
+- Modify: `plugins/work/skills/start-work/SKILL.md`
+- Modify: `plugins/build/skills/build-rule/SKILL.md`
+- Modify: `plugins/build/skills/check-skill/SKILL.md`
+
+**Branch:** `fix/metadata-correctness-lint-accuracy`
+**PR:** closes #291, #292, #293, #294, #295
+
+## Tasks
+
+---
+
+### Task 1: Fix wiki:lint false positives on test fixtures (#292)
+
+- [x] Add `"tests"` to `_SKIP` in `Document.scan()`, verify tests pass and lint produces no fixtures output, commit <!-- sha:c783d2f -->
+
+In `plugins/wiki/src/wiki/document.py`, locate the `_SKIP` frozenset inside `Document.scan()` (around line 266) and add `"tests"` to it:
+
+```python
+_SKIP = frozenset({
+    "node_modules", "__pycache__", "venv", ".venv",
+    "dist", "build", ".tox", ".mypy_cache", ".pytest_cache",
+    "tests",
+})
+```
+
+**Verify:**
+```bash
+python3 -m pytest plugins/wiki/tests/ -v -x
+python3 plugins/wiki/scripts/lint.py --root . 2>&1 | grep "tests/fixtures"
+# second command should produce no output
+```
+
+Commit: `fix(wiki): exclude tests/ from Document.scan skip list (#292)`
+
+---
+
+### Task 2: Add required frontmatter to all 17 consider skills (#293)
+
+- [x] Add `name:` and `user-invocable: true` to all 17 consider SKILL.md files, verify no files missing fields, commit <!-- sha:37919e7 -->
+
+For each skill directory under `plugins/consider/skills/`, open its `SKILL.md` and insert `name: <directory-name>` and `user-invocable: true` into the frontmatter block. The directory names are:
+
+`10-10-10`, `5-whys`, `circle-of-competence`, `consider`, `eisenhower-matrix`, `first-principles`, `hanlons-razor`, `inversion`, `map-vs-territory`, `occams-razor`, `one-thing`, `opportunity-cost`, `pareto`, `reversibility`, `second-order`, `swot`, `via-negativa`
+
+Each frontmatter should look like (example for `pareto`):
+```yaml
+---
+name: pareto
+description: Apply the 80/20 rule...
+argument-hint: "[area where effort and results feel misaligned]"
+user-invocable: true
+---
+```
+
+**Verify:**
+```bash
+grep -rL "^name:" plugins/consider/skills/*/SKILL.md
+# should produce no output (all files have name:)
+grep -rL "user-invocable:" plugins/consider/skills/*/SKILL.md
+# should produce no output (all files have user-invocable:)
+```
+
+Commit: `fix(consider): add name and user-invocable frontmatter to all 17 skills (#293)`
+
+---
+
+### Task 3: Fix verify-work name mismatch and start-work chain reference (#294)
+
+- [x] Fix `name: check-work` → `name: verify-work` in verify-work SKILL.md and `Chainable to: check-work` → `verify-work` in start-work Handoff, verify, commit <!-- sha:5f2b5c3 -->
+
+**File 1:** `plugins/work/skills/verify-work/SKILL.md`
+- Change frontmatter `name: check-work` → `name: verify-work`
+
+**File 2:** `plugins/work/skills/start-work/SKILL.md`
+- In the `## Handoff` section, change `**Chainable to:** check-work` → `**Chainable to:** verify-work`
+
+**Verify:**
+```bash
+grep "^name:" plugins/work/skills/verify-work/SKILL.md
+# → name: verify-work
+grep "Chainable to:" plugins/work/skills/start-work/SKILL.md
+# → **Chainable to:** verify-work
+```
+
+Commit: `fix(work): correct verify-work name and start-work chain reference (#294)`
+
+---
+
+### Task 4: Fix build-rule test file placement for Claude Code format (#295)
+
+- [x] Replace single co-located test file instruction in build-rule Step 8 with format-specific path table, verify table present, commit <!-- sha:9427c66 -->
+
+In `plugins/build/skills/build-rule/SKILL.md`, locate Step 8 "Write the Rule". Replace the single co-located test file instruction:
+
+> `Write a co-located test file at <same-dir>/<slug>.tests.md ...`
+
+with a format-specific path table prepended before the existing instruction text:
+
+```
+Write the test file at the format-specific location:
+
+| Format | Test file location |
+|--------|--------------------|
+| WOS | `docs/rules/<slug>.tests.md` |
+| Cursor | `.cursor/rules/<slug>.tests.md` |
+| Claude Code | `docs/rules/<slug>.tests.md` (create directory if needed) |
+```
+
+Keep the existing instruction about minimum 3 PASS / 3 FAIL cases and the Rule Testing Guide reference — only the path specification changes.
+
+**Verify:**
+```bash
+grep -A6 "Test file location" plugins/build/skills/build-rule/SKILL.md
+# should show the three-row table with WOS, Cursor, Claude Code rows
+```
+
+Commit: `fix(build): add format-specific test file path table to build-rule Step 8 (#295)`
+
+---
+
+### Task 5: Fix check-skill static-check script reference (#291)
+
+- [x] Fix script path to `<plugin-scripts-dir>/../../src/check/lint.py`, `python` → `python3`, add install prerequisite in check-skill SKILL.md, verify, commit <!-- sha:716423f -->
+
+In `plugins/build/skills/check-skill/SKILL.md`, locate Step 2 "Run Static Checks". Replace the broken command block:
+
+```bash
+python scripts/lint.py --root <project-root> --no-urls
+```
+
+with:
+
+```bash
+# Prerequisite: pip install -e plugins/build
+python3 <plugin-scripts-dir>/../../src/check/lint.py --root <project-root> --no-urls
+```
+
+**Verify:**
+```bash
+grep "plugin-scripts-dir" plugins/build/skills/check-skill/SKILL.md
+# → python3 <plugin-scripts-dir>/../../src/check/lint.py
+grep "pip install" plugins/build/skills/check-skill/SKILL.md
+# → # Prerequisite: pip install -e plugins/build
+grep "python3" plugins/build/skills/check-skill/SKILL.md
+# → python3 (not bare `python`)
+```
+
+Commit: `fix(build): correct check-skill static-check script path and add prerequisite (#291)`
+
+---
+
+## Validation
+
+All five criteria from the design must hold before the PR is opened:
+
+1. `python3 plugins/wiki/scripts/lint.py --root . 2>&1 | grep "tests/fixtures"` → no output
+2. `grep -rL "^name:" plugins/consider/skills/*/SKILL.md` → no output
+3. `grep "^name:" plugins/work/skills/verify-work/SKILL.md` → `name: verify-work`
+4. `grep "Chainable to:" plugins/work/skills/start-work/SKILL.md` → `verify-work`
+5. `grep "Test file location" plugins/build/skills/build-rule/SKILL.md` → table header present
+6. `grep "plugin-scripts-dir" plugins/build/skills/check-skill/SKILL.md` → path present
+7. `python3 -m pytest plugins/wiki/tests/ -v` → all tests pass

--- a/docs/plans/2026-04-16-metadata-correctness-lint-accuracy.plan.md
+++ b/docs/plans/2026-04-16-metadata-correctness-lint-accuracy.plan.md
@@ -2,7 +2,7 @@
 name: Metadata Correctness and Lint Accuracy Batch Fix
 description: Fix five open bugs causing skill enumeration failures, false-positive lint results, a broken skill chain reference, and unusable static-check tooling.
 type: plan
-status: executing
+status: completed
 branch: fix/metadata-correctness-lint-accuracy
 related:
   - docs/designs/2026-04-16-metadata-correctness-lint-accuracy.design.md

--- a/plugins/build/.claude-plugin/plugin.json
+++ b/plugins/build/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "build",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Skills for creating and refining Claude Code skills, rules, hooks, and subagents.",
   "author": {
     "name": "Brandon Beidel"

--- a/plugins/build/pyproject.toml
+++ b/plugins/build/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "check"
-version = "0.1.1"
+version = "0.1.2"
 description = "Claude Code plugin for auditing Claude Code skills and rules for quality issues."
 requires-python = ">=3.9"
 dependencies = []

--- a/plugins/build/skills/build-rule/SKILL.md
+++ b/plugins/build/skills/build-rule/SKILL.md
@@ -154,7 +154,15 @@ Show the complete rule file to the user. Iterate on feedback. Do not write until
 
 - Create the parent directory if it doesn't exist
 - Write the rule file at the correct path for the detected format
-- Write a co-located test file at `<same-dir>/<slug>.tests.md` with at minimum 3 PASS cases and 3 FAIL cases, each with a rationale note. Reference the [Rule Testing Guide](references/rule-testing-guide.md) for format. Test cases must use different code than the rule's own examples.
+- Write the test file at the format-specific location:
+
+  | Format | Test file location |
+  |--------|--------------------|
+  | WOS | `docs/rules/<slug>.tests.md` |
+  | Cursor | `.cursor/rules/<slug>.tests.md` |
+  | Claude Code | `docs/rules/<slug>.tests.md` (create directory if needed) |
+
+  Include at minimum 3 PASS cases and 3 FAIL cases, each with a rationale note. Reference the [Rule Testing Guide](references/rule-testing-guide.md) for format. Test cases must use different code than the rule's own examples.
 - Report both file paths
 
 ## Example

--- a/plugins/build/skills/check-skill/SKILL.md
+++ b/plugins/build/skills/check-skill/SKILL.md
@@ -23,7 +23,8 @@ then offer an opt-in repair loop.
 ### 2. Run Static Checks
 
 ```bash
-python scripts/lint.py --root <project-root> --no-urls
+# Prerequisite: pip install -e plugins/build
+python3 <plugin-scripts-dir>/../../src/check/lint.py --root <project-root> --no-urls
 ```
 
 Extract findings for the target skill(s). Static checks cover two of the

--- a/plugins/consider/.claude-plugin/plugin.json
+++ b/plugins/consider/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "consider",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Structured mental models for decision-making — first principles, Occam's razor, inversion, and more.",
   "author": {
     "name": "Brandon Beidel"

--- a/plugins/consider/skills/10-10-10/SKILL.md
+++ b/plugins/consider/skills/10-10-10/SKILL.md
@@ -1,6 +1,8 @@
 ---
+name: 10-10-10
 description: Evaluate decisions by considering impact across three time horizons
 argument-hint: "[decision you're weighing or struggling with]"
+user-invocable: true
 ---
 
 <objective>

--- a/plugins/consider/skills/5-whys/SKILL.md
+++ b/plugins/consider/skills/5-whys/SKILL.md
@@ -1,6 +1,8 @@
 ---
+name: 5-whys
 description: Drill to root cause by asking why repeatedly until fundamentals emerge
 argument-hint: "[problem or symptom to trace to its root cause]"
+user-invocable: true
 ---
 
 <objective>

--- a/plugins/consider/skills/circle-of-competence/SKILL.md
+++ b/plugins/consider/skills/circle-of-competence/SKILL.md
@@ -1,6 +1,8 @@
 ---
+name: circle-of-competence
 description: Scope decisions by distinguishing what you know well from what you don't
 argument-hint: "[domain or decision where expertise boundaries matter]"
+user-invocable: true
 ---
 
 <objective>

--- a/plugins/consider/skills/consider/SKILL.md
+++ b/plugins/consider/skills/consider/SKILL.md
@@ -1,6 +1,8 @@
 ---
+name: consider
 description: Apply structured mental models to think through problems. Use when the user wants to "analyze", "evaluate", "think through", "decide between", "weigh tradeoffs", or needs a framework for a decision.
 argument-hint: "{model-name} [topic to analyze]"
+user-invocable: true
 ---
 
 Apply structured mental models to problems. If a specific model was requested,

--- a/plugins/consider/skills/eisenhower-matrix/SKILL.md
+++ b/plugins/consider/skills/eisenhower-matrix/SKILL.md
@@ -1,6 +1,8 @@
 ---
+name: eisenhower-matrix
 description: Prioritize tasks and decisions by mapping urgency against importance
 argument-hint: "[list of tasks, decisions, or competing priorities]"
+user-invocable: true
 ---
 
 <objective>

--- a/plugins/consider/skills/first-principles/SKILL.md
+++ b/plugins/consider/skills/first-principles/SKILL.md
@@ -1,6 +1,8 @@
 ---
+name: first-principles
 description: Break down assumptions and rebuild reasoning from fundamental truths
 argument-hint: "[problem or system to deconstruct]"
+user-invocable: true
 ---
 
 <objective>

--- a/plugins/consider/skills/hanlons-razor/SKILL.md
+++ b/plugins/consider/skills/hanlons-razor/SKILL.md
@@ -1,6 +1,8 @@
 ---
+name: hanlons-razor
 description: Interpret behavior charitably — attribute to mistakes before malice
 argument-hint: "[situation where someone's behavior seems problematic]"
+user-invocable: true
 ---
 
 <objective>

--- a/plugins/consider/skills/inversion/SKILL.md
+++ b/plugins/consider/skills/inversion/SKILL.md
@@ -1,6 +1,8 @@
 ---
+name: inversion
 description: Solve problems backwards by identifying what would guarantee failure
 argument-hint: "[goal or outcome to achieve]"
+user-invocable: true
 ---
 
 <objective>

--- a/plugins/consider/skills/map-vs-territory/SKILL.md
+++ b/plugins/consider/skills/map-vs-territory/SKILL.md
@@ -1,6 +1,8 @@
 ---
+name: map-vs-territory
 description: Recognize where your mental model diverges from reality
 argument-hint: "[situation where assumptions may not match reality]"
+user-invocable: true
 ---
 
 <objective>

--- a/plugins/consider/skills/occams-razor/SKILL.md
+++ b/plugins/consider/skills/occams-razor/SKILL.md
@@ -1,6 +1,8 @@
 ---
+name: occams-razor
 description: Find the simplest explanation or solution that accounts for all known facts
 argument-hint: "[phenomenon or problem with multiple possible explanations]"
+user-invocable: true
 ---
 
 <objective>

--- a/plugins/consider/skills/one-thing/SKILL.md
+++ b/plugins/consider/skills/one-thing/SKILL.md
@@ -1,6 +1,8 @@
 ---
+name: one-thing
 description: Identify the single highest-leverage action that makes everything else easier
 argument-hint: "[goal or area where focus is needed]"
+user-invocable: true
 ---
 
 <objective>

--- a/plugins/consider/skills/opportunity-cost/SKILL.md
+++ b/plugins/consider/skills/opportunity-cost/SKILL.md
@@ -1,6 +1,8 @@
 ---
+name: opportunity-cost
 description: Evaluate what you give up by choosing one option over alternatives
 argument-hint: "[decision with multiple options to compare]"
+user-invocable: true
 ---
 
 <objective>

--- a/plugins/consider/skills/pareto/SKILL.md
+++ b/plugins/consider/skills/pareto/SKILL.md
@@ -1,6 +1,8 @@
 ---
+name: pareto
 description: Apply the 80/20 rule to find the highest-leverage inputs
 argument-hint: "[area where effort and results feel misaligned]"
+user-invocable: true
 ---
 
 <objective>

--- a/plugins/consider/skills/reversibility/SKILL.md
+++ b/plugins/consider/skills/reversibility/SKILL.md
@@ -1,6 +1,8 @@
 ---
+name: reversibility
 description: Assess decision risk by classifying as one-way or two-way door
 argument-hint: "[decision to evaluate for reversibility]"
+user-invocable: true
 ---
 
 <objective>

--- a/plugins/consider/skills/second-order/SKILL.md
+++ b/plugins/consider/skills/second-order/SKILL.md
@@ -1,6 +1,8 @@
 ---
+name: second-order
 description: Think through the consequences of consequences before acting
 argument-hint: "[decision or action to evaluate]"
+user-invocable: true
 ---
 
 <objective>

--- a/plugins/consider/skills/swot/SKILL.md
+++ b/plugins/consider/skills/swot/SKILL.md
@@ -1,6 +1,8 @@
 ---
+name: swot
 description: Map strengths, weaknesses, opportunities, and threats systematically
 argument-hint: "[project, product, team, or strategy to evaluate]"
+user-invocable: true
 ---
 
 <objective>

--- a/plugins/consider/skills/via-negativa/SKILL.md
+++ b/plugins/consider/skills/via-negativa/SKILL.md
@@ -1,6 +1,8 @@
 ---
+name: via-negativa
 description: Improve by removing problems rather than adding solutions
 argument-hint: "[system, process, or situation to improve]"
+user-invocable: true
 ---
 
 <objective>

--- a/plugins/wiki/.claude-plugin/plugin.json
+++ b/plugins/wiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Skills for building and maintaining structured project context — setup, research, ingest, and lint.",
   "author": {
     "name": "Brandon Beidel"

--- a/plugins/wiki/pyproject.toml
+++ b/plugins/wiki/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wiki"
-version = "0.1.4"
+version = "0.1.5"
 description = "Claude Code plugin for building and maintaining structured project context."
 requires-python = ">=3.9"
 dependencies = []

--- a/plugins/wiki/src/wiki/document.py
+++ b/plugins/wiki/src/wiki/document.py
@@ -266,6 +266,7 @@ class Document:
         _SKIP = frozenset({
             "node_modules", "__pycache__", "venv", ".venv",
             "dist", "build", ".tox", ".mypy_cache", ".pytest_cache",
+            "tests",
         })
 
         root_path = Path(root)

--- a/plugins/work/.claude-plugin/plugin.json
+++ b/plugins/work/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "work",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Skills for the full work lifecycle — scope-work, plan-work, start-work, verify-work, and finish-work.",
   "author": {
     "name": "Brandon Beidel"

--- a/plugins/work/skills/start-work/SKILL.md
+++ b/plugins/work/skills/start-work/SKILL.md
@@ -151,4 +151,4 @@ Wait for user confirmation before invoking the skill.
 
 **Receives:** Plan file path (`.plan.md`) with `status: approved`
 **Produces:** Implemented code and files per plan; plan tasks marked `[x]` with commit SHAs
-**Chainable to:** check-work
+**Chainable to:** verify-work

--- a/plugins/work/skills/verify-work/SKILL.md
+++ b/plugins/work/skills/verify-work/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: check-work
+name: verify-work
 description: >
   Verifies completed work against validation criteria. Works in two
   modes: with a plan (runs the plan's Validation section) or ad-hoc


### PR DESCRIPTION
## Summary

- **#292** `wiki:lint` — add `"tests"` to `Document.scan()` skip list; lint on toolkit root now exits clean
- **#293** `consider` plugin — add `name:` and `user-invocable: true` to all 17 skills; they now surface in discovery and pass `Document.parse()` validation
- **#294** `work:verify-work` — fix frontmatter `name: check-work` → `name: verify-work`; fix `start-work` Handoff `Chainable to:` reference to match
- **#295** `build:build-rule` — replace ambiguous co-located test file instruction in Step 8 with a format-specific path table (WOS / Cursor / Claude Code)
- **#291** `build:check-skill` — fix hardcoded `scripts/lint.py` → `<plugin-scripts-dir>/../../src/check/lint.py`, `python` → `python3`, add install prerequisite note

## Version bumps

| Plugin | Before | After |
|--------|--------|-------|
| `wiki` | 0.1.4 | 0.1.5 |
| `consider` | 0.1.0 | 0.1.1 |
| `work` | 0.1.2 | 0.1.3 |
| `build` | 0.1.1 | 0.1.2 |

## Test plan

- [x] `python3 -m pytest plugins/wiki/tests/ -q` → 269 passed
- [x] `python3 plugins/wiki/scripts/lint.py --root . --no-urls | grep tests/fixtures` → no output
- [x] `grep -rL "^name:" plugins/consider/skills/` → no output (all files have `name:`)
- [x] `grep "^name:" plugins/work/skills/verify-work/SKILL.md` → `name: verify-work`
- [x] `grep "Chainable to:" plugins/work/skills/start-work/SKILL.md` → `verify-work`
- [x] `grep "Test file location" plugins/build/skills/build-rule/SKILL.md` → table present
- [x] `grep "plugin-scripts-dir" plugins/build/skills/check-skill/SKILL.md` → correct path present

🤖 Generated with [Claude Code](https://claude.com/claude-code)