### PR TITLE
feat(build): PR 4 of #311 — lifecycle, evals, and quality patterns (closes sequence)

### DIFF
--- a/plugins/build/skills/build-skill/SKILL.md
+++ b/plugins/build/skills/build-skill/SKILL.md
@@ -79,6 +79,7 @@ Start by understanding the user's intent. If `$ARGUMENTS` is non-empty, use it a
 2. When should this skill trigger? (what user phrases/contexts)
 3. What's the expected output format?
 4. Should we set up test cases to verify the skill works? Skills with objectively verifiable outputs (file transforms, data extraction, code generation, fixed workflow steps) benefit from test cases. Skills with subjective outputs (writing style, art) often don't need them. Suggest the appropriate default based on the skill type, but let the user decide.
+5. When should we scaffold evals — before or after the body? Anthropic's best-practices recommend **evaluation-driven development**: write ≥3 eval scenarios first, then let them shape the body. That catches vague instructions and missing edge cases early. Writing the body first is also valid if the skill's output is hard to describe without a draft. Either is fine; the point is the explicit timing choice, not the default.
 
 ### Interview and Research
 
@@ -178,7 +179,7 @@ Write to the full path determined by the scope decision in the Interview step (e
 
 ### Test Cases
 
-After writing the skill draft, come up with 2-3 realistic test prompts — the kind of thing a real user would actually say. Share them with the user: [you don't have to use this exact language] "Here are a few test cases I'd like to try. Do these look right, or do you want to add more?" Then run them.
+If the user chose upfront eval scaffolding in the Interview (question 5), write ≥3 eval scenarios now — **before** drafting the body. Otherwise, come up with 2-3 realistic test prompts after writing the skill draft. Either way, these are the kind of thing a real user would actually say. Share them with the user: [you don't have to use this exact language] "Here are a few test cases I'd like to try. Do these look right, or do you want to add more?" Then run them.
 
 Save test cases to `evals/evals.json`. Don't write assertions yet — just the prompts. You'll draft assertions in the next step while the runs are in progress.
 

--- a/plugins/build/skills/build-skill/SKILL.md
+++ b/plugins/build/skills/build-skill/SKILL.md
@@ -110,6 +110,8 @@ Check available MCPs - if useful for research (searching docs, finding similar s
 
 ### Write the SKILL.md
 
+Before drafting the body, read `references/skill-writing-guide.md` → **Lifecycle & Compaction**. Skills are standing instructions that persist throughout a conversation, not one-time steps. First 5K tokens are the only part guaranteed to survive compaction, so lead with load-bearing content.
+
 Based on the user interview, fill in these components. Most skills need only `name` + `description` — reach for the others when the use case calls for it:
 
 - **name**: Skill identifier (lowercase, hyphens, ≤64 chars). Reserved words (`anthropic`, `claude`) are rejected — they collide with platform-owned namespaces. Prefer **gerund form** (`processing-pdfs`, `analyzing-spreadsheets`) or **agent-noun form** (`checker`, `parser`) — these read as actions and improve trigger matching. Reject vague tokens (`helper`, `utils`, `tools`, `thing`, `stuff`) — they provide no triggering signal. *(check-skill: gerund-naming WARN)*

--- a/plugins/build/skills/build-skill/references/skill-writing-guide.md
+++ b/plugins/build/skills/build-skill/references/skill-writing-guide.md
@@ -39,6 +39,45 @@ cloud-deploy/
 ```
 Claude reads only the relevant reference file.
 
+## Lifecycle & Compaction
+
+Skills aren't scripts — they're standing instructions that enter the
+conversation once and persist.
+
+**Normal lifecycle.** When a skill triggers, Claude Code renders the
+SKILL.md body into a single message and inserts it into the
+conversation. That message stays for the whole session. Every turn
+after the trigger reads the same body. Nothing reloads unless the
+user re-triggers.
+
+**After compaction.** When the conversation is compacted (either
+explicitly via `/compact` or automatically near the context limit),
+skills are re-attached with two caps:
+
+- **5,000 tokens per skill** — only the first 5K tokens of each
+  re-attached SKILL.md survive. Content past that point is dropped.
+- **25,000 tokens combined** — all re-attached skills share a single
+  25K budget. Skills beyond the budget are dropped entirely.
+
+**Practical implications:**
+
+- **Put the load-bearing instructions first.** The trigger phrase lives
+  in `description`, but the body's first 5K tokens are the only part
+  guaranteed to survive compaction. Structure accordingly.
+- **Write standing instructions, not one-time steps.** A body that
+  says "First, introduce yourself" or "Start by asking three questions"
+  goes stale after the first use and confuses the model on re-read.
+  Write procedures that apply consistently throughout a task: "When
+  processing a file, extract the header first." "Gate destructive ops
+  on explicit user approval." These read correctly on every turn.
+- **Use progressive disclosure for long content.** Move detail to
+  `references/` instead of inlining it. Reference files load on
+  demand and don't consume the 25K combined budget unless actually
+  loaded.
+- **The soft-cap of 500 lines in the body isn't arbitrary** — it
+  approximates the post-compaction survival zone. Skills that blow
+  past it risk losing their tail after a long conversation.
+
 ## Degrees of Freedom
 
 Match instruction specificity to task fragility. Fragile tasks get

--- a/plugins/build/skills/check-skill/SKILL.md
+++ b/plugins/build/skills/check-skill/SKILL.md
@@ -41,6 +41,9 @@ and always precede LLM checks. They cover:
 - **Gerund/vague naming** — warn on vague tokens (`helper`, `utils`, `tools`, `thing`, etc.) anywhere in the name; warn on names that aren't in gerund (`-ing`) or agent-noun (`-er`) form (style suggestion only)
 - **Reference depth** — warn on files nested more than one level under `references/`; flat structure keeps on-demand loading predictable
 - **Reference TOC** — warn on reference files over 100 non-blank lines without a `## Table of Contents`, `## Contents`, or `## TOC` heading in the first 20 lines
+- **MCP reference format** — warn on raw `mcp__<server>__<tool>` names in prose; prefer the shorter `Server:tool_name` form per Anthropic best-practices (raw form in code is fine — it's the actual invocation string)
+- **Time-sensitive content** — warn on year references (`in 2025`, `as of 2024`) and version references (`v3.2`) outside `<details>` blocks; evergreen bodies should wrap historical content in `<details>` "old patterns" blocks
+- **Embedded-script exits** — warn on bare `sys.exit(N)` or `exit N` in `python` / `bash` / `sh` / `zsh` fenced blocks without an explanatory comment on the same or immediately prior line ("solve don't punt")
 
 ### 3. Run LLM Checks
 

--- a/plugins/build/src/check/skill.py
+++ b/plugins/build/src/check/skill.py
@@ -725,6 +725,9 @@ class SkillDocument(Document):
             self.meta.get("argument-hint"), self.content, self.path,
         ))
         result.extend(_check_body_paths(self.content, self.path))
+        result.extend(_check_mcp_references(self.content, self.path))
+        result.extend(_check_time_sensitive(self.content, self.path))
+        result.extend(_check_embedded_scripts(self.content, self.path))
         result.extend(_check_directives(self.content, self.path))
         result.extend(_check_body_lines(self.content, self.path))
         return result

--- a/plugins/build/src/check/skill.py
+++ b/plugins/build/src/check/skill.py
@@ -389,6 +389,159 @@ def _check_body_lines(body: str, file_str: str) -> List[dict]:
     return []
 
 
+_MCP_RAW_RE = re.compile(r"mcp__\w+__\w+")
+_YEAR_REF_RE = re.compile(
+    r"\b(?:in|as of|since|until|by)\s+20\d{2}\b",
+    re.IGNORECASE,
+)
+_VERSION_REF_RE = re.compile(r"\bv\d+\.\d+(?:\.\d+)?\b")
+_BARE_EXIT_RE = re.compile(
+    r"^\s*(?:sys\.exit\(|exit\s+[1-9])",
+)
+_SCRIPT_FENCE_LANGS = frozenset({"python", "bash", "sh", "zsh"})
+
+
+def _strip_code_segments(body: str) -> str:
+    """Return body with fenced code blocks and inline code spans removed.
+
+    Used by checks that should only match prose — e.g., MCP references
+    and time-sensitive phrases. Inside code, the raw form is legitimate
+    (actual tool names, literal commands).
+    """
+    lines = body.splitlines()
+    out: List[str] = []
+    in_fence = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            in_fence = not in_fence
+            out.append("")
+            continue
+        if in_fence:
+            out.append("")
+            continue
+        # Remove inline code spans.
+        out.append(re.sub(r"`[^`]*`", "", line))
+    return "\n".join(out)
+
+
+def _check_mcp_references(body: str, file_str: str) -> List[dict]:
+    """Warn on raw ``mcp__<server>__<tool>`` tool names in prose.
+
+    Anthropic best-practices recommend referring to MCP tools as
+    ``Server:tool_name`` when mentioning them in documentation. The
+    raw ``mcp__`` form is legitimate inside code (actual invocation
+    string) but noisy in prose.
+    """
+    issues: List[dict] = []
+    prose = _strip_code_segments(body)
+    seen: set[str] = set()
+    for match in _MCP_RAW_RE.finditer(prose):
+        name = match.group(0)
+        if name in seen:
+            continue
+        seen.add(name)
+        issues.append({
+            "file": file_str,
+            "issue": (
+                f"raw MCP tool name '{name}' in prose; prefer "
+                f"'Server:tool_name' form for readability"
+            ),
+            "severity": "warn",
+        })
+    return issues
+
+
+def _check_time_sensitive(body: str, file_str: str) -> List[dict]:
+    """Warn on year/version references outside ``<details>`` blocks.
+
+    Best-practices: avoid time-sensitive content in skill bodies except
+    in ``<details>`` "old patterns" sections that signal the content
+    is archival, not evergreen.
+    """
+    issues: List[dict] = []
+    prose = _strip_code_segments(body)
+    # Remove content inside <details>...</details> blocks.
+    prose_stripped = re.sub(
+        r"<details>.*?</details>", "", prose, flags=re.DOTALL | re.IGNORECASE,
+    )
+    seen: set[str] = set()
+    for match in _YEAR_REF_RE.finditer(prose_stripped):
+        phrase = match.group(0)
+        if phrase.lower() in seen:
+            continue
+        seen.add(phrase.lower())
+        issues.append({
+            "file": file_str,
+            "issue": (
+                f"time-sensitive phrase '{phrase}' in skill body; "
+                f"move to <details> 'old patterns' block or rephrase "
+                f"to stay evergreen"
+            ),
+            "severity": "warn",
+        })
+    for match in _VERSION_REF_RE.finditer(prose_stripped):
+        version = match.group(0)
+        if version in seen:
+            continue
+        seen.add(version)
+        issues.append({
+            "file": file_str,
+            "issue": (
+                f"version reference '{version}' in skill body; wrap "
+                f"in <details> if historical, otherwise drop"
+            ),
+            "severity": "warn",
+        })
+    return issues
+
+
+def _check_embedded_scripts(body: str, file_str: str) -> List[dict]:
+    """Warn on bare exits in embedded scripts without explanatory comment.
+
+    Best-practices "solve don't punt": a script that dies with
+    ``sys.exit(1)`` or ``exit 1`` and no context leaves the caller
+    guessing. Require a comment on the same line or the immediately
+    preceding line that names the reason.
+    """
+    issues: List[dict] = []
+    lines = body.splitlines()
+    in_fence = False
+    lang = ""
+    for idx, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            if in_fence:
+                in_fence = False
+                lang = ""
+            else:
+                in_fence = True
+                lang = stripped[3:].strip().lower()
+            continue
+        if not in_fence:
+            continue
+        if lang and lang not in _SCRIPT_FENCE_LANGS:
+            continue
+        if not _BARE_EXIT_RE.match(line):
+            continue
+        # Check for comment on same line or immediately prior line.
+        if "#" in line:
+            continue
+        prior = lines[idx - 1].strip() if idx > 0 else ""
+        if prior.startswith("#"):
+            continue
+        issues.append({
+            "file": file_str,
+            "issue": (
+                f"line {idx + 1}: bare exit in {lang or 'script'} fence "
+                f"without explanatory comment; print the reason before "
+                f"exiting so callers have context"
+            ),
+            "severity": "warn",
+        })
+    return issues
+
+
 _TOC_HEADING_RE = re.compile(
     r"^\s*##+\s*(table of contents|contents|toc)\b",
     re.IGNORECASE | re.MULTILINE,

--- a/plugins/build/tests/test_skill_audit.py
+++ b/plugins/build/tests/test_skill_audit.py
@@ -606,6 +606,110 @@ class TestCheckGerundNaming:
         assert _check_gerund_naming("analyze-spreadsheets-merging", "f") == []
 
 
+class TestCheckMcpReferences:
+    def test_no_mcp_no_issues(self) -> None:
+        from check.skill import _check_mcp_references
+        assert _check_mcp_references("Normal prose about things.", "f") == []
+
+    def test_raw_mcp_in_prose_warns(self) -> None:
+        from check.skill import _check_mcp_references
+        body = "Use mcp__claude_ai_Slack__send_message to post.\n"
+        issues = _check_mcp_references(body, "f")
+        assert len(issues) == 1
+        assert issues[0]["severity"] == "warn"
+        assert "mcp__claude_ai_Slack__send_message" in issues[0]["issue"]
+
+    def test_raw_mcp_in_fenced_code_no_issues(self) -> None:
+        from check.skill import _check_mcp_references
+        body = "```\nmcp__claude_ai_Slack__send_message\n```\n"
+        assert _check_mcp_references(body, "f") == []
+
+    def test_raw_mcp_in_inline_code_no_issues(self) -> None:
+        from check.skill import _check_mcp_references
+        body = "Call `mcp__claude_ai_Slack__send_message` directly.\n"
+        assert _check_mcp_references(body, "f") == []
+
+    def test_duplicate_reference_deduplicated(self) -> None:
+        from check.skill import _check_mcp_references
+        body = (
+            "Use mcp__foo__bar here. Then use mcp__foo__bar again.\n"
+        )
+        issues = _check_mcp_references(body, "f")
+        assert len(issues) == 1
+
+
+class TestCheckTimeSensitive:
+    def test_evergreen_prose_no_issues(self) -> None:
+        from check.skill import _check_time_sensitive
+        assert _check_time_sensitive("Processes files consistently.", "f") == []
+
+    def test_year_reference_warns(self) -> None:
+        from check.skill import _check_time_sensitive
+        issues = _check_time_sensitive("In 2025 we updated the flow.", "f")
+        assert len(issues) == 1
+        assert issues[0]["severity"] == "warn"
+
+    def test_version_reference_warns(self) -> None:
+        from check.skill import _check_time_sensitive
+        issues = _check_time_sensitive("Requires v3.2 of the library.", "f")
+        assert len(issues) == 1
+        assert "v3.2" in issues[0]["issue"]
+
+    def test_year_inside_details_block_no_issues(self) -> None:
+        from check.skill import _check_time_sensitive
+        body = "<details>\nIn 2024 we did X.\n</details>\n"
+        assert _check_time_sensitive(body, "f") == []
+
+    def test_year_in_code_no_issues(self) -> None:
+        from check.skill import _check_time_sensitive
+        body = "```\ndate = 'In 2025'\n```\n"
+        assert _check_time_sensitive(body, "f") == []
+
+
+class TestCheckEmbeddedScripts:
+    def test_no_scripts_no_issues(self) -> None:
+        from check.skill import _check_embedded_scripts
+        assert _check_embedded_scripts("Just prose.\n", "f") == []
+
+    def test_bare_sys_exit_warns(self) -> None:
+        from check.skill import _check_embedded_scripts
+        body = "```python\nsys.exit(1)\n```\n"
+        issues = _check_embedded_scripts(body, "f")
+        assert len(issues) == 1
+        assert issues[0]["severity"] == "warn"
+
+    def test_bare_shell_exit_warns(self) -> None:
+        from check.skill import _check_embedded_scripts
+        body = "```bash\nexit 1\n```\n"
+        issues = _check_embedded_scripts(body, "f")
+        assert len(issues) == 1
+
+    def test_exit_with_same_line_comment_no_issues(self) -> None:
+        from check.skill import _check_embedded_scripts
+        body = "```python\nsys.exit(1)  # license invalid\n```\n"
+        assert _check_embedded_scripts(body, "f") == []
+
+    def test_exit_with_prior_comment_no_issues(self) -> None:
+        from check.skill import _check_embedded_scripts
+        body = (
+            "```python\n"
+            "# license invalid, cannot proceed\n"
+            "sys.exit(1)\n"
+            "```\n"
+        )
+        assert _check_embedded_scripts(body, "f") == []
+
+    def test_exit_zero_no_issues(self) -> None:
+        from check.skill import _check_embedded_scripts
+        body = "```bash\nexit 0\n```\n"
+        assert _check_embedded_scripts(body, "f") == []
+
+    def test_non_script_fence_ignored(self) -> None:
+        from check.skill import _check_embedded_scripts
+        body = "```json\nsys.exit(1)\n```\n"
+        assert _check_embedded_scripts(body, "f") == []
+
+
 class TestCheckReferenceDepth:
     def test_no_references_dir_no_issues(self, tmp_path: Path) -> None:
         from check.skill import _check_reference_depth


### PR DESCRIPTION
## Summary

Final PR of the four-PR sequence on #311. Adds lifecycle/compaction
guidance, reframes eval scaffolding as an upfront decision, and adds
three small static quality checks (MCP references, time-sensitive
content, bare exits in embedded scripts).

With this PR merged, issue #311 is **closed**.

## Changes

**Lifecycle & Compaction** (`skill-writing-guide.md`):

New reference section explains the two-phase lifecycle:

- Normal: rendered SKILL.md enters the conversation as one message
  and persists for the whole session.
- After compaction: first 5K tokens per skill survive under a 25K
  combined budget across all re-attached skills.

Practical implications: put load-bearing instructions first; write
standing instructions, not one-time steps; use progressive disclosure
for long content; the 500-line body soft-cap approximates the
post-compaction survival zone.

Cross-linked from `build-skill/SKILL.md` at the Write step so authors
encounter it before drafting.

**Eval scaffolding as upfront decision** (`build-skill/SKILL.md`):

The Interview step now includes a timing choice: scaffold ≥3 evals
before drafting the body (Anthropic's evaluation-driven development
recommendation) or write the body first and evals after. Either is
valid; the point is the explicit choice. Test Cases section honors
the upfront selection.

**Three new static checks** (`plugins/build/src/check/skill.py`):

- `_check_mcp_references` — WARN on raw `mcp__<server>__<tool>`
  names in prose (outside code). Recommend `Server:tool_name` form.
- `_check_time_sensitive` — WARN on year references (`In 2025`,
  `as of 2024`) and version references (`v3.2`) outside `<details>`
  blocks. Evergreen bodies should wrap historical content in
  `<details>` "old patterns" blocks.
- `_check_embedded_scripts` — WARN on bare `sys.exit(N)` / `exit N`
  in `python` / `bash` / `sh` / `zsh` fenced blocks without an
  explanatory comment. "Solve don't punt" from best-practices.

Shared helper `_strip_code_segments` removes fences and inline code
before matching MCP/time-sensitive patterns.

**`check-skill/SKILL.md`** documents all three new checks in the
static-checks paragraph. 22-criteria numbering unchanged.

## Acceptance sweep notes

Running `check_skill_meta` across all `plugins/*/skills/`:

- **0 FAILs** — no regressions.
- **0 MCP WARNs** — no skill currently uses raw MCP tool references.
- **0 embedded-script WARNs** — no skill has bare exits in documented
  fenced scripts.
- **1 time-sensitive WARN** — `build-hook` references Claude Code
  `v2.1.85+` as a minimum version for the `if` hook field. This is
  a legitimate compatibility note; author can wrap in `<details>`
  or accept the signal.

Well-calibrated checks: high signal, minimal false positives.

## #311 sequence complete

| PR | Focus | Status |
|----|-------|--------|
| #312 | Correctness bugs (PR 1) | Merged |
| #313 | Canonical features (PR 2) | Merged |
| #314 | Body-structure realignment (PR 3) | Merged |
| This | Lifecycle, evals, quality patterns (PR 4) | This PR |

## Test plan

- [x] `python -m pytest plugins/build/tests/test_skill_audit.py -v` — 98 passed (17 new)
- [x] Hand-crafted SKILL with `mcp__foo__bar` in prose → 1 WARN
- [x] Hand-crafted SKILL with `In 2025` in prose → 1 WARN
- [x] Hand-crafted SKILL with bare `sys.exit(1)` in python fence → 1 WARN
- [x] Hand-crafted SKILL with commented `sys.exit(1)` → clean
- [x] Sweep all plugin skills — 0 FAILs, 1 intentional WARN
- [ ] CI green (ruff + pytest)

Closes #311.

🤖 Generated with [Claude Code](https://claude.com/claude-code)