### PR TITLE
refactor(build): align hook pair with build-skill/check-skill updates

### DIFF
--- a/plugins/build/skills/build-hook/SKILL.md
+++ b/plugins/build/skills/build-hook/SKILL.md
@@ -162,6 +162,13 @@ leading text triggers "JSON validation failed."
   10,000 characters (spec-wide truncation rule).
 - `continue: false` + `stopReason` — halts the entire conversation.
 - `systemMessage` — user-visible message.
+- `suppressOutput: true` — omits hook output from the debug log (keeps
+  functional effects like `additionalContext` / `decision` intact).
+- `sessionTitle` (UserPromptSubmit only) — auto-names the session.
+- `retry: true` (PermissionDenied only) — tells Claude it may retry the
+  denied tool call.
+- `worktreePath` (WorktreeCreate, HTTP handlers) — required return field;
+  command handlers print the path to stdout instead.
 
 **Artifact 2: settings.json entry**
 
@@ -330,6 +337,14 @@ Operational implication: treat hook additions to `settings.json` with the
 same code-review scrutiny as executable source files. The enhanced warning
 dialog Anthropic added after the CVE is the last line of defense.
 
+**Recursive-loop safety (spec warning).** Avoid invoking `claude` or
+`claude-code` from inside a hook command — each spawn re-fires hooks on the
+nested session and compounds exponentially. This is distinct from the
+Stop-hook infinite-loop case (§5): even non-Stop hooks that shell out to
+Claude can cause runaway spawning. If LLM-mediated decisions genuinely need
+to run inside a hook, use `type: "prompt"` or `type: "agent"` handlers
+instead of a shell-out to `claude`.
+
 ## Known Limitations
 
 Three permanent limitations that affect hook design decisions:
@@ -339,7 +354,11 @@ Three permanent limitations that affect hook design decisions:
   to resolve to the project root regardless of cwd; `$HOME` and `~` have
   been observed to expand inconsistently across versions and silently fail
   to load the script. Verify the hook appears in `/hooks` after any path
-  change.
+  change. Plugin-bundled hooks additionally get `${CLAUDE_PLUGIN_ROOT}`
+  (install dir, changes on update) and `${CLAUDE_PLUGIN_DATA}` (persistent
+  data dir, survives updates). `$CLAUDE_ENV_FILE` is available inside
+  `SessionStart`, `CwdChanged`, and `FileChanged` hook scripts for
+  persisting environment variables into the session.
 - **Non-interactive mode:** Under `claude -p` (non-interactive / CI), the
   `AskUserQuestion` and `ExitPlanMode` tools block because there is no user to
   answer them. The documented workaround is a `PreToolUse` hook that returns

--- a/plugins/build/skills/build-hook/SKILL.md
+++ b/plugins/build/skills/build-hook/SKILL.md
@@ -332,7 +332,7 @@ dialog Anthropic added after the CVE is the last line of defense.
 
 ## Known Limitations
 
-Two permanent limitations that affect hook design decisions:
+Three permanent limitations that affect hook design decisions:
 
 - **Path expansion:** Use `$CLAUDE_PROJECT_DIR` (or an absolute path) in
   `settings.json` `"command"` values. `$CLAUDE_PROJECT_DIR` is guaranteed
@@ -340,9 +340,12 @@ Two permanent limitations that affect hook design decisions:
   been observed to expand inconsistently across versions and silently fail
   to load the script. Verify the hook appears in `/hooks` after any path
   change.
-- **Non-interactive mode:** `PermissionRequest` hooks do not fire when Claude Code
-  runs with the `-p` flag (non-interactive / CI). Any enforcement that must work in
-  CI must use `PreToolUse` instead.
+- **Non-interactive mode:** Under `claude -p` (non-interactive / CI), the
+  `AskUserQuestion` and `ExitPlanMode` tools block because there is no user to
+  answer them. The documented workaround is a `PreToolUse` hook that returns
+  `permissionDecision: "allow"` with an `updatedInput` supplying the answer.
+  Anchor CI-critical enforcement on `PreToolUse`, not on interactive-only
+  events.
 - **Shell profile pollution:** `~/.bashrc` or `~/.zshrc` statements that emit
   output unconditionally corrupt the stdin JSON pipe and cause hook parse
   failures. Fix by guarding interactive-only output:
