### PR TITLE
refactor(build): align subagent pair with build-skill/check-skill updates

### DIFF
--- a/plugins/build/skills/build-subagent/SKILL.md
+++ b/plugins/build/skills/build-subagent/SKILL.md
@@ -237,10 +237,10 @@ Add fields only when they were raised and confirmed in Step 3:
 |---|---|
 | `disallowedTools` | denylist approach was chosen over allowlist |
 | `model` | specific model was justified for this workflow |
-| `permissionMode` | agent makes broad or irreversible changes |
+| `permissionMode` | agent's risk profile differs from the parent session (see Step 3 for the 6 spec values) |
 | `maxTurns` | multi-step or recursive workflow |
 | `background` | parallelism was the Step 1 justification |
-| `isolation: worktree` | agent writes files AND `background: true`, or modifies versioned files requiring a clean working copy |
+| `isolation: worktree` | **required** when `background: true` AND effective tools include `Write` or `Edit`; also recommended when modifying versioned files that require a clean working copy |
 | `skills` | workflow needs project-specific procedures |
 
 Do not include fields that were not discussed. Do not include commented-out
@@ -313,7 +313,7 @@ definitions that pass the checks it enforces downstream.
 
 ## Key Instructions
 
-- **Won't write the definition file until the user explicitly approves the draft** — Step 6 is a hard gate; no file is written before it passes
+- **Won't write the definition file until the user explicitly approves the draft** — Step 8 is a hard gate; no file is written before it passes
 - **Won't proceed to intake if a skill would suffice** — Step 1 justification check is mandatory; redirect to `/build:build-skill` if none of the three justification conditions hold
 
 ## Anti-Pattern Guards

--- a/plugins/build/skills/build-subagent/SKILL.md
+++ b/plugins/build/skills/build-subagent/SKILL.md
@@ -42,6 +42,10 @@ Do not proceed to intake until the user confirms a subagent is the right primiti
 
 ### 2. Elicit Requirements
 
+If `$ARGUMENTS` is non-empty, seed the intake from it: treat the first token
+as the proposed name and the remainder as the capability description, then
+confirm with the user before moving on.
+
 Gather four inputs, one at a time:
 
 1. **Name** — slug form: lowercase, hyphen-separated, no spaces
@@ -71,8 +75,12 @@ For tools not requested but clearly needed, suggest them and explain why:
 - `Bash` when only file reads are needed
 - `Write`/`Edit` when the agent only produces reports
 - `WebFetch`/`WebSearch` for internal-only workflows
-- `Agent` listed in tools — subagents cannot spawn other subagents; the
-  Agent tool is filtered out at the platform level. Listing it has no effect.
+- `Agent` listed in tools for a **subagent-scoped** definition — subagents
+  cannot spawn other subagents; the Agent tool is filtered out at the
+  platform level. Listing it has no effect. Exception: the `Agent` and
+  `Agent(worker, researcher)` syntax *is* meaningful when the definition
+  is intended to run as the *main thread* via `claude --agent <name>` (spec
+  documents this path explicitly). Flag only for subagent-scoped use.
 
 **`tools` allowlist vs `disallowedTools` denylist:**
 Use `tools` when the agent needs only a small, specific set. Use
@@ -84,13 +92,24 @@ specific ones. If both are set, `disallowedTools` is applied first.
 Do not present these as a menu. Surface each only when the described
 workflow signals it:
 
-**`permissionMode`** — raise only if the agent makes broad or irreversible
-changes:
-- `plan`: proposes changes for user approval before acting
-- `acceptEdits`: accepts file edits without prompting (fully automated writes)
-- Note: if the parent uses `bypassPermissions` or `auto` mode, this field is
-  overridden — the subagent cannot restrict its own permissions below the
-  parent's level.
+**`permissionMode`** — raise only when the agent's risk profile differs from
+the parent session (read-only exploration, auto-accepting edits, etc.). Spec
+values:
+- `default`: standard permission checking with prompts
+- `acceptEdits`: auto-accepts file edits and common filesystem commands for
+  paths in the working directory or `additionalDirectories`
+- `auto`: background classifier reviews commands and protected-directory writes
+- `dontAsk`: auto-denies permission prompts (explicitly allowed tools still work)
+- `bypassPermissions`: skips permission prompts (use with caution)
+- `plan`: plan mode (read-only exploration)
+
+Parent-session precedence rules (spec):
+- If the parent uses `bypassPermissions` **or `acceptEdits`**, that takes
+  precedence and the subagent's `permissionMode` is ignored.
+- If the parent uses `auto` mode, the subagent inherits auto mode and its own
+  `permissionMode` is ignored; the parent's classifier evaluates each tool call.
+- Plugin subagents have `permissionMode`, `hooks`, and `mcpServers` silently
+  ignored regardless of value (spec: security-scoped plugin restriction).
 
 **`maxTurns`** — raise only if the workflow is multi-step or recursive:
 > "This workflow has several steps — add `maxTurns: N` as a safety net.
