### PR TITLE
feat(dummy): scratch plugin for --as-tool validation (#327)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -23,6 +23,11 @@
       "name": "consider",
       "source": "./plugins/consider",
       "description": "Structured mental models for decision-making — first principles, Occam's razor, inversion, and more."
+    },
+    {
+      "name": "dummy",
+      "source": "./plugins/dummy",
+      "description": "Scratch plugin validating the --as-tool skill invocation pattern (issue #327). Temporary; will be removed after validation lands."
     }
   ],
   "recommended": {

--- a/plugins/dummy/.claude-plugin/plugin.json
+++ b/plugins/dummy/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "dummy",
+  "version": "0.1.0",
+  "description": "Scratch plugin validating the --as-tool invocation pattern. Temporary; remove after #327 lands.",
+  "author": {
+    "name": "Brandon Beidel"
+  }
+}

--- a/plugins/dummy/skills/greet-team/SKILL.md
+++ b/plugins/dummy/skills/greet-team/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: greet-team
+description: >
+  Composes greetings for several teammates by invoking
+  `/dummy:greet --as-tool` once per name. Demonstrates the caller side
+  of the --as-tool invocation pattern — single elicit, repeated inner
+  invocations, merged output, single approval gate. Scratch skill
+  validating the pattern (issue #327).
+argument-hint: "[names]"
+user-invocable: true
+---
+
+# Greet Team
+
+Compose greetings for a list of teammates by repeatedly invoking `/dummy:greet` under `--as-tool`. The inner skill never speaks to the user directly — this skill owns all human interaction.
+
+## Workflow
+
+### 1. Elicit
+
+Ask the user once:
+
+- **Names** — a comma-separated list or freeform text naming several people. LLM-parse the list out.
+- **Time of day** — one of `morning`, `afternoon`, `evening`. Used for every greeting.
+
+### 2. Invoke `/dummy:greet --as-tool` per name
+
+For each name, invoke:
+
+```
+/dummy:greet --as-tool name=<name> time-of-day=<shared-tod>
+```
+
+Read the JSON block the inner skill returns. Dispatch on `type`:
+
+- **`Success`** — append `value.text` to the collected greetings list.
+- **`NeedsMoreInfo`** — one retry only. Attempt to fill any fields listed in `missing` from this skill's elicited context (usually `time_of_day` is already in scope). If the retry still returns `NeedsMoreInfo`, skip that name and note it.
+- **`Refusal`** — skip the name. Append `{name, reason}` to a "skipped" list.
+
+Retry budget: **one retry per name**. No unbounded loops.
+
+### 3. Present
+
+Show the user a single combined view:
+
+```
+Greetings:
+  - Good morning, bob!
+  - Good morning, alice!
+
+Skipped:
+  - root — refusing to greet a privileged account
+```
+
+### 4. Approve
+
+Ask `approve? [y/N]`. Print the final combined list regardless of response.
+
+## Key Instructions
+
+- Do not prompt the user per name. Elicit once; reuse the shared `time-of-day` for every inner invocation.
+- Do not show the inner skill's raw JSON to the user — read it, branch on `type`, render only the merged result.
+- A `Refusal` is not an error for this skill. Collect refusals and show them alongside successes.
+- Retry budget is **one** per name. Do not loop beyond that.
+
+## Handoff
+
+**Receives:** list of teammate names (from `$ARGUMENTS` or elicited), one shared `time-of-day`.
+**Produces:** a combined list of greetings plus a skipped list.
+**Chainable to:** any skill consuming a list of composed greetings.

--- a/plugins/dummy/skills/greet/SKILL.md
+++ b/plugins/dummy/skills/greet/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: greet
+description: >
+  Greets a person by name with a time-appropriate salutation. Supports
+  human mode (prompts for missing info, asks for approval) and
+  `--as-tool` mode (structured return, no ceremony, for skill callers).
+  Scratch skill validating the --as-tool invocation pattern (issue #327).
+argument-hint: "[name] [time-of-day]"
+user-invocable: true
+---
+
+# Greet
+
+Emit a time-appropriate greeting for a given name. Two invocation modes:
+
+- **Human** (default) — prompts for missing info, prints the greeting, asks for approval.
+- **`--as-tool`** — skill-caller mode. No prompts, no approval, no rendering. Returns structured JSON.
+
+## Required fields
+
+- `name` — the person to greet.
+- `time-of-day` — one of `morning`, `afternoon`, `evening`. Anything else falls back to a generic `Hello`.
+
+## `$ARGUMENTS` parsing
+
+| Shape | Mode | Behavior |
+|---|---|---|
+| empty | human | full Elicit |
+| freeform text (no `=`, no `--`) | human | LLM-parse `name` and `time-of-day` from text; prompt for missing |
+| `key=value` tokens | human | parse named fields; prompt for missing; non-kv tokens ignored |
+| `--as-tool` present | skill | require all fields; hard-fail via `NeedsMoreInfo` if any missing; skip Elicit + approval |
+
+## Workflow
+
+### 1. Parse `$ARGUMENTS` per the table above.
+
+### 2. Scope gate
+
+If `name` starts with `root` (case-sensitive): refuse.
+- **Human mode:** print `REFUSED: refusing to greet a privileged account` and stop.
+- **`--as-tool` mode:** return `Refusal` (see Return below).
+
+### 3. Compose
+
+Map `time-of-day` to a salutation:
+- `morning` → `Good morning`
+- `afternoon` → `Good afternoon`
+- `evening` → `Good evening`
+- anything else → `Hello`
+
+Compose: `<salutation>, <name>!`
+
+### 4a. Human mode — present + approve
+
+Print the greeting. Ask `approve? [y/N]`. Print the final greeting regardless of response (this is a scratch skill; no save step).
+
+### 4b. `--as-tool` mode — return structured
+
+Output **only** a JSON block. No prose, no preamble. One of three shapes:
+
+**Success:**
+```json
+{"type": "Success", "value": {"text": "Good morning, bob!", "name": "bob", "time_of_day": "morning"}}
+```
+
+**NeedsMoreInfo** (any required field missing):
+```json
+{"type": "NeedsMoreInfo", "missing": ["time_of_day"], "hint": "pass `name` and `time_of_day` as structured args under --as-tool"}
+```
+
+**Refusal** (scope gate fired):
+```json
+{"type": "Refusal", "reason": "refusing to greet a privileged account", "category": "scope-gate"}
+```
+
+## Key Instructions
+
+- Under `--as-tool`: emit the JSON block and nothing else. No `input()`. No approval.
+- Under `--as-tool`: hard-fail on missing required fields by returning `NeedsMoreInfo`. Do not prompt.
+- Under human mode: prompt for whatever `$ARGUMENTS` didn't supply.
+
+## Handoff
+
+**Receives:** `name`, `time-of-day` (from `$ARGUMENTS` or elicited).
+**Produces:** a greeting string (human) or structured JSON (`--as-tool`).


### PR DESCRIPTION
## Summary

- New plugin `dummy` with two skills exercising the `--as-tool` invocation pattern end-to-end.
- `/dummy:greet` — inner skill. Human mode prompts + shows greeting; `--as-tool` mode returns JSON (Success / NeedsMoreInfo / Refusal).
- `/dummy:greet-team` — outer skill. Elicits once, invokes `/dummy:greet --as-tool` per name, handles all three return types, presents a single merged approval gate.

Purpose: validate skill-to-skill structured invocation mechanics in isolation before applying the pattern to the `build-hook` / `build-shell` refactor.

See [#327](https://github.com/bcbeidel/toolkit/issues/327) for design context; registered in `.claude-plugin/marketplace.json` as temporary / scratch.

## Test plan

- [ ] In a fresh session, invoke `/dummy:greet` directly — confirm prompts, scope-gate refusal on name `root`, approval prompt.
- [ ] Invoke `/dummy:greet --as-tool name=bob time-of-day=morning` — confirm JSON-only output, `type: "Success"`.
- [ ] Invoke `/dummy:greet --as-tool name=bob` — confirm `NeedsMoreInfo` JSON with `missing: ["time_of_day"]`.
- [ ] Invoke `/dummy:greet --as-tool name=root time-of-day=morning` — confirm `Refusal` JSON.
- [ ] Invoke `/dummy:greet-team` with a list including `root` — confirm single elicit, merged greetings list, skipped entry for `root`, single approval prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)