@@ -369,11 +372,11 @@ decides.
 
 Present both artifacts — the complete hook script and the settings.json
 snippet — and wait for explicit user approval before writing any file to
-disk. Do not write anything before this gate passes.
+disk. Write only after this gate passes.
 
 If the user requests changes, revise and re-present. Continue this loop
-until the user explicitly approves the artifacts or cancels. Do not
-proceed to Save on anything short of explicit approval.
+until the user explicitly approves the artifacts or cancels. Proceed to
+Save only on explicit approval.
 
 ## 8. Save
 

--- a/plugins/build/skills/build-hook/SKILL.md
+++ b/plugins/build/skills/build-hook/SKILL.md
@@ -34,16 +34,21 @@ Determine whether a hook is the right primitive before asking hook-specific ques
 
 ## 2. Elicit
 
+If `$ARGUMENTS` is non-empty, parse it as `[hook-event] [enforcement-goal]` —
+pre-fill the two fields below from the tokens, confirm them with the user, and
+only ask the handler-type question. Otherwise:
+
 Ask three things, one question at a time:
 
 **1. Hook event** — which lifecycle moment should trigger this hook?
 
 | Category | Events |
 |----------|--------|
-| Tool execution | `PreToolUse` (fires before; can block), `PostToolUse` (fires after; cannot prevent), `PostToolUseFailure` |
-| Session lifecycle | `SessionStart`, `SessionEnd`, `UserPromptSubmit`, `PreCompact`, `PostCompact` |
-| Agent coordination | `Stop`, `SubagentStop`, `SubagentStart` |
-| Permission | `Notification` (observability only), `PermissionRequest`, `PermissionDenied` |
+| Tool execution | `PreToolUse` (blockable), `PostToolUse` (cannot prevent), `PostToolUseFailure` |
+| Session lifecycle | `SessionStart`, `SessionEnd`, `UserPromptSubmit` (blockable), `PreCompact` (blockable), `PostCompact`, `InstructionsLoaded`, `ConfigChange` (blockable), `CwdChanged`, `FileChanged` |
+| Agent coordination | `Stop` (blockable), `StopFailure`, `SubagentStart`, `SubagentStop` (blockable), `TeammateIdle` (blockable) |
+| Tasks & worktrees | `TaskCreated` (blockable), `TaskCompleted` (blockable), `WorktreeCreate` (**any** non-zero exit fails creation), `WorktreeRemove` |
+| Permission & MCP | `Notification` (observability only), `PermissionRequest` (blockable), `PermissionDenied`, `Elicitation` (blockable), `ElicitationResult` (blockable) |
 
 If the goal is to *block* or *prevent* something, the event must be
 `PreToolUse` — `PostToolUse` fires after execution and cannot prevent it.