@@ -101,16 +120,40 @@ in Step 1:
 > "Since parallelism is the reason for this subagent, `background: true`
 > lets it run concurrently while the parent continues."
 
-**`isolation: worktree`** — raise when the agent writes or modifies files AND
-parallelism was cited in Step 1 (`background: true`), or when the agent
-makes changes to versioned files that require a clean working copy:
+**`isolation: worktree`** — **required** when `background: true` is set AND
+the effective tool set includes `Write` or `Edit`. Also recommended when
+the agent makes changes to versioned files that require a clean working
+copy. This mirrors check-subagent #11: background agents with write access
+and no worktree isolation are a flagged warn because parallel writes on
+shared files conflict. Surface this to the user:
 > "Since this agent modifies files in parallel, `isolation: worktree` gives
-> it a clean working copy to prevent write conflicts."
+> it a clean working copy to prevent write conflicts. Without it,
+> check-subagent will flag this combination."
 
 **`skills`** — raise only if the workflow implies needing project-specific
 context or WOS procedures:
 > "Parent session skills aren't inherited. If this agent needs [skill]
 > procedures, list it explicitly in the `skills` field."
+
+**`mcpServers`** — raise when the subagent needs MCP access the parent
+doesn't have, or when you want to keep an MCP server's tool descriptions
+out of the parent conversation's token budget:
+> "The `mcpServers` field scopes MCP servers to this subagent. Inline
+> definitions connect at start and disconnect at finish; string references
+> reuse the parent session's connection. Defining a server here instead of
+> in `.mcp.json` keeps its tool descriptions out of the parent context."
+
+**`memory`** — raise only if the user wants the subagent to accumulate
+knowledge across sessions (codebase patterns, recurring issues, debugging
+insights):
+> "Setting `memory: project` (or `user`/`local`) gives this subagent a
+> persistent directory. Heads-up: enabling memory auto-grants Read/Write/Edit
+> regardless of the `tools` field, so the subagent can manage its memory
+> files. If you specified a narrow `tools` allowlist, memory will expand it."
+
+Scope choices: `user` (`~/.claude/agent-memory/<name>/`), `project`
+(`.claude/agent-memory/<name>/` — shareable via version control, recommended
+default), `local` (`.claude/agent-memory-local/<name>/` — not checked in).
 
 **Portability** — raise only if the user mentions Copilot, Cursor, or
 cross-platform use:
@@ -162,20 +205,30 @@ produces, when to use it.>
 
 <Specific trigger conditions — name the problem, not just the action.
 What makes this the right agent over a skill or inline execution?
-Include 1-2 example requests that SHOULD route here.
-Include at least one example that should NOT (routes to a skill instead).>
+Required: 1–2 example requests that SHOULD route here.
+Required: at least one example that should NOT (routes to a skill
+instead, or is handled inline). The negative case is what disambiguates
+this agent from adjacent routing targets and is checked by
+check-subagent #3.>
 
 ## Workflow
 
 <Numbered steps describing the agent's execution pattern.
 The final step must state an explicit completion condition:
-what "done" looks like and what the agent returns to the parent.>
+what "done" looks like and what the agent returns to the parent.
+See check-subagent #5 — agents without a completion condition AND
+without `maxTurns` are flagged as runaway risks.>
 
 ## Handoff
 
