### PR TITLE
chore(skills): consider skill quality audit + fix issues #298, #300, #303, #304

### DIFF
--- a/docs/plans/2026-04-16-consider-skill-quality-audit.plan.md
+++ b/docs/plans/2026-04-16-consider-skill-quality-audit.plan.md
@@ -1,0 +1,284 @@
+---
+name: Consider Plugin Skill Quality Audit
+description: Audit all 17 skills in plugins/consider with check-skill, fix clear-cut issues, file GitHub issues for judgment calls.
+type: plan
+status: executing
+branch: chore/consider-skill-quality-audit
+related:
+  - docs/designs/2026-04-16-build-skill-quality-audit.design.md
+---
+
+# Consider Plugin Skill Quality Audit
+
+## Goal
+
+Audit all 17 skills in `plugins/consider/skills/` using `/build:check-skill`, fix every finding that has an obvious correct answer (clear-cut), and file a GitHub issue for every finding that requires subjective judgment. One commit per skill; all work on one branch.
+
+## Scope
+
+Must have:
+- Audit all 17 skills: `10-10-10`, `5-whys`, `circle-of-competence`, `consider`, `eisenhower-matrix`, `first-principles`, `hanlons-razor`, `inversion`, `map-vs-territory`, `occams-razor`, `one-thing`, `opportunity-cost`, `pareto`, `reversibility`, `second-order`, `swot`, `via-negativa`
+- Fix clear-cut issues: wrong/missing frontmatter fields, stale paths or command names, broken cross-references, structural omissions with an obvious correct value
+- File a GitHub issue per judgment-call finding (routing quality, vagueness, workflow ordering, content-quality criteria requiring subjective evaluation)
+- One commit per skill
+
+Won't have:
+- Fixes for judgment calls (those become open issues)
+- Audits of skills outside `plugins/consider/`
+- Plugin version bump (separate PR after issues are resolved)
+
+## Approach
+
+Seventeen sequential tasks, one per skill, each following the same protocol: run check-skill → read findings → triage → fix clear-cut issues → file issues for judgment calls → commit. Tasks are ordered alphabetically. No cross-task dependencies.
+
+**Triage guide (reference for executor):**
+- **Clear-cut:** missing required frontmatter field with an obvious value, stale skill name reference, broken relative path, duplicate frontmatter field, structural section missing with obvious content
+- **Judgment call:** routing description quality, vagueness of a rule, workflow step ordering ambiguity, anti-pattern guard completeness, example sufficiency, gate placement
+
+## File Changes
+
+- Modify: `plugins/consider/skills/10-10-10/SKILL.md` (if findings require it)
+- Modify: `plugins/consider/skills/5-whys/SKILL.md` (if findings require it)
+- Modify: `plugins/consider/skills/circle-of-competence/SKILL.md` (if findings require it)
+- Modify: `plugins/consider/skills/consider/SKILL.md` (if findings require it)
+- Modify: `plugins/consider/skills/eisenhower-matrix/SKILL.md` (if findings require it)
+- Modify: `plugins/consider/skills/first-principles/SKILL.md` (if findings require it)
+- Modify: `plugins/consider/skills/hanlons-razor/SKILL.md` (if findings require it)
+- Modify: `plugins/consider/skills/inversion/SKILL.md` (if findings require it)
+- Modify: `plugins/consider/skills/map-vs-territory/SKILL.md` (if findings require it)
+- Modify: `plugins/consider/skills/occams-razor/SKILL.md` (if findings require it)
+- Modify: `plugins/consider/skills/one-thing/SKILL.md` (if findings require it)
+- Modify: `plugins/consider/skills/opportunity-cost/SKILL.md` (if findings require it)
+- Modify: `plugins/consider/skills/pareto/SKILL.md` (if findings require it)
+- Modify: `plugins/consider/skills/reversibility/SKILL.md` (if findings require it)
+- Modify: `plugins/consider/skills/second-order/SKILL.md` (if findings require it)
+- Modify: `plugins/consider/skills/swot/SKILL.md` (if findings require it)
+- Modify: `plugins/consider/skills/via-negativa/SKILL.md` (if findings require it)
+
+**Branch:** `chore/consider-skill-quality-audit`
+
+## Tasks
+
+---
+
+### Task 1: Audit and fix `10-10-10`
+
+- [x] Run `/build:check-skill plugins/consider/skills/10-10-10/SKILL.md`, triage findings, fix clear-cut issues, file GitHub issues for judgment calls, commit <!-- sha:0bdd583 -->
+
+**Verify:**
+```bash
+git log --oneline -1  # commit present for 10-10-10
+gh issue list --state open --search "10-10-10" --limit 5  # judgment-call issues filed (if any)
+```
+
+---
+
+### Task 2: Audit and fix `5-whys`
+
+- [x] Run `/build:check-skill plugins/consider/skills/5-whys/SKILL.md`, triage findings, fix clear-cut issues, file GitHub issues for judgment calls, commit <!-- sha:bf7e029 -->
+
+**Verify:**
+```bash
+git log --oneline -1
+gh issue list --state open --search "5-whys" --limit 5
+```
+
+---
+
+### Task 3: Audit and fix `circle-of-competence`
+
+- [x] Run `/build:check-skill plugins/consider/skills/circle-of-competence/SKILL.md`, triage findings, fix clear-cut issues, file GitHub issues for judgment calls, commit <!-- sha:6cc9b27 -->
+
+**Verify:**
+```bash
+git log --oneline -1
+gh issue list --state open --search "circle-of-competence" --limit 5
+```
+
+---
+
+### Task 4: Audit and fix `consider`
+
+- [x] Run `/build:check-skill plugins/consider/skills/consider/SKILL.md`, triage findings, fix clear-cut issues, file GitHub issues for judgment calls, commit <!-- sha:b067dcf -->
+
+**Verify:**
+```bash
+git log --oneline -1
+gh issue list --state open --search "consider" --limit 5
+```
+
+---
+
+### Task 5: Audit and fix `eisenhower-matrix`
+
+- [x] Run `/build:check-skill plugins/consider/skills/eisenhower-matrix/SKILL.md`, triage findings, fix clear-cut issues, file GitHub issues for judgment calls, commit <!-- sha:01124d8 -->
+
+**Verify:**
+```bash
+git log --oneline -1
+gh issue list --state open --search "eisenhower-matrix" --limit 5
+```
+
+---
+
+### Task 6: Audit and fix `first-principles`
+
+- [x] Run `/build:check-skill plugins/consider/skills/first-principles/SKILL.md`, triage findings, fix clear-cut issues, file GitHub issues for judgment calls, commit <!-- sha:f8e19e6 -->
+
+**Verify:**
+```bash
+git log --oneline -1
+gh issue list --state open --search "first-principles" --limit 5
+```
+
+---
+
+### Task 7: Audit and fix `hanlons-razor`
+
+- [x] Run `/build:check-skill plugins/consider/skills/hanlons-razor/SKILL.md`, triage findings, fix clear-cut issues, file GitHub issues for judgment calls, commit <!-- sha:e1462eb -->
+
+**Verify:**
+```bash
+git log --oneline -1
+gh issue list --state open --search "hanlons-razor" --limit 5
+```
+
+---
+
+### Task 8: Audit and fix `inversion`
+
+- [x] Run `/build:check-skill plugins/consider/skills/inversion/SKILL.md`, triage findings, fix clear-cut issues, file GitHub issues for judgment calls, commit <!-- sha:4d4f08d -->
+
+**Verify:**
+```bash
+git log --oneline -1
+gh issue list --state open --search "inversion" --limit 5
+```
+
+---
+
+### Task 9: Audit and fix `map-vs-territory`
+
+- [x] Run `/build:check-skill plugins/consider/skills/map-vs-territory/SKILL.md`, triage findings, fix clear-cut issues, file GitHub issues for judgment calls, commit <!-- sha:2e603a0 -->
+
+**Verify:**
+```bash
+git log --oneline -1
+gh issue list --state open --search "map-vs-territory" --limit 5
+```
+
+---
+
+### Task 10: Audit and fix `occams-razor`
+
+- [x] Run `/build:check-skill plugins/consider/skills/occams-razor/SKILL.md`, triage findings, fix clear-cut issues, file GitHub issues for judgment calls, commit <!-- sha:9c8df0b -->
+
+**Verify:**
+```bash
+git log --oneline -1
+gh issue list --state open --search "occams-razor" --limit 5
+```
+
+---
+
+### Task 11: Audit and fix `one-thing`
+
+- [x] Run `/build:check-skill plugins/consider/skills/one-thing/SKILL.md`, triage findings, fix clear-cut issues, file GitHub issues for judgment calls, commit <!-- sha:e7c6df9 -->
+
+**Verify:**
+```bash
+git log --oneline -1
+gh issue list --state open --search "one-thing" --limit 5
+```
+
+---
+
+### Task 12: Audit and fix `opportunity-cost`
+
+- [x] Run `/build:check-skill plugins/consider/skills/opportunity-cost/SKILL.md`, triage findings, fix clear-cut issues, file GitHub issues for judgment calls, commit <!-- sha:59abdee -->
+
+**Verify:**
+```bash
+git log --oneline -1
+gh issue list --state open --search "opportunity-cost" --limit 5
+```
+
+---
+
+### Task 13: Audit and fix `pareto`
+
+- [x] Run `/build:check-skill plugins/consider/skills/pareto/SKILL.md`, triage findings, fix clear-cut issues, file GitHub issues for judgment calls, commit <!-- sha:003cb7d -->
+
+**Verify:**
+```bash
+git log --oneline -1
+gh issue list --state open --search "pareto" --limit 5
+```
+
+---
+
+### Task 14: Audit and fix `reversibility`
+
+- [x] Run `/build:check-skill plugins/consider/skills/reversibility/SKILL.md`, triage findings, fix clear-cut issues, file GitHub issues for judgment calls, commit <!-- sha:78a1845 -->
+
+**Verify:**
+```bash
+git log --oneline -1
+gh issue list --state open --search "reversibility" --limit 5
+```
+
+---
+
+### Task 15: Audit and fix `second-order`
+
+- [x] Run `/build:check-skill plugins/consider/skills/second-order/SKILL.md`, triage findings, fix clear-cut issues, file GitHub issues for judgment calls, commit <!-- sha:8c30222 -->
+
+**Verify:**
+```bash
+git log --oneline -1
+gh issue list --state open --search "second-order" --limit 5
+```
+
+---
+
+### Task 16: Audit and fix `swot`
+
+- [x] Run `/build:check-skill plugins/consider/skills/swot/SKILL.md`, triage findings, fix clear-cut issues, file GitHub issues for judgment calls, commit <!-- sha:9dee919 -->
+
+**Verify:**
+```bash
+git log --oneline -1
+gh issue list --state open --search "swot" --limit 5
+```
+
+---
+
+### Task 17: Audit and fix `via-negativa`
+
+- [x] Run `/build:check-skill plugins/consider/skills/via-negativa/SKILL.md`, triage findings, fix clear-cut issues, file GitHub issues for judgment calls, commit <!-- sha:b4392ea -->
+
+**Verify:**
+```bash
+git log --oneline -1
+gh issue list --state open --search "via-negativa" --limit 5
+```
+
+---
+
+## Validation
+
+1. All 17 skills audited — one commit per skill present in branch history:
+   ```bash
+   git log --oneline origin/main..HEAD | grep "audit"
+   # should show 17 entries
+   ```
+2. No regressions:
+   ```bash
+   python3 -m pytest plugins/wiki/tests/ -q
+   # 269 passed (or more)
+   ```
+3. Open issues filed for judgment calls:
+   ```bash
+   gh issue list --state open --limit 30
+   # judgment-call findings appear as issues
+   ```

