### PR TITLE
chore(dummy): invocation-probe evidence marker (#327)

### DIFF
--- a/plugins/dummy/.claude-plugin/plugin.json
+++ b/plugins/dummy/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dummy",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Scratch plugin validating the --as-tool invocation pattern. Temporary; remove after #327 lands.",
   "author": {
     "name": "Brandon Beidel"

--- a/plugins/dummy/skills/greet/SKILL.md
+++ b/plugins/dummy/skills/greet/SKILL.md
@@ -56,7 +56,17 @@ Print the greeting. Ask `approve? [y/N]`. Print the final greeting regardless of
 
 ### 4b. `--as-tool` mode — return structured
 
-Output **only** a JSON block. No prose, no preamble. One of three shapes:
+**Evidence marker (temporary — invocation-mechanism probe for #327).**
+
+Before emitting the return JSON, use the Bash tool to append one line to the evidence file:
+
+```bash
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) inner name=<NAME-OR-null> tod=<TOD-OR-null>" >> /tmp/greet-evidence.txt
+```
+
+Substitute the actual parsed values in place of `<NAME-OR-null>` and `<TOD-OR-null>` (use the literal string `null` when a field is missing). This line runs on every `--as-tool` invocation regardless of the return kind (Success, NeedsMoreInfo, or Refusal) — it is the invocation trace, not an output artifact. The marker will be removed after the probe completes.
+
+After the evidence append, output **only** a JSON block. No prose, no preamble. One of three shapes:
 
 **Success:**
 ```json


### PR DESCRIPTION
## Summary

Add a file-append side effect to `/dummy:greet` under `--as-tool`. Every invocation writes one line to \`/tmp/greet-evidence.txt\` before emitting its return JSON.

Purpose: settle the open question from the prior validation session — when \`/dummy:greet-team\` runs with N names, are we seeing **real runtime invocations** of \`/dummy:greet --as-tool\` (one per name), or **in-context simulation** by the outer skill's LLM?

## Test plan

In a fresh session with the dummy plugin installed:

1. \`rm -f /tmp/greet-evidence.txt\`
2. Run \`/dummy:greet-team\` with 4 names (e.g., \`alice, bob, carol, dave\`; time-of-day \`morning\`).
3. \`cat /tmp/greet-evidence.txt\` and \`wc -l\` it.

Interpretation:

| Lines in file | Mechanism | Implication |
|---|---|---|
| **4** | Real runtime invocation | \`--as-tool\` pattern is structurally real; improvements to inner skill propagate per-call. Proceed with build-skill / check-skill scaffolding. |
| **0 or 1** | In-context simulation | Outer LLM read both SKILL.md files and mentally executed the inner — no actual sub-skill runtime. Pattern reduces to reference-by-prose with extra steps. Reconsider scaffolding approach. |
| **Other** | Something else entirely | Investigate — e.g., partial invocation, retry logic firing, plugin cache weirdness. |

Also worth a direct check: \`/dummy:greet --as-tool name=bob time-of-day=morning\` should write exactly 1 line to the evidence file (sanity: the Bash tool invocation happens even on a single direct call).

## Notes

- Evidence marker fires on every \`--as-tool\` invocation regardless of return kind (Success, NeedsMoreInfo, Refusal) — we care about *whether the skill ran*, not *what it returned*.
- Temporary. The SKILL.md language flags it as probe-only; remove once the mechanism question is answered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)