-**Receives:** <specific inputs from parent — name the data, not the category>
-**Produces:** <specific outputs returned to parent — format, location, or structure>
-**Returns to:** <parent agent or orchestrator>
+**Receives:** <concrete input descriptor — e.g., "list of failing test
+names and their error messages", not "test results". Generic category
+descriptors are flagged by check-subagent #4.>
+**Produces:** <concrete output descriptor — format, file path, or
+structure the downstream consumer can parse, e.g., "Markdown report at
+`.research/<slug>.research.md` with Claims table, Sources table, and
+Findings sections">
+**Returns to:** <parent agent or orchestrator name>
 ```
 
 Add fields only when they were raised and confirmed in Step 3:
@@ -206,17 +259,57 @@ A one-liner with no exclusions and no output format is insufficient. A descripti
 
 **Skills are not inherited.** The parent session's active skills do not carry over to subagents. If the workflow requires project-specific procedures, list them explicitly in the `skills` field. If omitted, the subagent starts with no skill context beyond its own system prompt.
 
-### 6. Present for Approval
+### 6. Narrate the Draft
 
-Show the complete draft. Wait for explicit user confirmation before writing
-any file. If the user requests changes, revise and re-present.
+Before asking for approval, walk the user through the key design choices in
+3–6 bullets. Cover:
+
+- **Frontmatter choices** — explain any non-default field settings and why.
+  Name the field *and* the reasoning: "I set `permissionMode: acceptEdits`
+  because this agent auto-applies linter fixes — interactive prompts would
+  defeat the point."
+- **Structure choices** — why the workflow is ordered the way it is, where
+  gate checks are placed and what they guard, and how prescriptive vs.
+  flexible each step is.
+- **Patterns applied** — call out `isolation: worktree`, `background: true`,
+  `memory: project`, `mcpServers` scoping, or other patterns you used.
+- **What you didn't use and why** — briefly note patterns you considered
+  but skipped (e.g., "I didn't set `maxTurns` because the workflow has one
+  step; if we add retry logic, we should add it then"). This is often the
+  most educational part of the narration.
+
+The goal is that a user unfamiliar with subagent authoring can read the
+narration and disagree with any structural choice. If you can't explain a
+choice clearly, revisit it before presenting.
+
+### 7. WOS Quality Check
+
+Before writing to disk, run lint and reindex on the worktree root:
+
+```bash
+python3 plugins/wiki/scripts/lint.py --root <project-root> --no-urls
+python3 plugins/wiki/scripts/reindex.py --root <project-root>
+```
+
+Fix any findings surfaced by lint before writing. `reindex.py` updates
+`_index.md` navigation so the new agent is discoverable.
+
+### 8. Present for Approval
+
+Show the complete draft and the narration together. Wait for explicit user
+confirmation before writing any file. If the user requests changes, revise
+and re-present.
 
 Do not write the file until approved.
 
-### 7. Write the File
+### 9. Write the File and Audit
 
 Write to `.claude/agents/<name>.md`. Confirm the path and that the file
 was written.
+
+After writing, invoke `check-subagent` on the new file — surface any findings
+and offer the repair loop before moving on. build-subagent must produce
+definitions that pass the checks it enforces downstream.
 
 ## Key Instructions
 

--- a/plugins/build/skills/check-subagent/SKILL.md
+++ b/plugins/build/skills/check-subagent/SKILL.md
@@ -92,7 +92,6 @@ Severity: **warn**
 
 **Category:** best-practice.
 
-
 Does the description imply capabilities not covered by the effective tool
 set? Apply the same effective-set logic as Check 1 — a tool removed via
 `disallowedTools` is absent even if not explicitly missing from `tools`.
@@ -374,7 +373,7 @@ are user-judgment calls and may be skipped without regret.
 
 - Won't auto-fix findings — audit produces a report; fixes require explicit user action or invocation of `build-subagent`
 - Won't flag broad tool sets without anchoring the assessment to the agent's stated description — over-permissioning is relative to purpose, not an absolute count
-- Won't pass generic or placeholder handoff fields — `**Receives:** inputs` is a fail, not a pass
+- Won't pass generic or placeholder handoff fields — placeholder text (`<inputs>`, "TBD", empty values) fails Check 4; generic category descriptors ("data", "output", "results") warn on Check 4; concrete descriptors ("list of failing test names with stack traces") pass
 
 ## Handoff
 

--- a/plugins/build/skills/check-subagent/SKILL.md
+++ b/plugins/build/skills/check-subagent/SKILL.md
@@ -24,9 +24,8 @@ agent definitions."
 
 ### 1. Discover
 
-If a file path argument was provided, audit only that file.
-
-Otherwise, scan `.claude/agents/` recursively for `.md` files.
+If `$ARGUMENTS` is non-empty, treat it as a file path and audit only that
+file. Otherwise, scan `.claude/agents/` recursively for `.md` files.
 
 If the directory does not exist or contains no `.md` files:
 
@@ -34,14 +33,26 @@ If the directory does not exist or contains no `.md` files:
 
 Exit after reporting.
 
-### 2. Run Ten Checks
+### 2. Run Eleven Checks
 
-For each definition file, run all ten checks in order.
+For each definition file, run all eleven checks in order.
+
+**Category key:** **canonical** = enforces a spec-documented requirement.
+**best-practice** = recommended by Anthropic best-practices, not binding.
+**toolkit-opinion** = house style with no spec backing; flagged only when a
+trigger condition elevates the finding. Each check is tagged with its
+category so authors can weigh findings appropriately.
 
 #### Check 1 — Tool Over-Permissioning
 
+**Category:** best-practice (anchored to spec's least-privilege guidance but
+flagged on judgment, not fixed thresholds).
+
 Does the effective tool set include capabilities the description does not
-support?
+support? Anchor the assessment to the description — omission of `tools` is
+the spec-documented default (inherit all tools), not inherently suspicious.
+Flag only when the inherited or listed set exceeds what the described
+workflow needs.
 
 **Determining the effective tool set:**
 - If `tools` is set: effective set = listed tools only
@@ -59,18 +70,28 @@ Flag when:
   involves reading or reporting
 - `WebFetch` or `WebSearch` are in the effective set but the agent is
   described as internal-only
-- `Agent` is listed in `tools` — subagents cannot spawn other subagents;
-  the Agent tool is filtered out at the platform level; listing it has
-  no effect and is misleading
+- `Agent` is listed in `tools` for a definition that runs as a
+  subagent (via Agent tool or `@`-mention) — subagents cannot spawn
+  other subagents; the Agent tool is filtered out at the platform level;
+  listing it has no effect. Exception: `Agent` or `Agent(<type>, ...)` is
+  legitimate syntax for definitions intended to run as the *main thread*
+  via `claude --agent <name>` (spec documents this path). Flag only when
+  the definition's description does not indicate main-thread use
 - Only `disallowedTools` is set for a narrowly-scoped agent — the agent
   inherits all tools except the denylisted ones; verify the inherited set
   is not broader than the workflow requires
-- More than 6 tools in the effective set for a narrowly-scoped agent
-  (description covers a single workflow step)
+- An effective tool set substantially wider than the described workflow
+  needs. A "narrow scope" here means the description covers a single
+  workflow step (one verb, one artifact produced); an allowlist of >6 tools
+  for that scope warrants review. For multi-step agents, anchor to the
+  workflow steps, not a fixed tool count
 
 Severity: **warn**
 
 #### Check 2 — Tool Under-Permissioning
+
+**Category:** best-practice.
+
 
 Does the description imply capabilities not covered by the effective tool
 set? Apply the same effective-set logic as Check 1 — a tool removed via
@@ -90,6 +111,10 @@ Flag when:
 Severity: **warn**
 
 #### Check 3 — Description Quality and Invocation Guidance
+
+**Category:** canonical for `description`-field rules (spec-documented
+1024-char cap, routing signal); toolkit-opinion for the `## When to invoke`
+body section (house convention to disambiguate ambiguous descriptions).
 
 A well-formed definition has two routing artifacts: a `description`
 frontmatter field that reads as a routing rule, and a `## When to invoke`
