### PR TITLE
feat(build): PR 1 of #311 — skill correctness bugs

### DIFF
--- a/plugins/build/skills/build-skill/SKILL.md
+++ b/plugins/build/skills/build-skill/SKILL.md
@@ -98,17 +98,18 @@ Check available MCPs - if useful for research (searching docs, finding similar s
 
 Based on the user interview, fill in these components. Most skills need only `name` + `description` — reach for the others when the use case calls for it:
 
-- **name**: Skill identifier (lowercase, hyphens, ≤64 chars)
-- **description**: When to trigger, what it does. This is the primary triggering mechanism — include both what the skill does AND specific contexts for when to use it. All "when to use" info goes here, not in the body. Note: Claude has a tendency to undertrigger skills. Make descriptions a little "pushy" — cover adjacent phrasings and contexts even when the user doesn't name the skill explicitly. *(check-skill #7, #13)*
+- **name**: Skill identifier (lowercase, hyphens, ≤64 chars). Reserved words (`anthropic`, `claude`) are rejected — they collide with platform-owned namespaces.
+- **description**: When to trigger, what it does. Primary triggering mechanism — write it in **third person** ("Processes X", not "You can use this to…") and front-load the trigger phrase. Cap is **1024 characters**; for longer guidance, split trigger phrases into optional `when_to_use` (combined cap 1536). Avoid vague phrasings ("helps with", "processes data") — name a specific capability. Claude undertriggers, so cover adjacent phrasings and contexts even when the user doesn't name the skill explicitly. *(check-skill #7, #13)*
+- **when_to_use** _(Claude Code only)_: Optional split for trigger phrases when the `description` alone would exceed 1024 chars. The two fields are concatenated at routing time under a combined 1536-char cap.
 - **argument-hint**: One-line hint shown in the CLI (e.g., `"[skill name and description]"`) *(check-skill #20)*
-- **user-invocable**: `true` so users can invoke with `/skill-name`. Set to `false` for background knowledge skills — hides from the `/` menu, designed to be preloaded into an agent rather than called directly. *(check-skill #17)*
+- **user-invocable**: Default `true` — **omit** unless you need `false` (reduces frontmatter noise and the post-compaction token budget). Set `false` for background-knowledge skills that should be preloaded into an agent rather than called directly; this also hides them from the `/` menu. *(check-skill #17)*
 - **disable-model-invocation** _(optional)_: Set `true` for dangerous or consequential skills (deploy, destructive ops) that should only fire on explicit user invocation — never auto-triggered. *(check-skill #23)*
 - **model** _(optional)_: Override the session model for this skill. Use `haiku` for fast lookups, `opus` for complex multi-step work.
 - **effort** _(optional)_: Override reasoning depth (`low`/`medium`/`high`/`max`). Use `low` for templating, `high` for code review or analysis.
 - **context: fork** _(optional)_: Run the skill in an isolated subagent — the parent context only sees the final result, not intermediate tool calls. Pair with `agent:` to set the subagent type. When using `context: fork`, declare the subagent's operational scope in `## Key Instructions` (read-only, write-gated, requires approval, etc.). *(check-skill #18)*
 - **hooks** _(optional)_: Lifecycle hooks scoped to this skill's session. Use for on-demand safety guardrails — see On-Demand Hooks below.
 - **paths** _(optional)_: Glob patterns that limit when the skill auto-activates. Useful in monorepos to prevent a backend skill firing in frontend code: `paths: "packages/backend/**"`. *(check-skill #17)*
-- **allowed-tools** _(optional)_: Tools that run without per-use confirmation when this skill is active.
+- **allowed-tools** _(optional)_: Tools that run without per-use confirmation when this skill is active. Canonical forms: **space-separated string** (`Grep Read`) or **YAML list** (`[Grep, Read]` or block form). **Never comma-separated as a string** (`Grep, Read`) — YAML parses it as one literal value and the field silently does nothing.
 - **tested_with** _(optional)_: Model tiers verified against (e.g., `[sonnet, haiku]`); omit if untested. *(check-skill #2)*
 - **references** _(optional)_: Reference files or assets in the skill directory for progressive disclosure.
 
@@ -120,6 +121,10 @@ Read `references/skill-writing-guide.md` before drafting. It covers anatomy,
 progressive disclosure patterns, on-demand hooks, config.json setup, skill
 composition, persistent state, writing style, writing patterns, and the full
 quality requirements checklist.
+
+**Canonical correctness.** In code blocks and inline code, use forward slashes
+(`path/to/file`) — Windows-style backslashes (`path\to\file`) are rejected by
+`check-skill` as they don't round-trip across platforms.
 
 ### Narrate the Draft
 

--- a/plugins/build/skills/check-skill/SKILL.md
+++ b/plugins/build/skills/check-skill/SKILL.md
@@ -27,9 +27,16 @@ then offer an opt-in repair loop.
 python3 <plugin-scripts-dir>/../../src/check/lint.py --root <project-root> --no-urls
 ```
 
-Extract findings for the target skill(s). Static checks cover two of the
-twenty-two criteria (body length, ALL-CAPS density) and run deterministically —
-always run these before LLM checks.
+Extract findings for the target skill(s). Static checks run deterministically
+and always precede LLM checks. They cover:
+
+- **Body length** — warn at >500 non-blank lines (criterion #1)
+- **ALL-CAPS directive density** — warn at ≥3 MUST/NEVER/ALWAYS/REQUIRED/FORBIDDEN (criterion #2)
+- **`allowed-tools` shape** — fail on comma-separated-as-string (canonical: space-separated or YAML list)
+- **Description cap** — fail at >1024 chars; when `when_to_use` is present, fail at >1536 combined
+- **Description quality** — warn on second-person ("you can", "I will"), vague phrasings ("helps with", "processes data"), or XML tags
+- **Reserved words in name** — fail on `anthropic` or `claude` (platform-owned namespaces)
+- **Windows-style paths** — fail on backslash path separators in fenced blocks or inline code (drive-letter prefixes, relative `.\` / `..\` prefixes, or multi-component paths with file extensions)
 
 ### 3. Run LLM Checks
 

--- a/plugins/build/src/check/skill.py
+++ b/plugins/build/src/check/skill.py
@@ -112,20 +112,46 @@ def _check_name(name: str, file_str: str) -> List[dict]:
     return issues
 
 
-def _check_description(desc: str, file_str: str) -> List[dict]:
+def _check_description(
+    desc: str,
+    file_str: str,
+    when_to_use: Optional[str] = None,
+) -> List[dict]:
     issues: List[dict] = []
-    if len(desc) > 1024:
-        issues.append({
-            "file": file_str,
-            "issue": f"skill description exceeds 1024 characters ({len(desc)})",
-            "severity": "warn",
-        })
+
+    # Cap enforcement — FAIL.
+    # Platform cap: description ≤ 1024 chars.
+    # Claude Code: description + when_to_use combined ≤ 1536 chars.
+    if when_to_use:
+        combined = len(desc) + len(when_to_use)
+        if combined > _DESCRIPTION_COMBINED_CAP:
+            issues.append({
+                "file": file_str,
+                "issue": (
+                    f"description + when_to_use combined exceeds "
+                    f"{_DESCRIPTION_COMBINED_CAP} characters ({combined})"
+                ),
+                "severity": "fail",
+            })
+    else:
+        if len(desc) > _DESCRIPTION_CAP:
+            issues.append({
+                "file": file_str,
+                "issue": (
+                    f"skill description exceeds {_DESCRIPTION_CAP} "
+                    f"characters ({len(desc)}); split into when_to_use "
+                    f"to use the combined {_DESCRIPTION_COMBINED_CAP} cap"
+                ),
+                "severity": "fail",
+            })
+
     if _XML_TAG_RE.search(desc):
         issues.append({
             "file": file_str,
             "issue": "skill description contains XML tags",
             "severity": "warn",
         })
+
     desc_lower = desc.lower()
     for pattern in _SECOND_PERSON_PATTERNS:
         if pattern in desc_lower:
@@ -138,6 +164,19 @@ def _check_description(desc: str, file_str: str) -> List[dict]:
                 "severity": "warn",
             })
             break
+
+    for phrase in _VAGUE_PHRASES:
+        if phrase in desc_lower:
+            issues.append({
+                "file": file_str,
+                "issue": (
+                    f"skill description uses vague phrasing "
+                    f"('{phrase}'); name a specific capability"
+                ),
+                "severity": "warn",
+            })
+            break
+
     return issues
 
 

--- a/plugins/build/src/check/skill.py
+++ b/plugins/build/src/check/skill.py
@@ -411,8 +411,9 @@ class SkillDocument(Document):
         """Return base issues plus skill-specific checks.
 
         Base checks: name and description non-empty.
-        Skill checks: name format, description quality, ALL-CAPS directive
-        density, and raw body line count.
+        Skill checks: name format, description quality (cap, third person,
+        vague phrasing), allowed-tools shape, Windows-style paths in code
+        segments, ALL-CAPS directive density, raw body line count.
 
         Args:
             root: Project root directory (passed to base issues()).
@@ -424,7 +425,13 @@ class SkillDocument(Document):
         if self.name:
             result.extend(_check_name(self.name, self.path))
         if self.description:
-            result.extend(_check_description(self.description, self.path))
+            when_to_use = self.meta.get("when_to_use") or self.meta.get("when-to-use")
+            when_to_use_str = when_to_use if isinstance(when_to_use, str) else None
+            result.extend(_check_description(
+                self.description, self.path, when_to_use=when_to_use_str,
+            ))
+        result.extend(_check_allowed_tools(self.allowed_tools, self.path))
+        result.extend(_check_body_paths(self.content, self.path))
         result.extend(_check_directives(self.content, self.path))
         result.extend(_check_body_lines(self.content, self.path))
         return result

--- a/plugins/build/src/check/skill.py
+++ b/plugins/build/src/check/skill.py
@@ -232,6 +232,84 @@ def _check_directives(body: str, file_str: str) -> List[dict]:
     return []
 
 
+# Match real Windows paths, not escape sequences inside string literals.
+# Requires one of: drive letter prefix, ./ or ../ prefix, or a backslash
+# immediately followed by a name with a recognizable file extension.
+_WINDOWS_PATH_RE = re.compile(
+    r"(?:[A-Za-z]:\\\S+"
+    r"|\.{1,2}\\[A-Za-z0-9_./-]+"
+    r"|[A-Za-z0-9_-]+(?:\\[A-Za-z0-9_-]+)*\\[A-Za-z0-9_-]+\.[A-Za-z]{1,5}\b)"
+)
+
+
+def _iter_code_segments(body: str):
+    """Yield (segment_text, line_no) for fenced blocks and inline code spans.
+
+    Fenced blocks: between ``` markers (``` may include a language hint).
+    Inline code: text between single backticks on a line.
+    """
+    in_fence = False
+    fence_buf: List[str] = []
+    fence_start_line = 0
+
+    for line_no, line in enumerate(body.splitlines(), start=1):
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            if in_fence:
+                yield ("\n".join(fence_buf), fence_start_line)
+                fence_buf = []
+                in_fence = False
+            else:
+                in_fence = True
+                fence_start_line = line_no
+            continue
+        if in_fence:
+            fence_buf.append(line)
+            continue
+
+        # Inline code spans on prose lines.
+        idx = 0
+        while True:
+            tick = line.find("`", idx)
+            if tick == -1:
+                break
+            end = line.find("`", tick + 1)
+            if end == -1:
+                break
+            yield (line[tick + 1:end], line_no)
+            idx = end + 1
+
+
+def _check_body_paths(body: str, file_str: str) -> List[dict]:
+    """Flag Windows-style backslash path separators in code segments.
+
+    Skips escape sequences that show up in regex / format strings
+    (``\\n``, ``\\t``, ``\\\\``) by requiring the backslash to be preceded
+    by an identifier character or a drive letter / dot pattern that matches
+    a real filesystem path.
+    """
+    issues: List[dict] = []
+    seen_lines: set[int] = set()
+
+    for segment, line_no in _iter_code_segments(body):
+        if line_no in seen_lines:
+            continue
+        for match in _WINDOWS_PATH_RE.finditer(segment):
+            issues.append({
+                "file": file_str,
+                "issue": (
+                    f"line {line_no}: Windows-style path separator in "
+                    f"code segment ('{match.group(0)}'); use forward "
+                    f"slashes for portability"
+                ),
+                "severity": "fail",
+            })
+            seen_lines.add(line_no)
+            break
+
+    return issues
+
+
 def _check_body_lines(body: str, file_str: str) -> List[dict]:
     raw_lines = sum(1 for line in body.splitlines() if line.strip())
     if raw_lines > 500:

--- a/plugins/build/src/check/skill.py
+++ b/plugins/build/src/check/skill.py
@@ -30,6 +30,16 @@ _SECOND_PERSON_PATTERNS = (
 )
 _RIGID_DIRECTIVE_RE = re.compile(r"\b(?:MUST|NEVER|ALWAYS|REQUIRED|FORBIDDEN)\b")
 _RIGID_DIRECTIVE_THRESHOLD = 3
+_VAGUE_PHRASES = (
+    "helps with",
+    "processes data",
+    "handles stuff",
+    "deals with",
+    "manages things",
+    "works with stuff",
+)
+_DESCRIPTION_CAP = 1024
+_DESCRIPTION_COMBINED_CAP = 1536
 
 
 def strip_frontmatter(text: str) -> str:
@@ -129,6 +139,43 @@ def _check_description(desc: str, file_str: str) -> List[dict]:
             })
             break
     return issues
+
+
+def _check_allowed_tools(value: object, file_str: str) -> List[dict]:
+    """Validate the shape of the ``allowed-tools`` frontmatter field.
+
+    Canonical forms (per Claude Code spec):
+
+    - YAML block list (parsed as a Python list)
+    - Space-separated string (``"Grep Read"``)
+    - Inline YAML list (``"[Grep, Read]"`` — stored as a string by the
+      stdlib parser, but real YAML parses it as a list)
+
+    The silent-breakage case is a comma-separated string like ``"Grep, Read"``
+    which YAML parses as one literal value, so the field does nothing.
+    """
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return []
+    if not isinstance(value, str):
+        return []
+
+    stripped = value.strip()
+    if stripped.startswith("[") and stripped.endswith("]"):
+        return []
+    if "," in stripped:
+        return [{
+            "file": file_str,
+            "issue": (
+                "allowed-tools is comma-separated as a string "
+                f"({value!r}); YAML parses this as one literal value. "
+                "Use space-separated (Grep Read) or YAML list "
+                "([Grep, Read] / block list)."
+            ),
+            "severity": "fail",
+        }]
+    return []
 
 
 def _check_directives(body: str, file_str: str) -> List[dict]:

--- a/plugins/build/tests/test_skill_audit.py
+++ b/plugins/build/tests/test_skill_audit.py
@@ -379,6 +379,26 @@ class TestCheckSkillMeta:
         issues = check_skill_meta(tmp_path / "empty-dir")
         assert issues == []
 
+    def test_allowed_tools_comma_string_fails(self, tmp_path: Path) -> None:
+        from check.skill import check_skill_meta
+        _create_skill(
+            tmp_path, "broken-tools",
+            "---\nname: broken-tools\ndescription: Valid skill.\n"
+            "allowed-tools: Grep, Read\n---\n# X\n",
+        )
+        issues = check_skill_meta(tmp_path / "broken-tools")
+        assert any("comma-separated" in i["issue"] for i in issues)
+
+    def test_windows_path_in_body_fails(self, tmp_path: Path) -> None:
+        from check.skill import check_skill_meta
+        _create_skill(
+            tmp_path, "win-paths",
+            "---\nname: win-paths\ndescription: Valid skill.\n---\n"
+            "# X\n\n```\nopen src\\check\\skill.py\n```\n",
+        )
+        issues = check_skill_meta(tmp_path / "win-paths")
+        assert any("Windows-style" in i["issue"] for i in issues)
+
 
 class TestCheckBodyPaths:
     def test_drive_letter_in_fence_fails(self) -> None:

--- a/plugins/build/tests/test_skill_audit.py
+++ b/plugins/build/tests/test_skill_audit.py
@@ -377,3 +377,32 @@ class TestCheckSkillMeta:
         (tmp_path / "empty-dir").mkdir()
         issues = check_skill_meta(tmp_path / "empty-dir")
         assert issues == []
+
+
+class TestCheckAllowedTools:
+    def test_none_no_issues(self) -> None:
+        from check.skill import _check_allowed_tools
+        assert _check_allowed_tools(None, "f") == []
+
+    def test_list_no_issues(self) -> None:
+        from check.skill import _check_allowed_tools
+        assert _check_allowed_tools(["Grep", "Read"], "f") == []
+
+    def test_space_separated_string_no_issues(self) -> None:
+        from check.skill import _check_allowed_tools
+        assert _check_allowed_tools("Grep Read", "f") == []
+
+    def test_inline_list_string_no_issues(self) -> None:
+        from check.skill import _check_allowed_tools
+        assert _check_allowed_tools("[Grep, Read]", "f") == []
+
+    def test_comma_string_fails(self) -> None:
+        from check.skill import _check_allowed_tools
+        issues = _check_allowed_tools("Grep, Read", "f")
+        assert len(issues) == 1
+        assert issues[0]["severity"] == "fail"
+        assert "comma-separated" in issues[0]["issue"]
+
+    def test_single_tool_no_issues(self) -> None:
+        from check.skill import _check_allowed_tools
+        assert _check_allowed_tools("Grep", "f") == []

--- a/plugins/build/tests/test_skill_audit.py
+++ b/plugins/build/tests/test_skill_audit.py
@@ -298,7 +298,7 @@ class TestCheckSkillMeta:
         issues = check_skill_meta(tmp_path / "claude-helper")
         assert any("reserved" in i["issue"] for i in issues)
 
-    def test_description_too_long_warns(self, tmp_path: Path) -> None:
+    def test_description_too_long_fails(self, tmp_path: Path) -> None:
         from check.skill import check_skill_meta
         long_desc = "x " * 600
         _create_skill(
@@ -306,8 +306,9 @@ class TestCheckSkillMeta:
             f"---\nname: verbose\ndescription: {long_desc}\n---\n# X\n",
         )
         issues = check_skill_meta(tmp_path / "verbose")
-        assert any("1024" in i["issue"] for i in issues)
-        assert any(i["severity"] == "warn" for i in issues)
+        cap_issues = [i for i in issues if "1024" in i["issue"]]
+        assert len(cap_issues) == 1
+        assert cap_issues[0]["severity"] == "fail"
 
     def test_description_xml_tags_warns(self, tmp_path: Path) -> None:
         from check.skill import check_skill_meta
@@ -377,6 +378,38 @@ class TestCheckSkillMeta:
         (tmp_path / "empty-dir").mkdir()
         issues = check_skill_meta(tmp_path / "empty-dir")
         assert issues == []
+
+
+class TestDescriptionCap:
+    def test_description_combined_under_cap_no_fail(self) -> None:
+        from check.skill import _check_description
+        desc = "x" * 1100
+        when = "y" * 300  # combined 1400, under 1536
+        issues = _check_description(desc, "f", when_to_use=when)
+        assert not any(i["severity"] == "fail" for i in issues)
+
+    def test_description_combined_over_cap_fails(self) -> None:
+        from check.skill import _check_description
+        desc = "x" * 1200
+        when = "y" * 400  # combined 1600
+        issues = _check_description(desc, "f", when_to_use=when)
+        cap_issues = [i for i in issues if "1536" in i["issue"]]
+        assert len(cap_issues) == 1
+        assert cap_issues[0]["severity"] == "fail"
+
+    def test_vague_phrasing_warns(self) -> None:
+        from check.skill import _check_description
+        issues = _check_description("Helps with documents.", "f")
+        vague = [i for i in issues if "vague" in i["issue"]]
+        assert len(vague) == 1
+        assert vague[0]["severity"] == "warn"
+
+    def test_specific_description_no_vague_warn(self) -> None:
+        from check.skill import _check_description
+        issues = _check_description(
+            "Generates dbt models from a contract spec.", "f",
+        )
+        assert not any("vague" in i["issue"] for i in issues)
 
 
 class TestCheckAllowedTools:

--- a/plugins/build/tests/test_skill_audit.py
+++ b/plugins/build/tests/test_skill_audit.py
@@ -380,6 +380,47 @@ class TestCheckSkillMeta:
         assert issues == []
 
 
+class TestCheckBodyPaths:
+    def test_drive_letter_in_fence_fails(self) -> None:
+        from check.skill import _check_body_paths
+        body = "```\ncd C:\\Users\\bob\n```\n"
+        issues = _check_body_paths(body, "f")
+        assert len(issues) == 1
+        assert issues[0]["severity"] == "fail"
+
+    def test_relative_path_in_fence_fails(self) -> None:
+        from check.skill import _check_body_paths
+        body = "```\nopen src\\check\\skill.py\n```\n"
+        issues = _check_body_paths(body, "f")
+        assert len(issues) == 1
+        assert issues[0]["severity"] == "fail"
+
+    def test_inline_code_path_fails(self) -> None:
+        from check.skill import _check_body_paths
+        body = "Run the `src\\foo.py` script.\n"
+        issues = _check_body_paths(body, "f")
+        assert len(issues) == 1
+        assert issues[0]["severity"] == "fail"
+
+    def test_escape_sequence_no_fail(self) -> None:
+        from check.skill import _check_body_paths
+        body = "```python\nprint('hello\\nworld')\n```\n"
+        issues = _check_body_paths(body, "f")
+        assert issues == []
+
+    def test_forward_slash_no_fail(self) -> None:
+        from check.skill import _check_body_paths
+        body = "```\ncd plugins/build/src\n```\n"
+        issues = _check_body_paths(body, "f")
+        assert issues == []
+
+    def test_prose_backslash_ignored(self) -> None:
+        from check.skill import _check_body_paths
+        body = "Use the C:\\foo path on Windows.\n"
+        issues = _check_body_paths(body, "f")
+        assert issues == []
+
+
 class TestDescriptionCap:
     def test_description_combined_under_cap_no_fail(self) -> None:
         from check.skill import _check_description


### PR DESCRIPTION
## Summary

PR 1 of the four-PR sequence on #311. Fixes correctness defects that
make `build-skill` silently emit broken frontmatter and `check-skill`
miss canonical-spec violations from Anthropic's
[Claude Code skills spec](https://code.claude.com/docs/en/skills) and
[Platform best-practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices).

## Changes

`check-skill` (structural checks in `plugins/build/src/check/skill.py`):

- `_check_allowed_tools` — FAIL on comma-separated-as-string (`Grep, Read`),
  which YAML parses as one literal value, silently breaking the field.
- Description cap → FAIL at 1024 chars (was WARN); when `when_to_use`
  is set, FAIL at the combined 1536-char Claude Code cap.
- `_check_vague_phrasing` — WARN on description phrasings like
  "helps with", "processes data", "deals with".
- `_check_body_paths` — FAIL on Windows-style backslash separators
  inside fenced blocks or inline code (drive-letter, `.\` / `..\`,
  multi-component with file extension). Skips Python/regex escape
  sequences.

`build-skill` (`plugins/build/skills/build-skill/SKILL.md`):

- `name`: note reserved-word ban (`anthropic`, `claude`).
- `description`: third person, 1024-char cap, front-loaded triggers,
  no vague phrasings; point to `when_to_use` for longer guidance.
- New `when_to_use` bullet for the Claude Code split (combined 1536 cap).
- `user-invocable`: default `true` — omit unless needed; reframes the
  `false` case as the primary reason to set the field.
- `allowed-tools`: canonical forms (space-separated string or YAML list);
  explicitly flag comma-as-string as silent breakage.
- "Canonical correctness" note: forward slashes in code blocks.

`check-skill` (`plugins/build/skills/check-skill/SKILL.md`):

- Static-checks paragraph enumerates all seven deterministic checks.
- 22-criteria numbering unchanged; new checks are additive.

## Out of scope (later PRs)

- PR 2: `$ARGUMENTS` / `!cmd` substitutions, scope/location decision,
  gerund naming.
- PR 3: body-structure realignment (Handoff, Anti-Pattern Guards,
  Won't-statements) + 22-criteria audit.
- PR 4: lifecycle/compaction guidance, eval scaffolding, MCP/script
  audits, time-sensitive content.

## Test plan

- [x] `python -m pytest plugins/build/tests/test_skill_audit.py -v` — 57 passed (16 new)
- [x] Hand-crafted broken SKILL.md → 4 distinct FAILs (reserved word, cap, allowed-tools, Windows path)
- [x] Hand-crafted canonical SKILL.md → 0 issues
- [x] All real plugin skills clean under new checks
- [ ] CI green (ruff + pytest)

Closes part of #311.

🤖 Generated with [Claude Code](https://claude.com/claude-code)