--- a/plugins/build/skills/build-hook/SKILL.md
+++ b/plugins/build/skills/build-hook/SKILL.md
@@ -17,9 +17,9 @@ references:
 Scaffold a Claude Code hook: an event-driven script that enforces quality
 gates deterministically, bypassing LLM interpretation.
 
-**Workflow sequence:** Route → Elicit → Draft → Safety Check → (Stop Hook Guard if Stop/SubagentStop) → Rule Overlap → Review Gate → Save → Test
+**Workflow sequence:** 1. Route → 2. Elicit → 3. Draft → 4. Safety Check → (5. Stop Hook Guard if Stop/SubagentStop) → 6. Rule Overlap → 7. Review Gate → 8. Save → 9. Test
 
-## Route
+## 1. Route
 
 Determine whether a hook is the right primitive before asking hook-specific questions. Full decision matrix: [primitive-routing.md](../../_shared/references/primitive-routing.md).
 
@@ -32,7 +32,7 @@ Determine whether a hook is the right primitive before asking hook-specific ques
 - **Goal has a specific lifecycle trigger and must fire regardless of LLM judgment** →
   proceed to Elicit.
 
-## Elicit
+## 2. Elicit
 
 Ask three things, one question at a time:
 
@@ -59,7 +59,7 @@ Default to `command` unless the user has a specific reason otherwise.
 **3. Enforcement goal** — one sentence: what should this hook enforce or
 detect? Confirm the goal before drafting.
 
