### PR TITLE
chore(wiki): 0.3.0 — retroactive catchup for #325

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ Pre-restructure releases used a single version. Post-restructure, each plugin
 
 ## [Unreleased]
 
+## [wiki-0.3.0] - 2026-04-19
+
+Retroactive entry for #325, which merged ahead of v0.43.0 without a
+version bump or CHANGELOG line. Catches the wiki plugin up to reflect
+what shipped.
+
+### Added
+
+- **`wiki:setup` captures per-project Working Agreements (#325, closes
+  #321).** `/wiki:setup` seeds new projects with a default
+  codify-repetition ethos under a managed `## Working Agreements`
+  section in `AGENTS.md`. On re-run against projects that already have
+  the section, reviews with the user (keep / edit / replace) rather
+  than silently skipping. Eight new unit tests cover the
+  `has_working_agreements` detection path.
+
+### Changed
+
+- **Unified AGENTS.md migration (#325).** Build & Test, Design
+  Principles, and Conventions move from `CLAUDE.md` to `AGENTS.md` in
+  a uniform `- **Name.** imperative.` bullet form. `CLAUDE.md` becomes
+  a thin pointer. The repo's AGENTS.md now serves any AI coding tool
+  that favors the AGENTS.md convention, not just Claude Code.
+
 ## [build-0.4.0] - 2026-04-19
 
 ### Added

--- a/plugins/wiki/.claude-plugin/plugin.json
+++ b/plugins/wiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Skills for building and maintaining structured project context — setup, research, ingest, and lint.",
   "author": {
     "name": "Brandon Beidel"

--- a/plugins/wiki/pyproject.toml
+++ b/plugins/wiki/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wiki"
-version = "0.2.0"
+version = "0.3.0"
 description = "Claude Code plugin for building and maintaining structured project context."
 requires-python = ">=3.9"
 dependencies = []


### PR DESCRIPTION
## Summary

Retroactive housekeeping — PR #325 (Working Agreements capture in `/wiki:setup`) merged ahead of v0.43.0 without bumping the `wiki` plugin version or adding a CHANGELOG entry. This PR catches both up.

- Bumps `wiki` plugin from `0.2.0` → `0.3.0` in `plugin.json` and `pyproject.toml`.
- Adds a `[wiki-0.3.0] - 2026-04-19` entry to `CHANGELOG.md` capturing what #325 shipped (Working Agreements setup flow + unified AGENTS.md migration).

No code changes. The wiki plugin's behavior is already on main from #325.

## Test plan

- [x] `plugin.json` and `pyproject.toml` both at 0.3.0
- [x] CHANGELOG entry uses the same format as prior entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)