### PR TITLE
feat(consider): add pick-model skill (consider-0.1.2)

### DIFF
--- a/plugins/consider/.claude-plugin/plugin.json
+++ b/plugins/consider/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "consider",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Structured mental models for decision-making — first principles, Occam's razor, inversion, and more.",
   "author": {
     "name": "Brandon Beidel"

--- a/plugins/consider/CHANGELOG.md
+++ b/plugins/consider/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+## 0.1.2
+
+- Add `pick-model` skill — AI model selection advisory based on external
+  benchmarks, cross-provider pricing, and effort/stakes tradeoffs
+- Add `pick-model` to `consider` meta-skill routing table
+- Add `references/model-landscape.md` with benchmark tables, pricing
+  comparison, and effort controls by provider (data as of April 2026)
+
+## 0.1.1
+
+- Skill quality audit — add Handoff, Anti-Pattern Guards, Key Instructions
+  to all 17 skills (#306)
+- Metadata correctness and lint accuracy fixes (#296)
+
+## 0.1.0
+
+- Initial release with 16 mental models + `consider` meta-skill (#264)

--- a/plugins/consider/skills/consider/SKILL.md
+++ b/plugins/consider/skills/consider/SKILL.md
@@ -29,6 +29,7 @@ help the user choose by presenting the options below.
 | `map-vs-territory` | Recognize model limitations, check assumptions |
 | `reversibility` | Assess decision risk — one-way vs two-way doors |
 | `hanlons-razor` | Interpret behavior charitably, avoid conspiracy thinking |
+| `pick-model` | Select the right AI model for a task based on benchmarks, pricing, and effort tradeoffs |
 
 ## Usage
 

--- a/plugins/consider/skills/pick-model/SKILL.md
+++ b/plugins/consider/skills/pick-model/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: pick-model
+description: "Select the right AI model for a task based on external benchmarks, pricing, and effort tradeoffs. Use when the user asks \"which model should I use?\", \"what's the best model for X?\", \"help me pick a model\", \"model comparison\", \"should I use Opus or Sonnet?\", or needs to decide between AI models for a specific workload. Also use when someone mentions cost optimization for LLM usage or wants to know if a cheaper model would work."
+argument-hint: "[task or workload to select a model for]"
+user-invocable: true
+---
+
+<objective>
+Recommend the right AI model for a task by routing through three decisions:
+what type of work, how much a mistake costs, and what the budget allows.
+Recommendations are grounded in external benchmarks — not vendor marketing.
+</objective>
+
+<process>
+1. **Classify the task type.** Ask what the user is trying to accomplish.
+   Decompose broad categories into specific sub-types — "coding" could mean
+   function completion (saturated — any model works), bug fixing (Claude/Gemini
+   lead), or agentic multi-file refactoring (scaffold matters more than model).
+   Read `references/model-landscape.md` for the task-type mapping table.
+
+2. **Assess stakes.** Ask: "What happens if the model gets this wrong?"
+   Map to one of three levels:
+   - **Exploratory** — brainstorming, throwaway drafts, learning. Mistakes
+     are free. Route to budget tier, low effort.
+   - **Professional** — real work that matters but is recoverable. Wrong
+     answers cost time, not catastrophe. Route to value tier, medium effort.
+   - **Critical** — production-facing, high-stakes, expensive to fix.
+     Wrong answers have business impact. Route to frontier tier, high effort.
+
+3. **Check cost sensitivity.** Ask if there's a budget constraint:
+   - **Unconstrained** — recommend the leader for the task type.
+   - **Cost-aware** — recommend the value pick (best quality-per-dollar).
+   - **Budget-limited** — recommend the budget pick (cheapest viable).
+
+4. **Apply the crossover check.** Before recommending a cheaper model,
+   check: does it score >70% of the frontier on the relevant benchmark?
+   If yes, recommend it with high effort. If <50%, skip to frontier.
+   Between 50-70%, note the tradeoff explicitly.
+
+5. **Set the effort parameter.** Based on stakes and provider, recommend
+   the specific effort setting. Read the effort controls table in
+   `references/model-landscape.md`.
+
+6. **Present the recommendation.** Use the output format below. Include
+   the primary pick, an alternative at a different price point, the
+   effort setting, and a one-line rationale citing the benchmark evidence.
+</process>
+
+<output_format>
+## Model Recommendation: [Task Description]
+
+### Primary Pick
+**[Model Name]** ([Provider]) — [one-line rationale with benchmark cite]
+- Cost: $X.XX / $X.XX per M tokens (input/output)
+- Effort: `[parameter_name]` = `[value]`
+
+### Alternative
+**[Model Name]** — [why this is the tradeoff option]
+- Cost: $X.XX / $X.XX per M tokens
+
+### Why This Over That
+[2-3 sentences explaining the key differentiator — benchmark evidence,
+cost math, or capability gap that drives the recommendation]
+
+### Caveats
+- Data as of [month year]. Benchmark rankings shift quarterly.
+- [Any task-specific caveats — scaffold matters, score variance, etc.]
+</output_format>
+
+<example>
+User: "I need to pick a model for our code review pipeline. It reviews
+PRs automatically, leaves comments, and sometimes suggests fixes. We
+process about 200 PRs a day. Cost matters but quality matters more —
+bad reviews erode developer trust."
+
+## Model Recommendation: Automated PR Code Review
+
+### Primary Pick
+**Claude Sonnet 4.6** (Anthropic) — SWE-bench Verified 79.6%, Chatbot
+Arena Coding ELO 1523. Within 1.2 points of Opus on coding benchmarks
+at 60% of the cost.
+- Cost: $3.00 / $15.00 per M tokens (input/output)
+- Effort: `effort` = `high`
+
+### Alternative
+**DeepSeek V3.2** — 73% SWE-bench at $0.26/M input (17x cheaper). For
+200 PRs/day, the cost difference is significant. Quality gap is real but
+may be acceptable for initial triage before human review.
+- Cost: $0.26 / $0.38 per M tokens
+
+### Why This Over That
+At 200 PRs/day, the Sonnet-to-Opus upgrade buys 1.2 SWE-bench points
+for a 67% price increase — not justified when developer trust depends
+on consistency, not peak capability. Sonnet's coding ELO (1523) is third
+overall, behind only Opus variants. The DeepSeek alternative is viable
+for a two-tier setup: DeepSeek for initial scan, Sonnet for flagged PRs.
+
+### Caveats
+- Data as of April 2026. SWE-bench Verified is saturated at the top —
+  the 1.2-point Sonnet-to-Opus gap is within noise.
+- For agentic PR review (multi-file reasoning, not just line comments),
+  agent scaffold quality matters more than model choice — the ~22%
+  scaffold effect dwarfs the ~1% model effect at the frontier.
+</example>
+
+## Key Instructions
+
+- **Ground every recommendation in external benchmarks.** Cite the
+  benchmark name and score. Do not recommend based on vendor marketing,
+  model descriptions, or general reputation. Read the benchmark tables
+  in `references/model-landscape.md`.
+- **Decompose broad task types before recommending.** "Coding" spans
+  function completion (saturated), bug fixing (differentiated), and
+  agentic workflows (scaffold-dependent). Different sub-types get
+  different models. Ask the user to be specific.
+- **State the freshness date on every recommendation.** Benchmark data
+  is from April 2026. Rankings shift. Say so explicitly.
+- **Does not recommend infrastructure, scaffolds, or architectures** —
+  produces model selection guidance only. For agentic tasks, note that
+  scaffold investment may yield more than model upgrades, but don't
+  design the scaffold.
+- **Does not make provider-loyalty assumptions.** Recommend across
+  providers based on benchmark evidence. A user on Claude may get a
+  Gemini recommendation if the benchmarks support it.
+
+## Anti-Pattern Guards
+
+1. **Recommending frontier for everything** — the most expensive model
+   is not always the best choice. On saturated benchmarks (function
+   completion, simple math), budget models perform equivalently. Cost
+   sensitivity matters — a 19x price difference for 1.2 benchmark points
+   is rarely justified.
+2. **Treating benchmark scores as cardinal** — the same model scores
+   2-17 points apart depending on evaluation protocol. Close-margin
+   comparisons (e.g., "Opus beats Sonnet by 1.2 points") should be
+   presented as ties, not winners. Use ordinal rankings.
+3. **Ignoring the scaffold effect** — for agentic coding tasks,
+   recommending a model upgrade when the real bottleneck is scaffold
+   quality wastes the user's money. Flag this when the task is agentic.
+4. **Stale data presented as current** — benchmark landscapes shift
+   quarterly. If the user asks about a model or benchmark not in the
+   reference data, say so rather than guessing.
+
+## Handoff
+
+**Receives:** A task or workload description the user wants to select a model for; optionally, constraints (budget, provider preference, latency requirements)
+**Produces:** A model recommendation with benchmark rationale, effort parameter guidance, cost comparison, and freshness caveat
+**Chainable to:** `opportunity-cost` (to analyze what switching models gives up), `pareto` (to find the 20% of workloads driving 80% of model costs)

--- a/plugins/consider/skills/pick-model/references/model-landscape.md
+++ b/plugins/consider/skills/pick-model/references/model-landscape.md
@@ -1,0 +1,109 @@
+# Model Landscape Reference
+
+Data as of April 2026. Benchmark gaps have a 12-18 month shelf life —
+revisit when this data feels stale.
+
+## Task-Type to Model Mapping
+
+Use this table to select the primary recommendation based on task type.
+"Leader" is the top-performing model on external benchmarks. "Value" offers
+the best quality-per-dollar. "Budget" is the cheapest viable option.
+
+| Task Type | Leader | Value | Budget |
+|-----------|--------|-------|--------|
+| Coding: function completion | Saturated — any frontier | Claude Sonnet 4.6 ($3/M) | DeepSeek V3.2 ($0.26/M) |
+| Coding: bug fixing / SWE | Claude Opus 4.5/4.6 (SWE-bench 80.8%) | Gemini 3.1 Pro ($1.25/M) | DeepSeek V3.2 (73%, $0.26/M) |
+| Coding: agentic multi-file | GPT-5.4 / Claude Opus 4.6 (Terminal-Bench ~82%) | Claude Sonnet 4.6 (59.1%) | DeepSeek V3.2 (39.6%) |
+| Reasoning: scientific (PhD-level) | Gemini 3.1 Pro (GPQA 94.1%) | Gemini 2.5 Flash ($0.30/M, 82.8%) | DeepSeek R1-0528 ($0.45/M, 81%) |
+| Reasoning: mathematical | GPT-5.4 (MATH-500 99%, USAMO 95%) | o4-mini ($1.10/M, 97.6%) | DeepSeek R1 ($0.55/M, 97.3%) |
+| Reasoning: abstract / novel | Gemini 3.1 Pro (ARC-AGI-2 77.1%) | GPT-5.4 (73.3%) | No budget option — open-weight absent |
+| Creative writing | Claude Opus 4.6 (Arena blind test 4/8 wins) | Claude Sonnet 4.6 | — |
+| Multilingual / translation | Gemini 3.1 Pro (100+ languages, MMMLU 91.8%) | Gemini 2.5 Flash | Qwen 3.5 (CJK specialist) |
+| Instruction following | Qwen3.5 397B (IFBench 78.8%) | Gemini 3 Flash (78.0%) | — |
+| Long-context processing | Llama 4 Scout (10M context) | Gemini 2.5 Pro/Flash (1M) | — |
+| Cost-optimized production | DeepSeek V3.2 ($0.26/M input, 73% SWE-bench) | GPT-4o-mini ($0.15/M) | — |
+| Vision / multimodal | Gemini 3 Pro (Arena Vision ELO 1286) | Gemini 2.5 Flash | — |
+
+## Pricing Quick Reference
+
+Prices are per million tokens (input / output).
+
+### Proprietary Models
+
+| Model | Input | Output | Context | Speed | Provider |
+|-------|-------|--------|---------|-------|----------|
+| Claude Opus 4.6/4.7 | $5.00 | $25.00 | 1M | Moderate | Anthropic |
+| Claude Sonnet 4.6 | $3.00 | $15.00 | 1M | Fast | Anthropic |
+| Claude Haiku 4.5 | $1.00 | $5.00 | 200K | Fastest | Anthropic |
+| GPT-5.4 | $2.50 | $15.00 | — | — | OpenAI |
+| o3 | $2.00 | $8.00 | 200K | Medium-Slow | OpenAI |
+| o4-mini | $1.10 | $4.40 | 200K | Medium | OpenAI |
+| GPT-4o | $2.50 | $10.00 | 128K | Fast | OpenAI |
+| GPT-4o-mini | $0.15 | $0.60 | 128K | Very fast | OpenAI |
+| Gemini 3.1 Pro | $1.25 | $5.00 | 1M | Slow (25s TTFT) | Google |
+| Gemini 2.5 Pro | $1.25 | $10.00 | 1M | Slow | Google |
+| Gemini 2.5 Flash | $0.30 | $2.50 | 1M | Fast (0.7s TTFT) | Google |
+
+### Open-Weight Models (API pricing)
+
+| Model | Input | Output | Context | Provider |
+|-------|-------|--------|---------|----------|
+| DeepSeek V3.2 | $0.26 | $0.38 | 128K | DeepSeek |
+| DeepSeek R1-0528 | $0.45 | $2.15 | 64K | DeepSeek |
+| Qwen3.5 397B | $0.39 | $2.34 | 128K+ | Alibaba |
+| Llama 4 Maverick | $0.27 | $0.85 | 1M | Meta (via Together) |
+| Llama 4 Scout | $0.18 | $0.59 | 10M | Meta (via Together) |
+| Mistral Large 3 | $0.50 | $1.50 | 256K | Mistral |
+
+## Effort Controls by Provider
+
+All three major providers offer semantic effort parameters. Tune effort
+after selecting the model — this is the second layer of the cost stack.
+
+| Provider | Parameter | Values | Default | Scope |
+|----------|-----------|--------|---------|-------|
+| Anthropic | `effort` | low / medium / high / xhigh / max | high | All tokens (text, tools, thinking) |
+| OpenAI | `reasoning_effort` | low / medium / high | medium | Reasoning tokens only |
+| Google | `thinkingLevel` (3.x) | minimal / low / medium / high | — | Thinking tokens |
+| Google | `thinkingBudget` (2.5) | 0-32768 (numeric) | -1 (dynamic) | Thinking tokens |
+
+### Effort Guidance
+
+- **Low effort**: Simple Q&A, formatting, classification, translation.
+  Saves 2-5x tokens. May skip thinking entirely on simple queries.
+- **Medium effort**: Most professional tasks, content creation, standard
+  coding. Good balance of quality and cost.
+- **High effort**: Complex reasoning, multi-step analysis, important
+  coding tasks. Default for intelligence-sensitive work.
+- **Max/xhigh effort**: Frontier problems, security review, research
+  synthesis. Reserve for genuinely hard problems — adds significant cost
+  for relatively small quality gains on most workloads.
+
+## Key Benchmark Notes
+
+**Saturated (do not use for differentiation):**
+MMLU (>88% at frontier), HumanEval (>92%), SWE-bench Verified (6 models
+within 0.8 pts), MATH-500 (97-99%), AIME 2025 (multiple at 99-100%).
+
+**Still differentiating:**
+GPQA Diamond, SWE-bench Pro, Terminal-Bench 2.0, ARC-AGI-2, FrontierMath,
+Chatbot Arena ELO.
+
+**Caveats:**
+- Benchmark scores vary 2-17 points for the same model across evaluation
+  protocols. Treat rankings as ordinal (who leads), not cardinal (by how much).
+- ARC-AGI-2: all 14 leaderboard scores are self-reported, 0 independently
+  verified.
+- Terminal-Bench scores depend on agent scaffold — swapping scaffolds
+  causes ~22% score change vs ~1% for swapping top models.
+
+## The Crossover Point
+
+A smaller model with high effort can outperform a larger model with low
+effort — up to a point. Research (Snell et al. ICLR 2025) shows a 7B
+model with compute-optimal inference can match a 14x larger model. But
+once accuracy saturates, the larger model wins regardless of effort.
+
+**Rule of thumb:** If the cheaper model achieves >70% of the frontier
+score on the relevant benchmark, try it with high effort before upgrading
+to the next tier. If it scores <50%, skip straight to the frontier.


### PR DESCRIPTION
## Summary
- Add `pick-model` skill to the `consider` plugin — an AI model selection advisory that recommends models based on external benchmarks, cross-provider pricing, and effort/stakes tradeoffs
- Add `references/model-landscape.md` with benchmark tables (GPQA Diamond, SWE-bench, Terminal-Bench, ARC-AGI-2), pricing comparison across 17 models, and effort controls by provider (data as of April 2026)
- Add `pick-model` to the `consider` meta-skill routing table
- Bump consider plugin version to 0.1.2 with CHANGELOG

## Context
Grounded in three research investigations:
- **Model selection decision matrix** — routing strategy, cascade patterns, tier gaps
- **Cross-provider benchmarks** — scores across Claude, GPT, Gemini, DeepSeek, Qwen, Llama, Mistral
- **Effort as routing signal** — how `effort`, `reasoning_effort`, `thinkingLevel` interact with model selection

## Test plan
- [ ] Invoke `/consider:pick-model` with a coding task and verify it decomposes into sub-types
- [ ] Invoke with a reasoning task and verify cross-provider recommendation (not Claude-only)
- [ ] Invoke with explicit budget constraint and verify budget-tier recommendation
- [ ] Verify `references/model-landscape.md` loads when skill runs
- [ ] Verify `/consider` meta-skill routes "which model should I use?" to `pick-model`
- [ ] Run `/build:check-skill plugins/consider/skills/pick-model/SKILL.md` — should pass all 22 criteria

🤖 Generated with [Claude Code](https://claude.com/claude-code)