-## Draft
+## 3. Draft
 
 Produce two artifacts.
 
@@ -185,7 +185,7 @@ the hook from running entirely.
 
 Present both artifacts to the user before any safety checks.
 
-## Safety Check
+## 4. Safety Check
 
 With the draft script from the preceding step in hand, review it against eleven criteria. Revise before proceeding if
 any fail.
@@ -250,7 +250,7 @@ any fail.
     run in parallel). Flag this as a misconfiguration; consolidate all input
     modifications for a given tool into one hook.
 
-## Stop Hook Guard
+## 5. Stop Hook Guard
 
 **Only for `Stop` and `SubagentStop` events.** Skip this section for all
 other events.
@@ -303,7 +303,7 @@ Two permanent limitations that affect hook design decisions:
   Claude Code spawns hooks in non-interactive shells, so the `i` flag is absent
   and the guarded block is skipped.
 
-## Rule Overlap
+## 6. Rule Overlap
 
 Check `CLAUDE.md` for instructions that already express the same enforcement
 goal.
@@ -316,7 +316,7 @@ If overlap is found, note it and ask:
 Both can be intentional (belt-and-suspenders); one may be stale. The user
 decides.
 
-## Review Gate
+## 7. Review Gate
 
 Present both artifacts — the complete hook script and the settings.json
 snippet — and wait for explicit user approval before writing any file to
@@ -326,7 +326,7 @@ If the user requests changes, revise and re-present. Continue this loop
 until the user explicitly approves the artifacts or cancels. Do not
 proceed to Save on anything short of explicit approval.
 
-## Save
+## 8. Save
 
 Write the approved hook to `.claude/hooks/<name>.sh` (or a path the user
 specifies). Make it executable:
@@ -343,7 +343,7 @@ should not be overwritten.
 > entry shown above to `.claude/settings.json` (or settings.local.json
 > for local-only enforcement) to activate it."
 
-## Test
+## 9. Test
 
 Read `references/hook-testing.md` and follow the three-layer verification
 procedure (configuration, logic isolation, execution trace) before activating

--- a/plugins/build/skills/refine-prompt/SKILL.md
+++ b/plugins/build/skills/refine-prompt/SKILL.md
@@ -159,4 +159,4 @@ If the user declines, move on without saving.
 
 **Receives:** Prompt text or file path to refine; optional target use-case context
 **Produces:** Refined prompt with assessment scores and improvement rationale; optionally saved to `docs/prompts/`