@@ -119,8 +124,8 @@ trap 'echo "Error on line ${LINENO}: ${BASH_COMMAND}" >&2' ERR
 trap 'rm -f "${TMPFILE:-}"' EXIT
 ```
 
-Never include `set -x` in production hooks — it floods stderr and can leak
-payload values from the JSON input in traces. Use it only during local debugging.
+Use `set -x` only during local debugging — in production it floods stderr and
+can leak payload values from the JSON input in traces.
 
 **Style:** Use `lower_case_with_underscores` for local variables and functions;
 `UPPER_CASE_WITH_UNDERSCORES` for exported variables and constants. When the
@@ -142,6 +147,22 @@ of blocking, print JSON to stdout on exit 0:
 This replaces the entire `tool_input` before execution. Use this when the goal is
 to strip dangerous flags rather than refuse the operation entirely.
 
+**Broader JSON output contract.** stdout on exit 0 may carry these fields; stdout
+on any non-zero exit is ignored. stdout must be **only** the JSON object — any
+leading text triggers "JSON validation failed."
+
+- `hookSpecificOutput.hookEventName` (required) — echo the event name.
+- `permissionDecision: "allow" | "deny" | "ask" | "defer"` plus
+  `permissionDecisionReason` — PreToolUse / PermissionRequest block-or-allow
+  channel. Precedence across hooks: `deny > defer > ask > allow`.
+- `decision: "block"` + `reason` — top-level field for UserPromptSubmit,
+  PostToolUse, Stop, SubagentStop, PreCompact, ConfigChange, TaskCreated,
+  TaskCompleted.
+- `additionalContext` — extra text injected into Claude's view; capped at
+  10,000 characters (spec-wide truncation rule).
+- `continue: false` + `stopReason` — halts the entire conversation.
+- `systemMessage` — user-visible message.
+
 **Artifact 2: settings.json entry**
 
 ```json
@@ -153,7 +174,7 @@ to strip dangerous flags rather than refuse the operation entirely.
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/[name].sh",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/[name].sh",
             "timeout": 60
           }
         ]