@@ -112,30 +137,61 @@ body section with concrete examples including at least one negative case.
   truncated without warning
 
 **On the `## When to invoke` body section — flag when:**
-- The section is absent entirely — this section is required; it should
-  contain at least one positive trigger example and one negative example
+- The `description` is ambiguous or risks over/undertriggering AND the
+  body has no `## When to invoke` section with disambiguating examples —
+  **Otherwise (description is already a clear routing rule): not flagged.**
+  This is a toolkit-opinion check; the body section is recommended, not
+  spec-required.
 - The section exists but contains no negative example (a request type
-  that should NOT route to this agent and should go to a skill instead)
+  that should NOT route to this agent) when the agent's capability
+  overlaps with a sibling skill or agent — a negative case is what
+  disambiguates overlapping routing targets.
 
-Severity: **warn**
+**Trigger-evaluation fallback:** When routing behavior is uncertain after
+the static checks above, generate 8–10 should-trigger queries and 8–10
+should-NOT-trigger queries (near-miss cases that test the exclusion
+boundary), evaluate each against the subagent's `description`, and report
+the hit rate. Pass when both rates exceed 80%; otherwise recommend
+description tightening.
+
+Severity: **warn** (description-field failures) / **info**
+(trigger-evaluation recommendation).
 
 #### Check 4 — Handoff Contract Completeness
 