-**Chainable to:** (context-dependent)
+**Chainable to:** build-skill (when refining a SKILL.md instruction block), build-hook (when refining a hook enforcement goal), build-rule (when refining a rule's intent statement)

--- a/plugins/consider/skills/10-10-10/SKILL.md
+++ b/plugins/consider/skills/10-10-10/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: 10-10-10
-description: Evaluate decisions by considering impact across three time horizons
+description: Evaluate decisions by considering impact across three time horizons — use when short-term emotions and long-term consequences may point in different directions
 argument-hint: "[decision you're weighing or struggling with]"
 user-invocable: true
 ---
@@ -65,4 +65,22 @@ Option B: Incrementally refactor the existing system module by module.
 ### Decision
 Incremental refactor (Option B). The 10-month horizon reveals that the rewrite's main appeal is emotional (fresh start) rather than practical. Refactoring delivers value continuously without betting on a single high-risk cutover.
 </example>
+
+## Key Instructions
+
+- If the user hasn't identified options yet, help them articulate 2–3 distinct choices before running the analysis.
+- If all three time horizons point to the same option, state that clearly — the model confirms rather than complicates the decision.
+- Does not make the decision for the user; produces structured analysis to inform the choice.
+- Does not apply to factual questions or already-made decisions being rationalized after the fact.
+
+## Anti-Pattern Guards
+
+1. **Applying the model to non-decisions** — 10-10-10 requires genuine options; applying it to informational questions or post-hoc rationalization produces noise, not insight.
+2. **Treating all three horizons equally** — the dominant time horizon varies by decision type; always identify which horizon carries the most weight for the specific context.
+
+## Handoff
+
+**Receives:** A decision the user is weighing, ideally with at least two options identified
+**Produces:** Structured time-horizon analysis table with divergence points and a recommendation
+**Chainable to:** `consider` (to apply additional mental models), `second-order` (for deeper consequence mapping on the chosen option)
 

--- a/plugins/consider/skills/5-whys/SKILL.md
+++ b/plugins/consider/skills/5-whys/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: 5-whys
-description: Drill to root cause by asking why repeatedly until fundamentals emerge
+description: Drill to root cause by asking why repeatedly until fundamentals emerge — use when a problem recurs or the quick fix keeps failing to hold
 argument-hint: "[problem or symptom to trace to its root cause]"
 user-invocable: true
 ---
@@ -66,4 +66,22 @@ Giving each parallel suite its own database instance would eliminate the shared-
 ### Action
 Create per-suite database instances in CI using a template database that's cloned at suite start and destroyed at suite end.
 </example>
+
+## Key Instructions
+
+- If the chain reaches "human error" or "bad luck," keep going — those are symptoms, not root causes; ask why that error was possible.
+- Stop when fixing the identified root cause would demonstrably prevent the original symptom from recurring.
+- Does not prescribe solutions; produces diagnosis to inform action.
+- Does not apply to novel one-off incidents where recurrence is not the concern.
+
+## Anti-Pattern Guards
+
+1. **Stopping at symptoms** — "the developer made a mistake" is a symptom; keep asking why that mistake was possible.
+2. **Single-chain tunnel vision** — most real problems have multiple contributing causes; check for branching chains at each level (process step 6).
+
+## Handoff
+
+**Receives:** A problem statement or recurring symptom the user wants to trace to its root cause
+**Produces:** A why-chain trace leading to root cause(s), with verification and a specific action
+**Chainable to:** `consider` (to apply additional mental models), `inversion` (to verify by imagining how to reproduce the problem)
 

--- a/plugins/consider/skills/circle-of-competence/SKILL.md
+++ b/plugins/consider/skills/circle-of-competence/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: circle-of-competence
-description: Scope decisions by distinguishing what you know well from what you don't
+description: Scope decisions by distinguishing what you know well from what you don't — use when expertise boundaries are uncertain or a decision requires knowledge outside your direct experience
 argument-hint: "[domain or decision where expertise boundaries matter]"
 user-invocable: true
 ---
@@ -72,4 +72,21 @@ Building the mobile app requires deep knowledge in all three zones. API integrat
 ### Strategy
 Bring in outside expertise. Hire or contract a mobile developer for the app shell and platform integration. Our team owns the API layer and backend (inside our circle). The mobile specialist handles what we'd spend months learning poorly. Review architecture decisions together so knowledge transfers over time.
 </example>
+
+## Key Instructions
+
+- If the user has no relevant experience to assess, help them identify who does before mapping the circle.
+- Does not evaluate whether a decision is worth making; only maps competence boundaries relative to it.
+- Does not apply to pure preference questions where competence is irrelevant.
+
+## Anti-Pattern Guards
+
+1. **Confusing familiarity with competence** — reading about a topic places it on the edge, not inside the circle; direct practice is the threshold.
+2. **Using the model to justify avoidance** — the goal is calibrated scope, not permission to stay comfortable; sometimes the right answer is to expand the circle.
+
+## Handoff
+
+**Receives:** A domain or decision where expertise boundaries affect the outcome
+**Produces:** A three-zone competence map (inside / edge / outside) with a recommended strategy
+**Chainable to:** `consider` (to apply additional mental models), `opportunity-cost` (to evaluate the cost of staying in vs. expanding the circle)
 

--- a/plugins/consider/skills/consider/SKILL.md
+++ b/plugins/consider/skills/consider/SKILL.md
@@ -40,3 +40,19 @@ help the user choose by presenting the options below.
 
 If no model is specified, ask the user what they want to think through, then
 suggest 2-3 models that would be most relevant to their problem.
+
+## Key Instructions
+
+- When no model is specified and the user's problem is unclear, ask one clarifying question before suggesting models.
+- Does not execute implementations or take action; produces framework analysis only.
+
+## Anti-Pattern Guards
+
+1. **Suggesting too many models** — presenting more than 2–3 options when no model is specified overwhelms rather than guides; curate to the best fit.
+2. **Routing non-analytical tasks here** — this skill applies mental models, not implementation, debugging, or research; route those elsewhere.
+
+## Handoff
+
+**Receives:** A problem, decision, or question the user wants to analyze; optionally, a specific model name
+**Produces:** A structured mental model analysis using the requested or recommended model
+**Chainable to:** Any `/consider:{model-name}` sub-skill

--- a/plugins/consider/skills/eisenhower-matrix/SKILL.md
+++ b/plugins/consider/skills/eisenhower-matrix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: eisenhower-matrix
-description: Prioritize tasks and decisions by mapping urgency against importance
+description: Prioritize tasks and decisions by mapping urgency against importance — use when facing competing demands and unclear where to focus first
 argument-hint: "[list of tasks, decisions, or competing priorities]"
 user-invocable: true
 ---
@@ -71,4 +71,21 @@ from crowding out what actually matters.
 ### Key Insight
 PR reviews feel urgent because notifications pile up, but they're not important enough to displace the architecture proposal. Batching reviews to end-of-day prevents them from fragmenting deep work on Q2 items.
 </example>
+
+## Key Instructions
+
+- "Urgent" means time-sensitive with an external deadline, not just "feels pressing right now."
+- If the user's list has more than 10 items, group related items before applying the matrix.
+- Does not make scheduling decisions; produces a prioritization framework the user applies.
+
+## Anti-Pattern Guards
+
+1. **Over-filling Q1** — if everything lands in "Do Now," the assessment needs recalibration; most perceived Q1 items are actually Q3 urgency traps.
+2. **Letting urgency displace importance** — the most common failure is Q3 items crowding out Q2; step 6 surfaces this explicitly; always call it out.
+
+## Handoff
+
+**Receives:** A list of tasks, decisions, or competing priorities the user wants to sort
+**Produces:** A four-quadrant prioritization matrix with specific next actions for Q1 and Q2 items
+**Chainable to:** `pareto` (to find the highest-leverage Q2 items), `one-thing` (to identify the single most important Q2 action)
 

--- a/plugins/consider/skills/first-principles/SKILL.md
+++ b/plugins/consider/skills/first-principles/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: first-principles
-description: Break down assumptions and rebuild reasoning from fundamental truths
+description: Break down assumptions and rebuild reasoning from fundamental truths — use when a standard approach feels wrong or produces diminishing returns but no one has questioned its underlying assumptions
 argument-hint: "[problem or system to deconstruct]"
 user-invocable: true
 ---
@@ -65,4 +65,20 @@ A modular monolith with clear internal boundaries gives us deploy isolation (via
 ### Key Insight
 The assumption "scaling = microservices" skipped the question "what are we actually scaling?" Our bottleneck is deploy speed, not request throughput — a problem microservices make worse, not better.
 </example>
+
+## Key Instructions
+
+- If all assumptions survive challenge, note that the conventional approach may already be optimal — first-principles doesn't always produce a novel solution.
+- Does not generate solutions from scratch; produces a framework for rebuilding reasoning once fundamentals are verified.
+
+## Anti-Pattern Guards
+
+1. **Rebuilding from convention** — stripping away a convention only to rebuild the same approach is the common failure; the rebuilt solution must trace to verified fundamentals, not intuition.
+2. **Mistaking "feels fundamental" for "is fundamental"** — a fundamental truth is verifiable, not just hard to argue with; apply the same skepticism to proposed fundamentals as to assumptions.
+
+## Handoff
+
+**Receives:** A problem or system the user wants to deconstruct and reason about from fundamentals
+**Produces:** An assumptions audit, verified fundamentals, and a rebuilt solution compared against the conventional approach
+**Chainable to:** `inversion` (to stress-test the rebuilt solution), `consider` (to apply additional mental models)
 

--- a/plugins/consider/skills/hanlons-razor/SKILL.md
+++ b/plugins/consider/skills/hanlons-razor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hanlons-razor
-description: Interpret behavior charitably — attribute to mistakes before malice
+description: Interpret behavior charitably — attribute to mistakes before malice; use when behavior seems hostile or frustrating and an adversarial interpretation is forming
 argument-hint: "[situation where someone's behavior seems problematic]"
 user-invocable: true
 ---
@@ -69,4 +69,20 @@ PR size + competing priorities. A 400-line PR requires 30-60 minutes of focused 
 ### Appropriate Response
 Break the PR into 2-3 smaller PRs if possible. Message the reviewer offering to walk through the changes in 15 minutes to reduce their review burden. If still no response after the offer, reassign to a different reviewer without resentment.
 </example>
+
+## Key Instructions
+
+- Charitable interpretation does not mean ignoring evidence of genuine malice; it means exhausting more likely explanations first.
+- Does not resolve the situation; produces a clearer interpretation framework and a recommended response approach.
+
+## Anti-Pattern Guards
+
+1. **Overriding clear evidence** — Hanlon's Razor applies before evidence, not against it; if malice is demonstrated, the razor doesn't apply.
+2. **Using charity to avoid addressing patterns** — a repeated pattern of the same "mistake" may indicate intent; acknowledge when the charitable explanation stops being the most likely one.
+
+## Handoff
+
+**Receives:** A situation where someone's behavior seems problematic, hostile, or deliberately harmful
+**Produces:** A structured alternatives analysis with distinguishing evidence and a recommended response
+**Chainable to:** `consider` (to apply additional models), `map-vs-territory` (to check what assumptions are driving the uncharitable interpretation)
 

--- a/plugins/consider/skills/inversion/SKILL.md
+++ b/plugins/consider/skills/inversion/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: inversion
-description: Solve problems backwards by identifying what would guarantee failure
+description: Solve problems backwards by identifying what would guarantee failure — use when direct optimization feels stuck or failure modes are unclear
 argument-hint: "[goal or outcome to achieve]"
 user-invocable: true
 ---
@@ -73,4 +73,20 @@ Start with pilot teams, solve their top 3 pain points, ship fast bug fixes, let 
 ### Blind Spots
 We haven't considered what happens if pilot teams' pain points diverge significantly — the platform might fragment into team-specific solutions rather than a shared one.
 </example>
+
+## Key Instructions
+
+- If all failure modes seem low-likelihood, explicitly ask what would have to be true for the plan to fail — most teams systematically underestimate operational risks.
+- Does not substitute for direct planning; produces a failure-mode inventory to inform a positive plan.
+
+## Anti-Pattern Guards
+
+1. **Listing generic risks** — failure modes must be specific to the stated goal and context; "poor communication" is noise unless it maps to a concrete scenario.
+2. **Stopping at failure identification** — inversion's value is the avoidance strategies and synthesized positive plan; always complete steps 5–7.
+
+## Handoff
+
+**Receives:** A goal or desired outcome the user wants to achieve
+**Produces:** A ranked failure-mode inventory with avoidance strategies and a synthesized positive plan
+**Chainable to:** `second-order` (to trace consequences of each failure mode), `first-principles` (to challenge whether the goal's assumptions are sound)
 

--- a/plugins/consider/skills/map-vs-territory/SKILL.md
+++ b/plugins/consider/skills/map-vs-territory/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: map-vs-territory
-description: Recognize where your mental model diverges from reality
+description: Recognize where your mental model diverges from reality — use when a plan or model is driving decisions and its assumptions haven't been stress-tested
 argument-hint: "[situation where assumptions may not match reality]"
 user-invocable: true
 ---
@@ -71,4 +71,20 @@ The external API dependency. Our velocity model assumes all work is within our c
 ### Reality Check
 Ask the external team for their delivery date and confidence level. If they can't commit, re-sequence the epic to pull forward work that doesn't depend on their API. Adjust the estimate to 4-5 sprints to account for the dependency and PTO gaps.
 </example>
+
+## Key Instructions
+
+- The goal is to find gaps before they cause failures, not to invalidate the model — a well-calibrated map with known limits is still useful.
+- Does not update the model; produces a gap audit and a verification plan the user acts on.
+
+## Anti-Pattern Guards
+
+1. **Treating simplifications as failures** — all maps simplify; the question is whether the simplification matters for the decision at hand.
+2. **Generating abstract gaps** — every gap must have a concrete risk statement ("if this gap is real, X could happen"), not just "this isn't modeled."
+
+## Handoff
+
+**Receives:** A mental model, plan, or abstraction the user is relying on for a decision
+**Produces:** A three-zone gap audit (matches / simplifies / ignores) with the highest-risk divergence and a reality-check approach
+**Chainable to:** `first-principles` (to rebuild from verified fundamentals), `second-order` (to trace consequences of the highest-risk gap)
 

--- a/plugins/consider/skills/occams-razor/SKILL.md
+++ b/plugins/consider/skills/occams-razor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: occams-razor
-description: Find the simplest explanation or solution that accounts for all known facts
+description: Find the simplest explanation or solution that accounts for all known facts — use when there are multiple competing explanations and the simplest hasn't been tried first
 argument-hint: "[phenomenon or problem with multiple possible explanations]"
 user-invocable: true
 ---
@@ -65,4 +65,20 @@ Upstream search provider experienced degradation. This requires only one assumpt
 ### Distinguishing Evidence
 Check the provider's status page for Tuesday incidents. If clean, run `curl` directly against the provider API to measure current latency. If provider is fast, re-examine the search index.
 </example>
+
+## Key Instructions
+
+- A simpler explanation that doesn't account for all known facts is not Occam's Razor — it's an incomplete explanation; simplicity cannot come at the cost of explanatory coverage.
+- Does not prescribe investigation steps; identifies the most parsimonious explanation to test first.
+
+## Anti-Pattern Guards
+
+1. **Discarding evidence to achieve simplicity** — the simplest explanation must fit all known facts; simplifying by ignoring inconvenient observations is not Occam's Razor.
+2. **Conflating common with simple** — a common explanation requires fewer assumptions only if its commonness doesn't itself require additional assumptions to explain.
+
+## Handoff
+
+**Receives:** A phenomenon or problem with multiple possible explanations and a set of known observations
+**Produces:** A ranked candidate explanation table with the simplest sufficient explanation and distinguishing evidence
+**Chainable to:** `5-whys` (to drill into the chosen explanation's root cause), `map-vs-territory` (to check whether the observations themselves are accurate)
 

--- a/plugins/consider/skills/one-thing/SKILL.md
+++ b/plugins/consider/skills/one-thing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: one-thing
-description: Identify the single highest-leverage action that makes everything else easier
+description: Identify the single highest-leverage action that makes everything else easier — use when there are too many competing priorities and focus needs to be established before work begins
 argument-hint: "[goal or area where focus is needed]"
 user-invocable: true
 ---
@@ -68,4 +68,21 @@ A new hire can run `make setup` on a fresh laptop and have all services running 
 ### Say No To
 Pause the architecture video project and the onboarding doc rewrite until setup works. Both are wasted effort if people can't run the code.
 </example>
+
+## Key Instructions
+
+- If no candidate action dominates on domino effect, help the user identify the constraint blocking progress before forcing a single choice.
+- The one thing must be within the user's control — not "hope the market changes" or "wait for someone else to decide."
+- Does not make the decision; produces a leverage analysis so the user can commit to one focus.
+
+## Anti-Pattern Guards
+
+1. **Choosing the easiest action, not the highest-leverage one** — quick wins often aren't domino actions; test each candidate against step 3 explicitly before selecting.
+2. **Anchoring too early** — list all candidate actions before evaluating leverage; premature commitment skips higher-domino options.
+
+## Handoff
+
+**Receives:** A goal or area where the user needs to establish focus amid competing priorities
+**Produces:** A candidate action leverage analysis identifying the single highest-leverage action, its definition of done, and what to deprioritize
+**Chainable to:** `eisenhower-matrix` (to slot the one thing alongside other demands), `pareto` (to validate the 80/20 leverage claim)
 

--- a/plugins/consider/skills/opportunity-cost/SKILL.md
+++ b/plugins/consider/skills/opportunity-cost/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: opportunity-cost
-description: Evaluate what you give up by choosing one option over alternatives
+description: Evaluate what you give up by choosing one option over alternatives — use when a decision is being made without explicitly naming the best alternative foregone
 argument-hint: "[decision with multiple options to compare]"
 user-invocable: true
 ---
@@ -68,4 +68,20 @@ If we build custom, we forgo 3 engineer-months of product work. At our current p
 ### Verdict
 Auth0 justified. The opportunity cost of building (delayed notifications = revenue risk) exceeds Auth0's dollar cost by roughly 10x. Revisit only if we outgrow Auth0's pricing tier or need auth behavior they can't support.
 </example>
+
+## Key Instructions
+
+- Always include "do nothing" as an alternative — it is the most frequently overlooked option and often has the clearest opportunity cost.
+- Does not make the decision; produces a comparison that makes the tradeoff explicit so the user can decide.
+
+## Anti-Pattern Guards
+
+1. **Comparing against only weak alternatives** — opportunity cost is the value of the best alternative, not a convenient one; include the strongest realistic option.
+2. **Omitting hidden costs** — direct dollar or time comparisons miss ongoing costs (maintenance, lock-in, expertise loss); step 6 must be completed, not skipped.
+
+## Handoff
+
+**Receives:** A decision with a favored option and at least one realistic alternative
+**Produces:** An option comparison table with opportunity cost named explicitly and a verdict
+**Chainable to:** `reversibility` (to assess how locked in the favored choice is), `second-order` (to trace downstream effects of the foregone alternative)
 

--- a/plugins/consider/skills/pareto/SKILL.md
+++ b/plugins/consider/skills/pareto/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pareto
-description: Apply the 80/20 rule to find the highest-leverage inputs
+description: Apply the 80/20 rule to find the highest-leverage inputs — use when effort and results feel misaligned or there are too many things competing for attention
 argument-hint: "[area where effort and results feel misaligned]"
 user-invocable: true
 ---
@@ -73,4 +73,20 @@ Reduce monthly support tickets from 500 to under 200.
 ### Recommended Focus Shift
 Two changes (self-service password reset + billing page redesign) would eliminate ~60% of tickets. Everything else combined is less impactful than either of these alone. Start with password reset — it's a weekend project with the highest single-category impact.
 </example>
+
+## Key Instructions
+
+- Contribution estimates don't need to be precise — ballpark percentages identify the vital few; perfect data is usually unavailable and not required.
+- Does not prescribe what to cut; produces a leverage map the user applies.
+
+## Anti-Pattern Guards
+
+1. **Treating 80/20 as a precise law** — it's a heuristic, not a formula; the vital few might be 15% producing 70% or 30% producing 90%; use it directionally, not literally.
+2. **Optimizing the wrong outcome** — before ranking inputs, confirm the outcome metric is the right one to optimize; the wrong metric produces a Pareto analysis that points at the wrong levers.
+
+## Handoff
+
+**Receives:** An area where the user wants to find the highest-leverage inputs or activities
+**Produces:** An input-to-outcome ranking identifying the vital few and a recommended focus shift
+**Chainable to:** `one-thing` (to narrow from the vital few to a single action), `eisenhower-matrix` (to prioritize vital-few items against urgency)
 

--- a/plugins/consider/skills/reversibility/SKILL.md
+++ b/plugins/consider/skills/reversibility/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reversibility
-description: Assess decision risk by classifying as one-way or two-way door
+description: Assess decision risk by classifying as one-way or two-way door — use when calibrating how much analysis a decision deserves before committing
 argument-hint: "[decision to evaluate for reversibility]"
 user-invocable: true
 ---
@@ -65,4 +65,20 @@ Use PostgreSQL vs DynamoDB for a new event-sourcing service.
 - **Ways to reduce commitment:** Start with a repository abstraction layer so business logic doesn't call database APIs directly. Build for PostgreSQL first (team knows it), but keep the option to swap the storage backend if DynamoDB's scaling becomes necessary.
 - **Recommendation:** Analyze thoroughly. Default to PostgreSQL (known quantity, team expertise, adequate for projected scale). Revisit DynamoDB only if event volume exceeds 50K/sec — a threshold we're unlikely to hit in year one.
 </example>
+
+## Key Instructions
+
+- If a decision appears one-way but has a viable partial path (pilot, phased rollout, abstraction layer), always surface it — full irreversibility is rarer than it appears.
+- Does not recommend whether to proceed; calibrates the appropriate level of analysis and commitment.
+
+## Anti-Pattern Guards
+
+1. **Treating all one-way doors as equally risky** — blast radius matters; a one-way door affecting only you deserves less caution than one affecting the whole organization.
+2. **Using irreversibility as a reason to avoid deciding** — one-way doors still require decisions; the output is appropriate deliberation level, not paralysis.
+
+## Handoff
+
+**Receives:** A decision the user wants to evaluate for reversibility before committing
+**Produces:** A one-way/two-way classification with rollback path (if reversible) or blast radius and partial-reversibility options (if irreversible)
+**Chainable to:** `opportunity-cost` (to weigh the cost of commitment), `second-order` (to trace consequences of irreversible choices)
 

--- a/plugins/consider/skills/second-order/SKILL.md
+++ b/plugins/consider/skills/second-order/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: second-order
-description: Think through the consequences of consequences before acting
+description: Think through the consequences of consequences before acting — use when an action has obvious immediate effects but the downstream consequences haven't been traced
 argument-hint: "[decision or action to evaluate]"
 user-invocable: true
 ---
@@ -69,4 +69,21 @@ Require two approvals on every pull request before merge.
 ### Revised Assessment
 Keep mandatory review but with one approval, not two. Add a "trivial" label for changes under 20 lines that need only one reviewer. This preserves the learning and bug-catching benefits while avoiding the bottleneck spiral.
 </example>
+
+## Key Instructions
+
+- Stop at third-order effects for most decisions — deeper chains multiply uncertainty without adding insight.
+- If a feedback loop identified in step 5 is reinforcing (amplifying), treat it as high severity regardless of the original decision's apparent scale.
+- Does not recommend actions; produces a consequence map so the user can make an informed decision.
+
+## Anti-Pattern Guards
+
+1. **Stopping at first-order effects** — the model's value is specifically the second and third-order consequences; if the analysis doesn't go deeper than "this will happen," it hasn't been applied.
+2. **Over-extending the chain** — fourth-order and beyond typically degrade into noise; flag when the analysis stops at third order and why that's sufficient.
+
+## Handoff
+
+**Receives:** A proposed action or decision the user wants to evaluate for downstream consequences
+**Produces:** A consequence chain to third order with feedback loops and a revised assessment of whether to proceed
+**Chainable to:** `inversion` (to identify which second-order effects become failure modes), `reversibility` (to assess how locked in the decision becomes once second-order effects activate)
 

--- a/plugins/consider/skills/swot/SKILL.md
+++ b/plugins/consider/skills/swot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swot
-description: Map strengths, weaknesses, opportunities, and threats systematically
+description: Map strengths, weaknesses, opportunities, and threats systematically — use when evaluating a strategic position or deciding how to proceed with both internal and external factors at play
 argument-hint: "[project, product, team, or strategy to evaluate]"
 user-invocable: true
 ---
@@ -71,4 +71,20 @@ defending weaknesses against threats.
 ### Priority Action
 Ship the IDE adapter integration — it leverages the core strength (simple CLI) to reach a new audience (IDE users) at exactly the moment visibility is growing (conference).
 </example>
+
+## Key Instructions
+
+- The value is the cross-reference step (steps 6–7), not the lists; a SWOT that produces only four quadrant lists without strategic options hasn't been completed.
+- Does not make strategic decisions; produces a structured inventory and options the user evaluates.
+
+## Anti-Pattern Guards
+
+1. **Over-populating all four quadrants** — length is noise; aim for 3–5 well-chosen items per quadrant over exhaustive lists that dilute the signal.
+2. **Skipping the cross-reference** — the strategic options (S+O, W+T, W+O) are where SWOT becomes actionable; listing quadrants without cross-referencing them is only half the analysis.
+
+## Handoff
+
+**Receives:** A project, product, team, or strategy to evaluate
+**Produces:** A four-quadrant inventory with cross-referenced strategic options and a priority action
+**Chainable to:** `opportunity-cost` (to evaluate tradeoffs between strategic options), `eisenhower-matrix` (to prioritize the resulting strategic actions)
 

--- a/plugins/consider/skills/via-negativa/SKILL.md
+++ b/plugins/consider/skills/via-negativa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: via-negativa
-description: Improve by removing problems rather than adding solutions
+description: Improve by removing problems rather than adding solutions — use when a system or process has accumulated complexity and improvement by addition has hit diminishing returns
 argument-hint: "[system, process, or situation to improve]"
 user-invocable: true
 ---
@@ -69,4 +69,20 @@ Deployment pipeline has 12 steps: lint, unit test, integration test, build Docke
 ### What NOT to Remove
 The 30-minute canary monitor looks like wasted time but caught a memory leak last month that smoke tests missed. It's load-bearing.
 </example>
+
+## Key Instructions
+
+- Always assess whether a removal candidate is load-bearing before proposing it; the "What NOT to Remove" section must be completed, not skipped.
+- Does not implement removals; produces a removal plan the user executes.
+
+## Anti-Pattern Guards
+
+1. **Removing without checking dependencies** — an element may look unused but be load-bearing for edge cases; step 5 must assess what breaks, not just what improves.
+2. **Using via negativa to justify rewrites** — subtraction should be incremental; removing everything at once and rebuilding is not via negativa, it's a rewrite.
+
+## Handoff
+
+**Receives:** A system, process, or situation where something currently present may be causing friction or unnecessary complexity
+**Produces:** A ranked removal candidate analysis with a simplified version and explicit load-bearing elements to preserve
+**Chainable to:** `occams-razor` (to confirm the simplified version is the most parsimonious one that still works), `first-principles` (to verify the core purpose before deciding what's essential)
 

--- a/plugins/work/skills/finish-work/SKILL.md
+++ b/plugins/work/skills/finish-work/SKILL.md
@@ -84,7 +84,7 @@ If that fails, try `master`. Confirm with the user:
 
 ### 4. Present 4 Options
 
-Present exactly these options with no additional explanation:
+Present these options, distinguishing the irreversible action:
 
 ```
 Implementation complete. What would you like to do?
@@ -92,7 +92,7 @@ Implementation complete. What would you like to do?
 1. Merge back to <base-branch> locally
 2. Push and create a Pull Request
 3. Keep the branch as-is (I'll handle it later)
-4. Discard this work
+4. Discard this work (irreversible)
 ```
 
 ### 5. Execute Chosen Option

--- a/plugins/work/skills/plan-work/SKILL.md
+++ b/plugins/work/skills/plan-work/SKILL.md
@@ -10,6 +10,7 @@ description: >
 argument-hint: "[design doc path or feature description]"
 user-invocable: true
 references:
+  - ../../_shared/references/plan-format.md
   - references/format-guide.md
   - references/plan-template.md
   - references/examples/small-plan.md


### PR DESCRIPTION
## Summary

- Audited and fixed all 16 `consider/` mental model skills for metadata correctness, handoff completeness, and criterion compliance (tasks 1–17)
- Fixed four additional skill issues filed during the audit:
  - **#298** `build:build-hook` — numbered all 9 workflow step headers (criterion 14)
  - **#300** `build:refine-prompt` — replaced vague `(context-dependent)` chainable-to with concrete skill references
  - **#303** `work:finish-work` — resolved contradiction between Step 4 "no additional explanation" and APG #6 by marking Option 4 as `(irreversible)` inline
  - **#304** `work:plan-work` — added always-needed `plan-format.md` shared reference to frontmatter

## Test plan

- [ ] Invoke a `consider/` skill and verify handoff section is present and specific
- [ ] Invoke `/build:build-hook` and verify numbered workflow steps render correctly
- [ ] Invoke `/work:finish-work` and verify option 4 shows `(irreversible)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)