@@ -163,10 +184,19 @@ to strip dangerous flags rather than refuse the operation entirely.
 }
 ```
 
-Set `"timeout"` generously (60–120s is typical). A hook that exceeds its
-timeout is treated as non-blocking — the operation proceeds and a hook
-error appears in the transcript. Slow hooks that approach their timeout
+Spec defaults: 600 s for command hooks, 30 s for prompt, 60 s for agent.
+Lower `"timeout"` for tight gates (10–60 s typical) so a stuck hook fails
+fast; raise only when the enforcement step genuinely needs it. A hook that
+exceeds its timeout is treated as non-blocking — the operation proceeds
+and a hook error appears in the transcript. Slow synchronous hooks
 accumulate session sluggishness and create pressure to bypass enforcement.
+
+Optional command-handler fields: `"shell": "bash" | "powershell"` (explicit
+shell selection for cross-platform hooks); `"statusMessage": "..."` (spinner
+text shown while the hook runs); `"asyncRewake": true` (async hook that wakes
+Claude on exit 2 with stderr/stdout, implies `async: true`). HTTP handlers
+accept `"headers"` and `"allowedEnvVars"`; prompt/agent handlers accept
+`"model"` (defaults to the fast model for prompt).
 
 Include `matcher` when the event is tool-scoped (PreToolUse, PostToolUse).
 Matcher syntax: simple name (`"Bash"`), pipe-separated (`"Write|Edit|MultiEdit"`),
@@ -176,6 +206,12 @@ wildcard (`"*"`), or regex (`"mcp__memory__.*"`).
 - `"*"`, `""`, or omitted → wildcard: fires on every tool call for this event
 - Alphanumeric + pipe only (e.g., `"Write|Edit|MultiEdit"`) → exact match or pipe-separated list
 - Any other character (e.g., `"mcp__memory__.*"`, `"^Notebook"`) → JavaScript regex (not POSIX; case-sensitive)
+
+**FileChanged matcher exception.** `FileChanged` treats `matcher` as a
+`|`-separated list of literal filenames, not a regex. `".envrc|.env"` watches
+those two files; regex syntax there is not interpreted. An MCP matcher like
+`"mcp__memory"` (no trailing `.*`) is exact-match and matches nothing — use
+`"mcp__memory__.*"` for regex scope.
 
 **`if` field** (v2.1.85+): filters individual handlers by tool name and arguments. The hook
 process does not spawn at all when `if` doesn't match — tighter than `matcher` alone and
@@ -268,9 +304,20 @@ This check is mandatory for any Stop/SubagentStop hook that may exit 2.
 
 **Important:** `stop_hook_active` is a **SubagentStop-only** field — it is
 absent from `Stop` event payloads (which include `stop_reason` instead). The
-guard above works for SubagentStop. For `Stop` hooks, implement an equivalent
-re-entry guard (e.g., check a session-scoped temp file or track that the hook
-has already fired) and exit 0 if re-entry is detected.
+guard above works for SubagentStop. For `Stop` hooks, use one of three
+loop-break layers (all three is belt-and-suspenders for production gates):
+
+1. **`stop_hook_active` field** — SubagentStop only; exits 0 on re-entry.
+2. **Progress-indicator check on `last_assistant_message`** (SubagentStop
+   payload field) — exit 0 if the subagent is making progress toward the
+   hook's requirement, so the block resolves when the subagent completes
+   the work.
+3. **Session-scoped guard file** keyed to `session_id` — touch a temp file
+   on first block; exit 0 if it already exists. Necessary for `Stop` hooks
+   since its payload lacks `stop_hook_active`.
+
+Without at least one layer, a blocking Stop/SubagentStop hook loops until the
+session is killed.
 
 ## Security Note
 
@@ -287,10 +334,12 @@ dialog Anthropic added after the CVE is the last line of defense.
 
 Two permanent limitations that affect hook design decisions:
 
-- **Path expansion:** `$HOME` is not expanded in `settings.json` `"command"` values.
-  A command like `"$HOME/.claude/hooks/script.sh"` silently fails to load. Use
-  absolute paths or `~` expansion. Verify the hook appears in `/hooks` after any
-  path change.
+- **Path expansion:** Use `$CLAUDE_PROJECT_DIR` (or an absolute path) in
+  `settings.json` `"command"` values. `$CLAUDE_PROJECT_DIR` is guaranteed
+  to resolve to the project root regardless of cwd; `$HOME` and `~` have
+  been observed to expand inconsistently across versions and silently fail
+  to load the script. Verify the hook appears in `/hooks` after any path
+  change.
 - **Non-interactive mode:** `PermissionRequest` hooks do not fire when Claude Code
   runs with the `-p` flag (non-interactive / CI). Any enforcement that must work in
   CI must use `PreToolUse` instead.
@@ -369,6 +418,7 @@ After testing, offer:
 - Won't build a hook when `permissions.deny` covers the goal — unconditional permanent blocks don't need logic or a script
 - Won't build a hook for advisory guidance or preferences — suggest CLAUDE.md or a skill instead
 - Won't skip the Safety Check — run all eleven criteria before declaring the draft ready
+- Recovery if a hook is written in error: run `chmod -x .claude/hooks/<name>.sh` to disable without deleting, or remove the file and the matching `settings.json` entry; a configured hook whose script is missing or non-executable silently fails and leaves normal tool flow intact
 
 ## Handoff
 

--- a/plugins/build/skills/check-hook/SKILL.md
+++ b/plugins/build/skills/check-hook/SKILL.md
@@ -113,7 +113,7 @@ Also check that each command hook's script file is executable (`chmod +x`). A no
 
 For each hook with a `matcher` field, verify the tool name uses exact canonical casing: `Bash`, `Write`, `Edit`, `MultiEdit`, `Read`, `Glob`, `Grep`, `WebFetch`, `WebSearch`, `Agent`, `NotebookEdit`, `NotebookRead`. A matcher on `bash` or `write` silently matches nothing, disabling the hook without any error. Flag as `fail`.
 
-Also check each hook's `"command"` field in `settings.json` for `$HOME`. `$HOME` is not expanded in JSON command fields; a hook using `"$HOME/.claude/hooks/script.sh"` silently fails to load. Use `~` or an absolute path instead. Flag as `fail`.
+Also check each hook's `"command"` field in `settings.json` for `$HOME` or `~`. Both have been observed to expand inconsistently across versions and silently fail to load the script; the spec's reference pattern is `"$CLAUDE_PROJECT_DIR"/.claude/hooks/<name>.sh` (or an absolute path), which resolves regardless of cwd. Flag as `warn`.
 
 ### 7. Enforcement intent on PostToolUse
 

--- a/plugins/build/skills/check-hook/SKILL.md
+++ b/plugins/build/skills/check-hook/SKILL.md
@@ -20,11 +20,10 @@ findings but does not modify any files.
 
 ## 1. Input
 
-Read hooks from both of these locations (use whichever exist):
+If `$ARGUMENTS` is non-empty, read the settings file at that path. Otherwise,
+read hooks from both of these default locations (use whichever exist):
 - `.claude/settings.json`
 - `.claude/settings.local.json`
-
-If a file path argument was provided, read that file instead.
 
 If neither location exists, or neither contains a `hooks:` key, report
 this as the first finding before running any checks:
@@ -90,6 +89,8 @@ Also flag as `warn` for Python hook scripts that use `sys.exit(1)` to signal val
 
 Also flag as `warn` if a hook writes structured JSON output (`hookSpecificOutput`, `systemMessage`, or raw stdout) that could exceed 10,000 characters in practice — hook stdout is capped at 10,000 characters and truncated silently, which corrupts structured JSON responses.
 
+Also flag as `warn` if a hook emits JSON on stdout but any non-zero exit path precedes or follows the emission — Claude Code parses stdout only on exit 0; stdout on any non-zero exit is discarded, so a JSON block emitted on exit 2 is silently lost. For the same reason, flag as `warn` if a JSON-emitting hook omits `hookSpecificOutput.hookEventName` (spec-required field) or emits leading non-JSON text (e.g., `echo "info" ; jq -n '...'`) — "JSON validation failed" errors surface in the transcript with no block effect.
+
 ### 4. Stop hook loop risk
 
 For any `Stop` or `SubagentStop` hook that may exit 2, check whether a re-entry guard is present.
@@ -99,6 +100,8 @@ For any `Stop` or `SubagentStop` hook that may exit 2, check whether a re-entry 
 **`Stop`:** The payload does not include `stop_hook_active` (it includes `stop_reason` instead). An equivalent re-entry guard is still required — check that the script uses a session-scoped mechanism (e.g., a temp file keyed to `session_id`) to detect and short-circuit repeated firing.
 
 Flag as `fail` for any Stop or SubagentStop hook that may exit 2 but contains no re-entry guard of either form.
+
+Also flag as `warn` for SubagentStop hooks that exit 2 and use `stop_hook_active` alone without inspecting `last_assistant_message` (the subagent's most recent output) for progress indicators. Spec recommends layering both: `stop_hook_active` shortcircuits the infinite re-fire, while the `last_assistant_message` check lets the block resolve naturally once the subagent satisfies the requirement — without it the hook remains a hard gate that the subagent cannot learn to pass.
 
 ### 5. Stdin correctness
 
@@ -119,7 +122,7 @@ Also check each hook's `"command"` field in `settings.json` for `$HOME`. `$HOME`
 fails to enforce. Flag as `warn` for any `PostToolUse` hook whose script
 or description suggests a blocking or gating intent.
 
-Also flag as `warn` if any hook uses the `PermissionRequest` event and the project may run in CI or non-interactive mode (`claude -p`). `PermissionRequest` hooks do not fire in non-interactive mode — enforcement silently absent. Use `PreToolUse` for enforcement that must work in automation.
+Also flag as `warn` if the project may run under `claude -p` and uses `AskUserQuestion` or `ExitPlanMode` without a `PreToolUse` hook that returns `permissionDecision: "allow"` plus an `updatedInput` supplying the answer. Per spec, those tools block in non-interactive mode; the documented workaround is a PreToolUse hook that pre-answers them. Enforcement logic that must fire under `-p` must be anchored on `PreToolUse`, not on interactive-only events.
 
 Also flag as `warn` if more than one `PreToolUse` hook targeting the same tool name returns `updatedInput`. Hooks run in parallel; the last to finish wins. Multiple hooks rewriting the same tool's input produce non-deterministic results with no runtime warning — consolidate input modifications for a given tool into one hook.
 


### PR DESCRIPTION
## Summary

Propagates recent build-skill / check-skill updates (#312-#315, #317) into the `build-hook` / `check-hook` pair and closes spec-conformance gaps against the current Claude Code hooks spec (code.claude.com/docs/en/hooks).

- **build-hook**: 11 targeted edits — affirmative phrasing, `\$ARGUMENTS` consumption, recovery path, event coverage (26 events, blockable labels), broader JSON output contract, `\$CLAUDE_PROJECT_DIR` canonical path pattern, corrected timeout defaults, softened `\$HOME` claim, missing schema fields (`shell`, `statusMessage`, `asyncRewake`, HTTP `headers`/`allowedEnvVars`, prompt/agent `model`), `FileChanged` matcher special case, three-layer Stop-loop-break including `last_assistant_message`.
- **check-hook**: 4 targeted edits — `\$ARGUMENTS` consumption, corrected stale `PermissionRequest`/`-p` claim, new JSON output-validity sub-checks in #3, new `last_assistant_message` progress-check warn in #4.

## Spec-conformance findings addressed

- 12 missing events in the lifecycle table → complete 26-event coverage
- JSON output contract (permissionDecision precedence `deny > defer > ask > allow`, top-level `decision: "block"`, `hookSpecificOutput.hookEventName` required) → documented
- Bare `.claude/hooks/<name>.sh` → `"\$CLAUDE_PROJECT_DIR"/.claude/hooks/<name>.sh`
- "60-120s is typical" timeout phrasing → spec defaults (600/30/60s) with 10-60s as a tight-gate hint
- Unconditional "`\$HOME` silently fails" → softened + redirect to `\$CLAUDE_PROJECT_DIR`
- Missing `shell`, `statusMessage`, `asyncRewake` schema fields → added
- `FileChanged` matcher literal-filename special case → flagged
- Stop loop-break: two layers → three layers

## Best-practice gaps closed

- `\$CLAUDE_PROJECT_DIR` path discipline (canonical spec pattern)
- Three-layer Stop-hook loop break (spec-recommended)
- Full JSON output contract for all blockable events (spec recommends JSON over exit code 2 for most events)

Backed by `.research/hook-best-practices.md` (SIFT document, not committed per repo .gitignore convention for `.research/`).

## check-skill audit deltas

- build-hook: **3 warns** (criteria #10, #20, #21) → **0 warns**
- check-hook: **1 warn** (criterion #20) → **0 warns**
- Static lint (`python3 plugins/wiki/scripts/lint.py --root . --no-urls`): passing before and after
- Body sizes: build-hook 378→427 lines, check-hook 229→231 lines — both under the 500-line soft cap

## Note on artifacts

Per the refine-hook-pair prompt, intermediate artifacts were produced in `.plans/` and `.research/`:

- `.plans/hook-refinement-checklist.md`
- `.research/hook-spec-conformance.md`
- `.research/hook-best-practices.md`
- `.research/hook-audit-before.md`
- `.research/hook-audit-after.md`
- `.research/hook-refinement-report.md`

These are **not included** in the PR because `.plans/*`, `.research/*`, and `.prompts/*` are explicitly gitignored by repo convention (PR #297). Reviewers with the branch checked out will find them in the worktree.

## Test plan

- [ ] `python3 plugins/wiki/scripts/lint.py --root . --no-urls` → All checks passed
- [ ] CI ruff check passes
- [ ] Spot-check a Stop hook built from the updated build-hook and confirm the three-layer loop-break guidance is actionable
- [ ] Invoke check-hook against a fixture settings.json containing a JSON-emitting-on-exit-2 hook and verify the new #3 check fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)