-Context loss at handoffs is the second-most common multi-agent production
-failure mode.
+**Category:** toolkit-opinion. The `## Handoff` section is not spec-required;
+it's a WOS convention for skill-chain composition and `check-skill-chain`
+verification. Context loss at handoffs is the second-most common multi-agent
+production failure mode per Anthropic's engineering writeups — the section is
+strongly recommended when the agent's output is consumed by another agent,
+skill, or workflow step.
 
-Flag when:
+**Trigger:** the agent's description or workflow implies the output flows
+into another agent/skill/step (chainable, callable, or produces a structured
+artifact a downstream consumer reads), OR the agent writes files a parent
+workflow will act on.
+
+**When triggered, flag when:**
 - No `## Handoff` section is present — **warn**
 - Section present but `**Receives:**`, `**Produces:**`, or `**Returns to:**`
   fields are missing or contain placeholder text (e.g., "TBD", `<inputs>`,
   empty values) — **fail**
+- Fields use generic category descriptors ("data", "output", "results")
+  rather than concrete descriptors ("list of failing test names and their
+  error messages") — **warn**. Concrete descriptors prevent context-loss
+  failures at handoff; generic ones hide what state is actually conveyed.
 
-Severity: **warn** (missing section) / **fail** (placeholder or empty fields)
+**Otherwise (self-contained agent whose output the user reads directly):
+not flagged.**
+
+Severity: **warn** / **fail** (as noted above).
 
 #### Check 5 — Termination Conditions
 
-Agents without explicit stopping conditions are a documented top cognitive
-fault in production agentic systems.
+**Category:** best-practice. Spec documents `maxTurns` as a safety net but
+does not require termination language in the body. Agents without explicit
+stopping conditions are a documented top cognitive fault ("context anxiety",
+premature wrap-up, runaway loops) per Anthropic's engineering writeups.
 
 Flag when the `## Workflow` section (or equivalent) has no step that
 describes what "done" looks like, what the agent returns to the parent on
@@ -147,6 +203,11 @@ are runaway risks.
 Severity: **warn**
 
 #### Check 6 — Context Cost Justified
+
+**Category:** toolkit-opinion. Not spec-required. Multi-agent workflows use
+4–7× more tokens than single-agent sessions (Anthropic *Multi-Agent Research
+System*); a subagent that buys no isolation, parallelism, or tool-scope
+benefit is a cost multiplier without upside.
 
 Subagents are full context forks — high overhead compared to skills or
 inline execution.
@@ -161,6 +222,9 @@ Severity: **warn**
 
 #### Check 7 — Skill Overlap
 
+**Category:** toolkit-opinion. Related to Check 6 but focused on a specific
+signal: exact capability duplication with an existing skill.
+
 Flag when the agent's described capability matches an existing skill
 in `skills/` and the definition provides no rationale for why a
 subagent is preferable (parallelism, tool isolation, or context pressure).
@@ -171,6 +235,9 @@ described primary capability.
 Severity: **warn**
 
 #### Check 8 — Skills Inheritance Gap
+
+**Category:** canonical (spec: "Subagents don't inherit skills from the
+parent conversation").
 
 Parent session skills are NOT inherited by subagents. Skills must be listed
 explicitly in the `skills` frontmatter field.
@@ -184,17 +251,45 @@ Severity: **warn**
 
 #### Check 9 — Permission Mode and Parent Propagation
 
+**Category:** canonical (enforces spec-documented plugin restrictions).
+
 Flag when:
 - `permissionMode: bypassPermissions` is set — this grants the subagent
   unrestricted access regardless of the user's session settings. Flag
   for explicit justification review.
-- `permissionMode` is set to any value but the agent is loaded from a
-  plugin (`agents/` in a plugin directory) — plugin subagents have
-  `permissionMode` silently ignored; the field is a no-op and misleading.
+- **Any of `permissionMode`, `hooks`, or `mcpServers` is set on an agent
+  loaded from a plugin** (`agents/` in a plugin directory). Spec: "For
+  security reasons, plugin subagents do not support the `hooks`,
+  `mcpServers`, or `permissionMode` frontmatter fields. These fields are
+  ignored when loading agents from a plugin." Any of the three in a plugin
+  definition is a no-op and misleading.
+- Parent-precedence mismatch: `permissionMode` is set on the subagent but
+  the expected parent context uses `bypassPermissions`, `acceptEdits`, or
+  `auto` — all three override the subagent's choice. Informational flag
+  only; the static definition can't know the runtime parent.
 
-Severity: **warn** (bypassPermissions) / **warn** (plugin no-op)
+Severity: **warn** (bypassPermissions) / **warn** (plugin no-op) / **info**
+(parent-precedence mismatch).
 
-#### Check 10 — Parallel Write Conflict Risk
+#### Check 10 — Memory Field Implicit Tool Grant
+
+**Category:** canonical (spec-documented side-effect).
+
+When `memory` is set (`user`, `project`, or `local`), the spec auto-enables
+Read, Write, and Edit so the subagent can manage its memory files. This
+silently expands a narrow `tools` allowlist.
+
+Flag when:
+- `memory` is set AND `tools` is also set AND the `tools` allowlist does
+  not include Read, Write, **and** Edit — the runtime will enable all three
+  regardless, so the allowlist is misleading about the agent's actual
+  capability surface.
+
+Severity: **warn**
+
+#### Check 11 — Parallel Write Conflict Risk
+
+**Category:** best-practice (quotes Anthropic blog; not spec-required).
 
 Flag when:
 - `background: true` is set AND the effective tool set includes `Write`
@@ -208,13 +303,24 @@ Severity: **warn**
 
 ### 3. Emit Findings
 
-Output one line per issue, in `scripts/lint.py` format:
+Print the summary line at the **top** of the report so reviewers see the
+headline before the detail:
+
+```
+Audited N agent(s): N fail, N warn, N info
+```
+
+Then one line per issue, in `scripts/lint.py` format:
 
 ```
 [severity] path/to/file.md — description of issue
 ```
 
-Group findings by file. Within each file, sort `[fail]` before `[warn]`.
+Group findings by file. Within each file, sort by severity (`[fail]` before
+`[warn]` before `[info]`), then by category (canonical before best-practice
+before toolkit-opinion), then by check number. This ordering surfaces the
+spec-binding failures before house-style warnings.
+
 If a file has no issues, output:
 
 ```
@@ -223,16 +329,30 @@ If a file has no issues, output:
 
 ### 4. Summarize
 
-After all findings, print:
-
-```
-Audited N agent(s): N ok, N warn, N fail
-```
-
-If any issues were found, add a one-sentence recommendation, e.g.:
+Repeat the summary line at the **bottom** of the report (same format as the
+top). If any issues were found, add a one-sentence recommendation, e.g.:
 
 > "3 agents have over-permissioned tool sets — run `/build:build-subagent`
 > to rebuild with least-privilege tool selection."
+
+### 5. Opt-In Repair Loop
+
+After presenting findings, ask:
+
+> "Apply fixes? Enter y (all), n (skip), or comma-separated numbers."
+
+For each selected finding:
+
+1. Read the relevant section of the agent definition
+2. Propose a minimal specific edit — fix the finding without restructuring
+   surrounding content
+3. Show the diff
+4. Write the change only on user confirmation
+5. Re-run the relevant check (and any adjacent checks whose inputs the edit
+   touched) to verify the fix before moving to the next selection
+
+Canonical-category findings should be applied first; toolkit-opinion findings
+are user-judgment calls and may be skipped without regret.
 
 ## Anti-Pattern Guards
 


### PR DESCRIPTION
## Summary
Propagate patterns from recent `build-skill` / `check-skill` updates (#312–#315, #317) into the `build-subagent` and `check-subagent` pair so the authoring and audit skills stay coherent and match the current Anthropic subagent spec.

- **3 canonical spec-drift items fixed** — `permissionMode` override list, plugin-ignored field list, `Agent(agent_type)` main-thread vs. subagent-scope distinction
- **Category key applied** — every `check-subagent` check now tagged `canonical` / `best-practice` / `toolkit-opinion` with trigger conditions and explicit "Otherwise: not flagged" clauses for toolkit-opinion checks
- **Build ↔ check coherence** verified across 8 topics (`## Handoff` concreteness, `## When to invoke` negative examples, `isolation: worktree` parallel-write rule, skills non-inheritance, termination+maxTurns, etc.)

## Key changes

### Spec conformance
- `build-subagent` `permissionMode` documents all 6 spec values (`default`, `acceptEdits`, `auto`, `dontAsk`, `bypassPermissions`, `plan`) and full parent-precedence rules (`bypassPermissions`, `acceptEdits`, and `auto` all override the subagent)
- `check-subagent` Check 9 flags plugin-ignored `permissionMode`, `hooks`, **and** `mcpServers` — spec silently ignores all three in plugin subagents, not just `permissionMode`
- `Agent(agent_type)` is now flagged **only** for subagent-scoped use; main-thread use via `claude --agent` is documented as legitimate

### Spec gaps closed
- `memory` and `mcpServers` frontmatter fields added to `build-subagent` Advanced configuration with triggers and implicit-grant callouts (enabling `memory` auto-grants Read/Write/Edit)
- `check-subagent` gains Check 10 (Memory Field Implicit Tool Grant) for the silent allowlist expansion

### Pattern propagation from build-skill / check-skill
- `check-subagent` adopts the three-tier category key (canonical/best-practice/toolkit-opinion) applied to all 11 checks
- `check-subagent` Step 3 gains top-of-report summary + category-based sort; new Step 5 adds opt-in repair loop with per-finding confirmation and canonical-first prioritization
- Check 3 gains trigger-evaluation fallback (8–10 should/should-not query test, >80% hit-rate threshold) mirroring `check-skill` #7
- `build-subagent` gains Narrate-the-Draft (Step 6), WOS Quality Check (Step 7 lint+reindex gate), and post-write `check-subagent` audit invocation (Step 9)
- Inline cross-references (`check-subagent #3`, `#4`, `#5`, `#11`) added to the draft template so authors see the auditor's rules while drafting
- `$ARGUMENTS` wired into both skills

### Coherence alignment
- `isolation: worktree` is now stated as **required** in `build-subagent` when `background: true` + Write/Edit, matching Check 11's trigger exactly
- Template requires a negative example in `## When to invoke` (Check 3)
- Template requires concrete input/output descriptors in `## Handoff` (Check 4 now also flags generic category descriptors like "data", "output")

## Deferred (out of scope for this PR)
- Building a deterministic Python linter for subagents to mirror `plugins/build/src/check/skill.py`. The category key added here labels which of the 11 checks are deterministic candidates.

## Verification
- `python3 plugins/wiki/scripts/lint.py --root . --no-urls` → passes
- `build-subagent` line count: 353 (under 500 ✓)
- `check-subagent` line count: 385 (under 500 ✓)
- Before/after audit deltas: **3 fail → 0**, **16 warn → 1 deferred**, **3 info → 1 deferred**

Full refinement report, before/after audits, spec-conformance doc, and best-practices research are in the worktree's `.plans/` and `.research/` directories (gitignored by project convention, not included in this PR).

## Test plan
- [ ] Re-run `lint.py --no-urls` on this branch in CI
- [ ] Spot-check: invoke `/build:build-subagent` in a test worktree and confirm the new Narrate-the-Draft and post-write check-subagent steps fire
- [ ] Spot-check: invoke `/build:check-subagent` on an existing agent definition and confirm findings show category labels and the top-of-report summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)