### PR TITLE
feat(build): --as-tool pattern support in build-skill and check-skill (build-0.5.0)

### DIFF
--- a/.designs/2026-04-20-build-check-skill-as-tool-support.design.md
+++ b/.designs/2026-04-20-build-check-skill-as-tool-support.design.md
@@ -1,0 +1,244 @@
+---
+name: build-skill and check-skill support for --as-tool pattern
+description: Teach /build:build-skill to scaffold the --as-tool dual-invocation pattern and /build:check-skill to audit it. Opt-in via `skill-invocable: true` frontmatter; inline contract declares DATA or ARTIFACT return shape (ARTIFACT supports multi-artifact via N fenced blocks); shared mechanism spec at plugins/build/_shared/references/as-tool-contract.md.
+type: design
+status: approved
+related:
+  - .research/2026-04-20-emit-only-invocation-prior-art.research.md
+---
+
+# build-skill and check-skill Support for `--as-tool` Pattern
+
+## Purpose
+
+Teach `/build:build-skill` and `/build:check-skill` to treat the `--as-tool` dual-invocation pattern as a first-class skill shape. Skill authors who want their skill to be callable by another skill opt in via frontmatter; the scaffolder asks during intake and generates the contract section; the auditor verifies declared contracts are consistent and complete.
+
+## Why Now
+
+- The `--as-tool` pattern was validated empirically on 2026-04-20 (PR #333 + PR #334). Fresh-session test confirmed real runtime invocation — 4 distinct skill loads + 4 Bash tool invocations when `/dummy:greet-team` invoked `/dummy:greet --as-tool` per teammate, in parallel. Mechanism (a) is proven.
+- Prior-art research (`.research/2026-04-20-emit-only-invocation-prior-art.research.md`, on `explore/327-structured-invocation-thinking`) established `--as-tool` as the LCD name (OpenAI Agents SDK `as_tool`, LangGraph subgraph-as-tool, Semantic Kernel agent-as-KernelFunction all converge on the metaphor).
+- Downstream consumers (issue #327 hook/shell refactor, future Python-script pair per #326) want to invoke the pattern. Without build-skill scaffolding it and check-skill auditing it, adoption relies on each author remembering the shape. High drift risk.
+- Ecosystem-wide adoption pressure is **not** the goal yet. Default-off opt-in gives us one skill at a time to refine the pattern before it's everywhere.
+
+## Locked Decisions
+
+1. **Default: pattern-OFF, opt-in via frontmatter.** Absence means human-only.
+2. **Frontmatter field: `skill-invocable: true`**. Parallels existing `user-invocable`. Two independent axes.
+3. **Contract location: inline in SKILL.md** under standardized `## --as-tool contract` section.
+4. **check-skill severity: fail on hard inconsistency, warn on completeness.** Declared-but-missing contract = fail; missing subsection = warn.
+5. **Ship together:** contract doc + build-skill/check-skill updates in one PR.
+
+## Behavior
+
+### New `skill-invocable` frontmatter field
+
+Boolean. Defaults to `false` when absent.
+
+- `skill-invocable: true` declares the skill supports `--as-tool` invocation per the shared contract. Requires a `## --as-tool contract` section in the body.
+- `skill-invocable: false` or absent declares the skill is human-only. No `--as-tool` scaffolding or audit applies.
+
+Independent of `user-invocable`. Valid combinations:
+- `user-invocable: true` + `skill-invocable: false` — human-only slash-command skill (most existing skills, default).
+- `user-invocable: true` + `skill-invocable: true` — dual-invocation (new pattern; dummy plugin).
+- `user-invocable: false` + `skill-invocable: true` — purely programmatic, no slash command (rare; not scaffolded by default; the auditor recognizes it).
+- `user-invocable: false` + `skill-invocable: false` — non-invocable (doesn't belong in `skills/`; auditor warns).
+
+### Return shapes: DATA vs ARTIFACT
+
+Every `--as-tool` skill emits a JSON envelope for control flow (`Success` / `NeedsMoreInfo` / `Refusal` — always structured). What differs is the **Success payload**:
+
+- **Shape DATA** — structured data skill (e.g., `/dummy:greet`, `/build:check-skill`). `Success` JSON contains a `value` field with a skill-declared schema. No fenced block.
+- **Shape ARTIFACT** — skill whose output is a text artifact in its native syntax (e.g., `/build:build-shell` produces a shell script, `/build:build-rule` produces a markdown file). `Success` JSON is a control envelope; the artifact body follows as one or more fenced code blocks.
+
+`NeedsMoreInfo` and `Refusal` are **always JSON-only regardless of shape** — no fenced block. This keeps the failure-path contract uniform.
+
+**Shape DATA — success emission:**
+```
+{"type": "Success", "value": {"text": "Good morning, bob!", ...}}
+```
+
+**Shape ARTIFACT — single-artifact success emission:**
+```
+{"type": "Success", "artifact_types": ["text/x-shellscript"], "metadata": {"target": "bash-3.2-portable"}}
+```
+```bash
+#!/usr/bin/env bash
+# ... the scaffold ...
+```
+
+**Shape ARTIFACT — multi-artifact success emission** (e.g., `/build:build-hook` producing both a hook script and a settings.json entry):
+```
+{"type": "Success", "artifact_types": ["text/x-shellscript", "application/json"], "metadata": {"hook_event": "PreToolUse"}}
+```
+```bash
+#!/usr/bin/env bash
+# hook script
+```
+```json
+{"hooks": {"PreToolUse": [...]}}
+```
+
+Rule: the number and order of fenced blocks match the `artifact_types` array exactly. Each fenced block's language tag matches the declared MIME type (e.g., `application/json` → ` ```json `, `text/x-shellscript` → ` ```bash `, `text/markdown` → ` ```markdown `). The caller LLM reads the JSON first, then each fenced block in declared order.
+
+### Standardized `## --as-tool contract` section
+
+When `skill-invocable: true`, the skill body must include the section. Shape:
+
+```markdown
+## `--as-tool` contract
+
+**Required fields:**
+- `<field>` — description
+- `<field>` — description
+
+**Return shape:** DATA | ARTIFACT
+- (if ARTIFACT) **Artifact types:** `text/x-shellscript`, `application/json`, ... (ordered).
+- `Success` — (DATA) describes `value` schema | (ARTIFACT) describes metadata fields and each fenced block's role.
+- `NeedsMoreInfo` — `missing: [...]`, `hint: "..."` (JSON only, always).
+- `Refusal` — categories used (`scope-gate`, `permission`, etc.) (JSON only, always).
+
+**Side effects:** list or "none" (e.g., reads file X, invokes /foo --as-tool).
+
+**Parallel-safe:** `yes` (default) or `no` + reason.
+```
+
+All four subsections expected. Missing Return shape declaration or artifact-types on an ARTIFACT skill → fail. Missing Side effects or Parallel-safe → warn.
+
+### `/build:build-skill` changes
+
+**Two-level intake** at Capture Intent or Interview phase:
+
+1. **Opt-in question:** "Should this skill be invocable by other skills via `--as-tool`? (y/N)". Default no — matches opt-in posture.
+2. **Shape question** (only if yes to #1): "Does this skill return structured data (DATA) or a text artifact like a script or markdown file (ARTIFACT)?". If ARTIFACT: "What artifact types? (e.g., `text/x-shellscript`, `text/markdown`, `application/json` — comma-separated if multiple)".
+
+If **opted in**:
+- Set `skill-invocable: true` in frontmatter; add `../../_shared/references/as-tool-contract.md` to `references:`.
+- Elicit required fields list, Success schema (DATA) or artifact-roles (ARTIFACT), side-effect list, parallel-safety.
+- Generate `## --as-tool contract` in the body with the declared shape.
+- Generate a mode-branched Workflow (`§Xa. Human mode` / `§Xb. --as-tool mode`), with the `--as-tool mode` step documenting the specific emission format (JSON only for DATA; JSON + N fenced blocks for ARTIFACT).
+- Generate Key Instructions entries enforcing mode-specific rules (emit JSON only for DATA; emit JSON-envelope-plus-fenced-blocks for ARTIFACT; hard-fail with `NeedsMoreInfo` on missing required fields; JSON-only on `NeedsMoreInfo` / `Refusal` regardless of shape).
+
+If **not opted in**: scaffold proceeds as today; no new frontmatter; no contract section.
+
+The scaffolded SKILL.md template has two variants (DATA and ARTIFACT) because the emission prose differs. Both variants share the envelope shape for failure cases.
+
+### `/build:check-skill` changes
+
+New checks (additive to the existing 22):
+
+| # | Check | Severity | Fires when |
+|---|---|---|---|
+| 23 | `skill-invocable` frontmatter present and boolean | warn | field present but non-boolean value |
+| 24 | Declared `skill-invocable: true` has a `## --as-tool contract` section | **fail** | field true, section missing or empty |
+| 25 | Contract section declares Return shape (DATA or ARTIFACT) | **fail** | section present but no `**Return shape:** DATA` or `ARTIFACT` line |
+| 26 | Contract section documents all three cases (Success / NeedsMoreInfo / Refusal) | **fail** | any case missing from the Return-shape subsection |
+| 27 | ARTIFACT shape declares `Artifact types:` with at least one MIME type | **fail** | Return shape is ARTIFACT but artifact types are missing or empty |
+| 28 | Contract section documents Required fields | warn | section present but Required fields list empty or missing |
+| 29 | Contract section documents Side effects | warn | section present but subsection absent |
+| 30 | Contract section documents Parallel-safe | warn | section present but subsection absent |
+| 31 | `user-invocable: false` + `skill-invocable: false` (non-invocable skill) | warn | both false or both absent |
+
+Skills with `skill-invocable: false` or absent: checks 24–30 do not fire. Check 31 only fires on the all-false pathology.
+
+### Shared mechanism spec
+
+New file: `plugins/build/_shared/references/as-tool-contract.md`.
+
+Skill-agnostic generic spec:
+- `$ARGUMENTS` parsing rule (empty / freeform / `key=value` / `--as-tool`).
+- Skip/run-per-step semantics under `--as-tool` (Elicit / Scope Gate / Draft / Safety Check / Review Gate / Save / Test handoff).
+- Three-case return envelope (Success / NeedsMoreInfo / Refusal).
+- **Two return shapes (DATA and ARTIFACT)** with emission examples for each. DATA: JSON only. ARTIFACT: JSON envelope + one or more fenced code blocks, with `artifact_types` declared in the envelope, fenced-block order matching, and language tag per MIME type.
+- Rule: `NeedsMoreInfo` and `Refusal` are always JSON-only regardless of shape.
+- Parallel-safety default (yes unless documented otherwise).
+- Freeform-text mode (voice-dictated human input; does not apply under `--as-tool`).
+- When to use / when not to use the pattern.
+- When to pick DATA vs ARTIFACT (rule of thumb: produces code/markdown/config → ARTIFACT; produces structured records → DATA).
+
+Referenced by build-skill and check-skill (both gain `references:` entry); authors of opted-in skills reference it from their own SKILL.md as well.
+
+## Components
+
+| File | Change |
+|---|---|
+| `plugins/build/_shared/references/as-tool-contract.md` | **Create** — generic mechanism spec. |
+| `plugins/build/skills/build-skill/SKILL.md` | **Modify** — add intake question; scaffold `skill-invocable: true` + `## --as-tool contract` section when opted in; reference shared contract doc. |
+| `plugins/build/skills/check-skill/SKILL.md` | **Modify** — add seven new checks (23–29); reference shared contract doc. |
+| `plugins/build/skills/build-skill/references/skill-writing-guide.md` | **Modify** — add section on the dual-invocation pattern; point to `as-tool-contract.md` for the full spec. |
+| `plugins/build/pyproject.toml` | **Modify** — `0.4.0` → `0.5.0`. |
+| `plugins/build/.claude-plugin/plugin.json` | **Modify** — `0.4.0` → `0.5.0`. |
+| Python lint code (`plugins/build/src/check/...`) | **Modify if applicable** — static checks that verify frontmatter shape may need to learn about `skill-invocable`. |
+
+## Constraints
+
+### Must have
+
+- Shared mechanism spec exists and is referenced by build-skill, check-skill, and any scaffolded opted-in skill.
+- build-skill asks the opt-in question during intake for every new skill; scaffolds the contract section when answered yes.
+- check-skill's new checks 23–29 fire per the severity calibration; no regression on existing checks 1–22.
+- All 41 existing SKILL.md files pass `/build:check-skill` with zero **new** fail-level findings (absence of `skill-invocable` = no new checks fire on them).
+- Build plugin bumps to 0.5.0; both `pyproject.toml` and `.claude-plugin/plugin.json` updated.
+- The `--as-tool contract` section shape is stable and documented in the shared spec so authors can copy-paste it into future skills.
+
+### Won't have
+
+- **Migration of existing skills.** No bulk-adding `skill-invocable: false` to the 41 existing files. Absent field = default off.
+- **Refactor of hook/shell pair** (#327's original scope). This is the precondition; the refactor is downstream.
+- **Dummy plugin changes.** `/dummy:greet` and `/dummy:greet-team` stay as proof-of-concept. Their SKILL.md files may not perfectly match the final shape — fine; they're scratch.
+- **Retroactive audit of every skill** for hidden `--as-tool` intent. If a skill secretly does dual-invocation but doesn't declare it, check-skill won't notice — and that's acceptable until it becomes a real problem.
+- **Python-side parser or validator** for `--as-tool` arguments. The parsing is SKILL-level prose; no runtime harness.
+- **check-skill LLM-judgment check** verifying "declared contract matches actual workflow." Out of scope; deterministic presence-checks are enough at this stage. A future iteration can add it.
+- **A `/build:as-tool-migrate` skill** to help opt-in existing skills. If demand emerges, separate issue.
+- **Enforcement via hook.** This is opt-in; no blocking hook.
+- **Cross-plugin invocation test harness.** Dummy plugin already proves it works; no automation needed in this scope.
+- **Graduation to required declaration (Q1 option C).** Deferred until the pattern has 3+ real adopters beyond the dummy plugin.
+
+## Acceptance Criteria
+
+Verifiable from outside after the PR merges:
+
+1. **Shared contract file exists.** `test -f plugins/build/_shared/references/as-tool-contract.md` returns 0; the file has six named sections (grep `^## ` returns ≥ 6).
+
+2. **build-skill and check-skill reference the contract.** `grep "as-tool-contract" plugins/build/skills/{build,check}-skill/SKILL.md` returns ≥ 2 lines.
+
+3. **build-skill's intake asks the question.** Reading the updated SKILL.md, there is a visible step prompting "Should this skill be invocable by other skills?" or equivalent.
+
+4. **check-skill documents nine new checks.** The SKILL.md Run-checks section adds checks 23–31 with the severities calibrated per this design (fail on hard inconsistency / missing return-shape declaration / missing artifact-types; warn on completeness gaps).
+
+5. **Existing skills still pass.** Running `/build:check-skill` against the repo (all 41 existing SKILL.md files) produces zero new fail-level findings attributable to the new checks.
+
+6. **Scaffolding produces the expected shape for DATA skills.** A sample run of `/build:build-skill` answered "yes → DATA" produces a SKILL.md with:
+   - `skill-invocable: true` in frontmatter
+   - `references:` including `../../_shared/references/as-tool-contract.md`
+   - `## --as-tool contract` section with `**Return shape:** DATA` and four populated subsections
+   - Workflow with `§Xb. --as-tool mode` instructing JSON-only emission
+
+7. **Scaffolding produces the expected shape for ARTIFACT skills.** A sample run of `/build:build-skill` answered "yes → ARTIFACT, types: text/x-shellscript" produces a SKILL.md with:
+   - `skill-invocable: true` in frontmatter
+   - `## --as-tool contract` section with `**Return shape:** ARTIFACT` and `**Artifact types:** text/x-shellscript`
+   - Workflow with `§Xb. --as-tool mode` instructing JSON envelope + single ```bash fenced block emission
+   - Multi-artifact variant tested separately with `text/x-shellscript, application/json` producing JSON envelope + two fenced blocks in declared order
+
+8. **Detected inconsistencies fire at the right severity.** Manually constructing test SKILL.md fixtures confirms:
+   - `skill-invocable: true` + no contract section → **fail**
+   - contract section present but no `Return shape:` declaration → **fail**
+   - `Return shape: ARTIFACT` + no `Artifact types:` line → **fail**
+   - contract section present but one of the three cases (Success / NeedsMoreInfo / Refusal) missing → **fail**
+   - contract section present but Side-effects subsection missing → **warn**
+   - `user-invocable: false` + `skill-invocable: false` → **warn**
+
+8. **Dummy plugin still works.** Running `/dummy:greet --as-tool name=bob time-of-day=morning` in a fresh session still returns `Success` JSON. (No regression from the scaffolding/audit changes.)
+
+9. **Version bump is coherent.** `grep version plugins/build/pyproject.toml plugins/build/.claude-plugin/plugin.json` shows 0.5.0 on both.
+
+10. **Self-audit of the two modified skills** — `/build:check-skill` run against `build-skill` and `check-skill` SKILL.md files shows zero new fail-level findings from the edits.
+
+## Open Questions
+
+None blocking. All five key decisions locked during scoping (default-OFF opt-in; `skill-invocable` field; inline contract section; fail-on-hard-inconsistency; ship-together).
+
+Minor tactical items (stated as defaults — flag during plan-work if they need revisiting):
+
+- **Shared contract doc naming:** `as-tool-contract.md` (chosen to match flag name). Alternative `skill-invocable-contract.md` or `emit-only-contract.md` rejected.
+- **check-skill number continuity:** new checks are 23–29, additive to existing 22. If renumbering becomes necessary elsewhere, that's a separate concern.
+- **build-skill tested_with field:** currently `[sonnet]`. No change needed for this work.

--- a/.plans/2026-04-20-build-check-skill-as-tool-support.plan.md
+++ b/.plans/2026-04-20-build-check-skill-as-tool-support.plan.md
@@ -277,7 +277,7 @@ For any fail-level finding, fix in place and re-audit. Warns acceptable if pre-e
 
 #### Task 9: Bump build plugin version to 0.5.0
 
-- [ ] Task 9: Bump build plugin version to 0.5.0
+- [x] Task 9: Bump build plugin version to 0.5.0 <!-- sha:7ae9b86 -->
 
 Edit `plugins/build/pyproject.toml`: `version = "0.4.0"` → `version = "0.5.0"`.
 Edit `plugins/build/.claude-plugin/plugin.json`: `"version": "0.4.0"` → `"version": "0.5.0"`.

--- a/.plans/2026-04-20-build-check-skill-as-tool-support.plan.md
+++ b/.plans/2026-04-20-build-check-skill-as-tool-support.plan.md
@@ -113,7 +113,7 @@ grep -c "^## " plugins/build/_shared/references/as-tool-contract.md    # returns
 
 #### Task 2: Update `build-skill` SKILL.md
 
-- [ ] Task 2: Update `build-skill` SKILL.md
+- [x] Task 2: Update `build-skill` SKILL.md <!-- sha:919ea28 -->
 
 Modify `plugins/build/skills/build-skill/SKILL.md`:
 
@@ -140,7 +140,7 @@ grep -c "DATA\|ARTIFACT" plugins/build/skills/build-skill/SKILL.md       # ≥ 4
 
 #### Task 3: Update `skill-writing-guide.md`
 
-- [ ] Task 3: Update `skill-writing-guide.md`
+- [x] Task 3: Update `skill-writing-guide.md` <!-- sha:0226efe -->
 
 Modify `plugins/build/skills/build-skill/references/skill-writing-guide.md`:
 
@@ -164,7 +164,7 @@ grep "plugins/dummy/skills/greet" plugins/build/skills/build-skill/references/sk
 
 #### Task 4: Add 9 new `_check_*` functions in Python
 
-- [ ] Task 4: Add 9 new `_check_*` functions in Python
+- [x] Task 4: Add 9 new `_check_*` functions in Python <!-- sha:025236f -->
 
 Modify `plugins/build/src/check/skill.py`. Add these functions following the existing `_check_*` style (return `List[dict]` with `check_id`, `severity`, `message`, `line` fields matching existing checks):
 
@@ -193,7 +193,7 @@ ruff check plugins/build/src/check/skill.py
 
 #### Task 5: Add tests for each new check
 
-- [ ] Task 5: Add tests for each new check
+- [x] Task 5: Add tests for each new check <!-- sha:830517f -->
 
 Modify `plugins/build/tests/test_skill_audit.py`. For each of the 9 new `_check_*` functions, add at least one **pass-case** (clean input, no findings) and one **fail-case** (triggering input, produces finding with correct severity). Use inline markdown fixtures per the existing test style (no file I/O for fixtures beyond `tmp_path`).
 
@@ -223,7 +223,7 @@ All tests pass, including the new ones.
 
 #### Task 6: Update `check-skill` SKILL.md
 
-- [ ] Task 6: Update `check-skill` SKILL.md
+- [x] Task 6: Update `check-skill` SKILL.md <!-- sha:e6ca1e2 -->
 
 Modify `plugins/build/skills/check-skill/SKILL.md`:
 
@@ -243,7 +243,7 @@ grep -E "thirty|31|twenty-two|22" plugins/build/skills/check-skill/SKILL.md | he
 
 #### Task 7: Regression-check existing skills
 
-- [ ] Task 7: Regression-check existing skills
+- [x] Task 7: Regression-check existing skills <!-- sha:e6ca1e2 verified --> (lint.py clean; 0 new fail findings across 41 existing skills)
 
 Run `/build:check-skill` (or invoke the lint script directly: `python3 plugins/wiki/scripts/lint.py --root . --no-urls`) against the repo to confirm zero new fail-level findings on the 41 existing skills.
 
@@ -262,7 +262,7 @@ python3 plugins/wiki/scripts/lint.py --root . --no-urls 2>&1 | \
 
 #### Task 8: Self-audit modified SKILL.md files
 
-- [ ] Task 8: Self-audit modified SKILL.md files
+- [x] Task 8: Self-audit modified SKILL.md files <!-- sha:e6ca1e2 verified --> (lint.py clean on build-skill/SKILL.md, check-skill/SKILL.md; 0 fails)
 
 Run `/build:check-skill` against each of the four modified SKILL.md files:
 - `plugins/build/skills/build-skill/SKILL.md`

--- a/.plans/2026-04-20-build-check-skill-as-tool-support.plan.md
+++ b/.plans/2026-04-20-build-check-skill-as-tool-support.plan.md
@@ -331,9 +331,14 @@ After all tasks complete, the following must all hold:
    ```
    Returns ≥ 2.
 
-5. **Both DATA and ARTIFACT scaffolds documented in build-skill.**
+5. **Both DATA and ARTIFACT scaffolds documented in build-skill's
+   scaffolding reference.** Amended during verification to reflect the
+   mid-execution extraction refactor: scaffolding detail moved from
+   `build-skill/SKILL.md` to `references/as-tool-scaffolding.md` on
+   explicit user direction after Task 2 landed. The authoritative
+   location for scaffolding guidance is now the reference file.
    ```
-   grep -c "DATA\|ARTIFACT" plugins/build/skills/build-skill/SKILL.md
+   grep -c "DATA\|ARTIFACT" plugins/build/skills/build-skill/references/as-tool-scaffolding.md
    ```
    Returns ≥ 4.
 

--- a/.plans/2026-04-20-build-check-skill-as-tool-support.plan.md
+++ b/.plans/2026-04-20-build-check-skill-as-tool-support.plan.md
@@ -86,7 +86,7 @@ No deletions. No new skills. No Python package-structure changes.
 
 #### Task 1: Create `as-tool-contract.md`
 
-- [ ] Task 1: Create `as-tool-contract.md`
+- [x] Task 1: Create `as-tool-contract.md` <!-- sha:7089c0e -->
 
 Create `plugins/build/_shared/references/as-tool-contract.md` per the design. Skill-agnostic. Required sections (as H2s, in this order):
 

--- a/.plans/2026-04-20-build-check-skill-as-tool-support.plan.md
+++ b/.plans/2026-04-20-build-check-skill-as-tool-support.plan.md
@@ -1,0 +1,393 @@
+---
+name: build-skill and check-skill support for --as-tool pattern
+description: Ship shared as-tool-contract reference, teach build-skill to scaffold the pattern via two-level intake (opt-in + DATA/ARTIFACT shape), extend check-skill with 9 new checks, and bump build plugin to 0.5.0.
+type: plan
+status: executing
+branch: feat/build-skill-as-tool-support
+related:
+  - .designs/2026-04-20-build-check-skill-as-tool-support.design.md
+---
+
+# build-skill and check-skill Support for `--as-tool` Pattern
+
+## Goal
+
+Teach `/build:build-skill` and `/build:check-skill` to treat the `--as-tool` dual-invocation pattern as a first-class skill shape. After this plan lands:
+
+- `plugins/build/_shared/references/as-tool-contract.md` exists as the single authoritative mechanism spec; both `build-skill` and `check-skill` reference it.
+- `/build:build-skill` intake asks two questions (opt-in y/N → if y, DATA or ARTIFACT + artifact types); scaffolds the contract section, workflow split, and frontmatter entries accordingly.
+- `/build:check-skill` runs 9 new checks (23–31) covering `skill-invocable` frontmatter shape, contract-section presence, Return-shape declaration, all-three-cases coverage, ARTIFACT artifact-types, and non-invocable pathology.
+- New Python static checks live in `plugins/build/src/check/skill.py` alongside the existing 22; tests cover each new check.
+- Build plugin bumps to 0.5.0.
+- All 41 existing SKILL.md files still pass with zero new fail-level findings (no migration).
+
+## Scope
+
+### Must have
+
+- `plugins/build/_shared/references/as-tool-contract.md` created as a skill-agnostic spec documenting: `$ARGUMENTS` four-mode parsing rule; skip/run-per-step semantics under `--as-tool`; three-case envelope (Success / NeedsMoreInfo / Refusal); two return shapes (DATA JSON-only, ARTIFACT JSON envelope + N fenced blocks); emission examples for each; language-tag-per-MIME rule; parallel-safety default; freeform-text mode; when to pick DATA vs ARTIFACT.
+- `plugins/build/skills/build-skill/SKILL.md` updated with: intake question added under Interview and Research; new conditional section in Draft describing what to scaffold when `skill-invocable: true`; both DATA and ARTIFACT scaffold variants documented; reference to the shared contract added to `references:` frontmatter.
+- `plugins/build/skills/build-skill/references/skill-writing-guide.md` gains a new H2 section on the dual-invocation pattern, pointing at the dummy plugin's `/dummy:greet` (DATA) as the canonical example.
+- `plugins/build/skills/check-skill/SKILL.md` updated to document the 9 new checks (23–31) with severities per the design; reference to the shared contract added.
+- `plugins/build/src/check/skill.py` gains 9 new `_check_*` functions wired into the check dispatcher; each returns findings in the existing format.
+- `plugins/build/tests/test_skill_audit.py` gains tests for each new check covering pass and fail cases.
+- `plugins/build/pyproject.toml` and `plugins/build/.claude-plugin/plugin.json` bump to 0.5.0.
+- `/build:check-skill` against all 41 existing SKILL.md files produces zero **new** fail-level findings attributable to the new checks.
+- PR opened against `main`; CI green (ruff).
+
+### Won't have
+
+- **Migration of existing 41 skills.** No bulk-add of `skill-invocable: false`. Absent = default off.
+- **Refactor of hook/shell pair.** Issue #327's original scope; downstream consumer of this work.
+- **Dummy plugin changes.** `/dummy:greet` and `/dummy:greet-team` remain as-is.
+- **LLM-judgment check** verifying declared contract matches actual workflow semantics. Deterministic presence-checks only.
+- **New skill-generation CLI** or helper script for retrofitting existing skills to the pattern.
+- **`/build:as-tool-migrate` skill** or any bulk-migration tooling.
+- **Blocking hook** to enforce the pattern at commit time.
+- **Cross-plugin invocation test harness.** Dummy plugin already proves the mechanism works.
+- **Graduation to required declaration** (Q1 Option C from scoping). Deferred until 3+ real adopters exist.
+- **`.claude-plugin/marketplace.json` changes.** Manifest references the plugin, not per-skill.
+- **Changes outside the `build` plugin.** No edits to wiki, work, consider, or dummy.
+
+## Approach
+
+**Bottom-up order, chunked.** Write the shared contract first — it's the authoritative spec that both `build-skill` (scaffolder) and `check-skill` (auditor) reference. Once the contract is fixed, update `build-skill` to scaffold against it. Then update `check-skill` + Python lint code + tests to audit against it. Release gates (self-audit + version bump + PR) come last.
+
+**Each chunk produces something self-verifiable.**
+- Chunk 1 (shared contract): a file on disk with ≥7 top-level sections covering both shapes.
+- Chunk 2 (build-skill): SKILL.md prose describes the two-level intake and both scaffold variants; skill-writing-guide has the new H2.
+- Chunk 3 (check-skill): SKILL.md documents 9 new checks; Python adds 9 `_check_*` functions; tests cover each.
+- Chunk 4 (release): all four modified SKILL.md files pass self-audit; version bumped; PR opened.
+
+**Test-first for the Python checks.** For each new `_check_*` function, write the test first (pass fixture + fail fixture), then the implementation. Keeps the severity contract honest (fail-case fixtures trigger fail; pass-case fixtures don't).
+
+**Fixture-based audit regression test.** Before closing Chunk 3, run `/build:check-skill` (or invoke the lint script directly) against all existing skills to confirm zero new fail findings. This is the guardrail against accidentally requiring the new frontmatter on skills that opted not to adopt.
+
+**No dummy plugin edits.** The dummy plugin is the working reference implementation. Touching it to "align" with the new contract is scope creep — the contract is derived from it, not the other way around. If the contract ends up demanding something the dummy doesn't have, flag as infeasibility and loop back to scope-work.
+
+## File Changes
+
+| File | Change |
+|------|--------|
+| `plugins/build/_shared/references/as-tool-contract.md` | **Create** — authoritative generic spec: parsing rule, step-skip semantics, three-case envelope, DATA vs ARTIFACT shapes with emission examples, parallel-safety, when-to-use guidance. |
+| `plugins/build/skills/build-skill/SKILL.md` | **Modify** — add intake question (§3 Interview), new conditional scaffolding subsection (§4 Draft), reference to shared contract in frontmatter `references:`. |
+| `plugins/build/skills/build-skill/references/skill-writing-guide.md` | **Modify** — add H2 section on the dual-invocation pattern, cite shared contract + dummy plugin's greet. |
+| `plugins/build/skills/check-skill/SKILL.md` | **Modify** — add 9 new checks (23–31) to the Run Checks table with severities; reference shared contract. |
+| `plugins/build/src/check/skill.py` | **Modify** — add 9 new `_check_*` functions; wire into the main dispatcher. |
+| `plugins/build/tests/test_skill_audit.py` | **Modify** — add pass/fail test cases for each new `_check_*`. |
+| `plugins/build/pyproject.toml` | **Modify** — version `0.4.0` → `0.5.0`. |
+| `plugins/build/.claude-plugin/plugin.json` | **Modify** — version `0.4.0` → `0.5.0`. |
+
+No deletions. No new skills. No Python package-structure changes.
+
+## Tasks
+
+### Chunk 1: Shared contract
+
+#### Task 1: Create `as-tool-contract.md`
+
+- [ ] Task 1: Create `as-tool-contract.md`
+
+Create `plugins/build/_shared/references/as-tool-contract.md` per the design. Skill-agnostic. Required sections (as H2s, in this order):
+
+- **Purpose** — one-paragraph summary of the pattern and when to reach for it.
+- **Parsing rule** — the four-mode `$ARGUMENTS` table (empty / freeform / `key=value` / `--as-tool`).
+- **Step skip/run under `--as-tool`** — Route (runs), Scope Gate (runs), Elicit (skipped), Draft/Computation (runs), Safety Check (runs, findings into payload), Review Gate (skipped), Save (skipped), Test handoff (skipped).
+- **Envelope — three cases** — Success / NeedsMoreInfo / Refusal; rule that `NeedsMoreInfo` and `Refusal` are always JSON-only regardless of shape.
+- **Return shape DATA** — JSON only; schema example with `{type, value}`; rule that `value` is a structured object declared by the skill.
+- **Return shape ARTIFACT** — JSON envelope + N fenced code blocks; `artifact_types` array rule; language-tag-per-MIME rule (`application/json` → `json`, `text/x-shellscript` → `bash`, `text/markdown` → `markdown`); single-artifact and multi-artifact emission examples.
+- **When to pick DATA vs ARTIFACT** — rule of thumb: structured records → DATA, code/markdown/config → ARTIFACT.
+- **Parallel-safety** — default yes; document `no` with reason when the skill serializes.
+- **Freeform-text human mode** — one paragraph noting voice-dictated intent is a first-class human shape; does not apply under `--as-tool`.
+- **When NOT to use the pattern** — exploratory skills, mental-model skills, skills where human judgment is the deliverable.
+
+**Verify:**
+```
+test -f plugins/build/_shared/references/as-tool-contract.md
+grep -c "^## " plugins/build/_shared/references/as-tool-contract.md    # returns ≥ 9
+```
+
+**Commit:** `docs(build): add as-tool-contract shared reference`
+
+### Chunk 2: build-skill
+
+#### Task 2: Update `build-skill` SKILL.md
+
+- [ ] Task 2: Update `build-skill` SKILL.md
+
+Modify `plugins/build/skills/build-skill/SKILL.md`:
+
+- Add `../../_shared/references/as-tool-contract.md` to frontmatter `references:`.
+- In §3 Interview and Research, append a new structural-decision bullet:
+  > **Should this skill be invocable by other skills via `--as-tool`?** If yes, the skill supports a dual-invocation pattern (human mode + skill-caller mode). Default: no — most skills are human-only. See `../../_shared/references/as-tool-contract.md`.
+- Add a second follow-up to the above: if yes, ask whether the skill returns **DATA** (structured object) or **ARTIFACT** (text file like a script, markdown, or config). If ARTIFACT, ask for the `artifact_types` list.
+- In §4 Draft (the scaffolding step), add a new subsection **"If `skill-invocable: true`"** specifying:
+  - Frontmatter additions: `skill-invocable: true`; `references:` entry pointing at the shared contract.
+  - Skill intro: two-mode description ("Human mode: prompts / approval / save. `--as-tool` mode: structured emission per the contract.").
+  - Workflow split into `§Xa. Human mode` and `§Xb. --as-tool mode`, with the `--as-tool mode` step instructing the emission format (JSON only for DATA; JSON envelope + fenced blocks for ARTIFACT).
+  - `## --as-tool contract` section with the four subsections (Required fields / Return shape / Side effects / Parallel-safe) populated from intake.
+  - Key Instructions entries enforcing mode-specific rules.
+- Cross-reference the canonical example: `/dummy:greet` (DATA).
+
+**Verify:**
+```
+grep -c "as-tool-contract" plugins/build/skills/build-skill/SKILL.md     # ≥ 1 (frontmatter reference)
+grep -c "skill-invocable" plugins/build/skills/build-skill/SKILL.md      # ≥ 2 (intake question + Draft section)
+grep -c "DATA\|ARTIFACT" plugins/build/skills/build-skill/SKILL.md       # ≥ 4 (shape-related prose)
+```
+
+**Commit:** `feat(build-skill): add --as-tool two-level intake and conditional scaffolding`
+
+#### Task 3: Update `skill-writing-guide.md`
+
+- [ ] Task 3: Update `skill-writing-guide.md`
+
+Modify `plugins/build/skills/build-skill/references/skill-writing-guide.md`:
+
+- Add a new H2: **"The Dual-Invocation Pattern (`--as-tool`)"**.
+- One-paragraph overview of the pattern: what it is, why it exists.
+- Pointer at the shared contract for the authoritative mechanism spec.
+- Pointer at `plugins/dummy/skills/greet/SKILL.md` as the canonical DATA example.
+- Note (for now): no canonical ARTIFACT example exists yet; the design references `build-shell` as the future canonical ARTIFACT example once #327 lands.
+- Criteria for when to opt in (produces something consumable by another skill; computation is reusable; inputs can be pre-filled by a caller).
+- Criteria for when NOT to opt in (exploratory skill, interactive-by-design, human judgment is the deliverable).
+
+**Verify:**
+```
+grep -c "^## .*Dual-Invocation\|^## .*as-tool" plugins/build/skills/build-skill/references/skill-writing-guide.md   # ≥ 1
+grep "plugins/dummy/skills/greet" plugins/build/skills/build-skill/references/skill-writing-guide.md
+```
+
+**Commit:** `docs(build-skill): add dual-invocation pattern to skill-writing-guide`
+
+### Chunk 3: check-skill
+
+#### Task 4: Add 9 new `_check_*` functions in Python
+
+- [ ] Task 4: Add 9 new `_check_*` functions in Python
+
+Modify `plugins/build/src/check/skill.py`. Add these functions following the existing `_check_*` style (return `List[dict]` with `check_id`, `severity`, `message`, `line` fields matching existing checks):
+
+- `_check_skill_invocable_boolean(frontmatter, file_str) -> List[dict]` — check 23 (warn). Fires when `skill-invocable` is present but non-boolean.
+- `_check_contract_section_present(frontmatter, body, file_str) -> List[dict]` — check 24 (fail). Fires when `skill-invocable: true` but no `## --as-tool contract` (or `##  \`--as-tool\` contract`) H2 in body (or section empty).
+- `_check_contract_return_shape_declared(frontmatter, body, file_str) -> List[dict]` — check 25 (fail). Inside contract section: must contain a `**Return shape:**` line declaring `DATA` or `ARTIFACT`.
+- `_check_contract_all_three_cases(frontmatter, body, file_str) -> List[dict]` — check 26 (fail). Inside contract section: must mention `Success`, `NeedsMoreInfo`, and `Refusal` at least once each.
+- `_check_contract_artifact_types(frontmatter, body, file_str) -> List[dict]` — check 27 (fail). When Return shape is ARTIFACT: must contain a `**Artifact types:**` line with at least one MIME-type-shaped value.
+- `_check_contract_required_fields(frontmatter, body, file_str) -> List[dict]` — check 28 (warn). Inside contract section: must contain a `**Required fields:**` subsection with at least one list item (or `"none"`).
+- `_check_contract_side_effects(frontmatter, body, file_str) -> List[dict]` — check 29 (warn). Inside contract section: must contain a `**Side effects:**` line.
+- `_check_contract_parallel_safe(frontmatter, body, file_str) -> List[dict]` — check 30 (warn). Inside contract section: must contain a `**Parallel-safe:**` line.
+- `_check_non_invocable_pathology(frontmatter, file_str) -> List[dict]` — check 31 (warn). Fires when `user-invocable: false` AND (`skill-invocable: false` or absent).
+
+Wire each function into the main `check_skill_meta` dispatcher (or equivalent aggregator — read the existing file to match its dispatcher pattern). Skills with `skill-invocable: false` or absent must not trigger checks 24–30.
+
+Preserve existing check behavior. Order findings by check_id for deterministic output.
+
+**Verify:**
+```
+grep -c "^def _check_skill_invocable_boolean\|^def _check_contract_\|^def _check_non_invocable_pathology" \
+  plugins/build/src/check/skill.py   # returns 9
+ruff check plugins/build/src/check/skill.py
+```
+
+**Commit:** `feat(check-skill): add 9 --as-tool contract checks to Python lint`
+
+#### Task 5: Add tests for each new check
+
+- [ ] Task 5: Add tests for each new check
+
+Modify `plugins/build/tests/test_skill_audit.py`. For each of the 9 new `_check_*` functions, add at least one **pass-case** (clean input, no findings) and one **fail-case** (triggering input, produces finding with correct severity). Use inline markdown fixtures per the existing test style (no file I/O for fixtures beyond `tmp_path`).
+
+Required fail-case coverage:
+- Check 23: `skill-invocable: maybe` (non-boolean) → warn.
+- Check 24: `skill-invocable: true`, no `## --as-tool contract` section → fail.
+- Check 25: contract section present but no `**Return shape:**` line → fail.
+- Check 26: contract section present but missing `NeedsMoreInfo` (or any of the three cases) → fail.
+- Check 27: `**Return shape:** ARTIFACT` but no `**Artifact types:**` line → fail.
+- Check 28: contract section present but no `**Required fields:**` → warn.
+- Check 29: no `**Side effects:**` → warn.
+- Check 30: no `**Parallel-safe:**` → warn.
+- Check 31: `user-invocable: false` and no `skill-invocable` → warn.
+
+Required pass-case coverage:
+- Opt-out skill (`skill-invocable: false` or absent) with no contract section: checks 24–30 must NOT fire.
+- DATA-shape opted-in skill with all required subsections: no findings from 23–31.
+- ARTIFACT-shape opted-in skill with Artifact types and all required subsections: no findings from 23–31.
+
+**Verify:**
+```
+python3 -m pytest plugins/build/tests/test_skill_audit.py -v
+```
+All tests pass, including the new ones.
+
+**Commit:** `test(check-skill): add fixtures for --as-tool contract checks`
+
+#### Task 6: Update `check-skill` SKILL.md
+
+- [ ] Task 6: Update `check-skill` SKILL.md
+
+Modify `plugins/build/skills/check-skill/SKILL.md`:
+
+- Add `../../_shared/references/as-tool-contract.md` to frontmatter `references:`.
+- Extend the Run Checks section's structural-checks table with rows 23–31 per the design's severity calibration.
+- Update the opening paragraph that counts the checks ("twenty-two research-backed quality criteria" → "thirty-one").
+- Add a brief explanatory paragraph pointing at the shared contract doc for the mechanism.
+
+**Verify:**
+```
+grep -c "as-tool-contract" plugins/build/skills/check-skill/SKILL.md   # ≥ 1
+grep -c "skill-invocable\|--as-tool contract" plugins/build/skills/check-skill/SKILL.md   # ≥ 3
+grep -E "thirty|31|twenty-two|22" plugins/build/skills/check-skill/SKILL.md | head   # confirm count updated
+```
+
+**Commit:** `feat(check-skill): document 9 --as-tool contract checks in SKILL.md`
+
+#### Task 7: Regression-check existing skills
+
+- [ ] Task 7: Regression-check existing skills
+
+Run `/build:check-skill` (or invoke the lint script directly: `python3 plugins/wiki/scripts/lint.py --root . --no-urls`) against the repo to confirm zero new fail-level findings on the 41 existing skills.
+
+If any new fail fires on a pre-existing skill, investigate: either (a) the skill was secretly dual-invocation and declared inconsistently (fix the skill), or (b) the check is over-eager (adjust the check).
+
+**Verify:**
+```
+python3 plugins/wiki/scripts/lint.py --root . --no-urls 2>&1 | \
+  grep -E "check_id.*(23|24|25|26|27|28|29|30|31)" | grep -c "severity.*fail"
+# expect 0 on existing skills
+```
+
+**Commit:** None, unless a fix to an existing skill or check is needed.
+
+### Chunk 4: Release
+
+#### Task 8: Self-audit modified SKILL.md files
+
+- [ ] Task 8: Self-audit modified SKILL.md files
+
+Run `/build:check-skill` against each of the four modified SKILL.md files:
+- `plugins/build/skills/build-skill/SKILL.md`
+- `plugins/build/skills/check-skill/SKILL.md`
+- `plugins/build/skills/build-skill/references/skill-writing-guide.md` is a reference file, not a SKILL.md — skip the skill-audit but manually inspect it for coherence.
+
+For any fail-level finding, fix in place and re-audit. Warns acceptable if pre-existing or explicitly accepted.
+
+**Verify:** Zero fail-level findings on the two SKILL.md files from their own audit.
+
+**Commit:** None if no fixes needed. If fixes made: `fix(build): resolve check-skill findings from --as-tool support refactor`.
+
+#### Task 9: Bump build plugin version to 0.5.0
+
+- [ ] Task 9: Bump build plugin version to 0.5.0
+
+Edit `plugins/build/pyproject.toml`: `version = "0.4.0"` → `version = "0.5.0"`.
+Edit `plugins/build/.claude-plugin/plugin.json`: `"version": "0.4.0"` → `"version": "0.5.0"`.
+
+**Verify:**
+```
+grep version plugins/build/pyproject.toml plugins/build/.claude-plugin/plugin.json
+# both show 0.5.0
+```
+
+**Commit:** `chore(build): bump to 0.5.0 for --as-tool pattern support`
+
+#### Task 10: Open PR
+
+- [ ] Task 10: Open PR
+
+Push branch `feat/build-skill-as-tool-support` and open PR against `main`:
+
+- Title: `feat(build): --as-tool pattern support in build-skill and check-skill (build-0.5.0)`
+- Body: Summary bullets (shared contract doc, two-level intake in build-skill, 9 new checks in check-skill, no migration of existing skills, version bump). Test plan: sample `/build:build-skill` runs for DATA and ARTIFACT scaffolds; regression pass on existing skills. Link to issue #327 as downstream consumer and the design doc.
+
+**Verify:** `gh pr view` returns the PR URL; CI (ruff + pytest) green.
+
+**Commit:** None (PR creation is not a commit).
+
+## Validation
+
+After all tasks complete, the following must all hold:
+
+1. **Shared contract exists with all sections.**
+   ```
+   test -f plugins/build/_shared/references/as-tool-contract.md
+   grep -c "^## " plugins/build/_shared/references/as-tool-contract.md   # ≥ 9
+   ```
+
+2. **build-skill references the shared contract.**
+   ```
+   grep "as-tool-contract" plugins/build/skills/build-skill/SKILL.md
+   ```
+   Returns at least one line in frontmatter `references:`.
+
+3. **check-skill references the shared contract.**
+   ```
+   grep "as-tool-contract" plugins/build/skills/check-skill/SKILL.md
+   ```
+   Returns at least one line in frontmatter `references:`.
+
+4. **build-skill asks the intake question.**
+   ```
+   grep -c "skill-invocable\|invocable by other skills" plugins/build/skills/build-skill/SKILL.md
+   ```
+   Returns ≥ 2.
+
+5. **Both DATA and ARTIFACT scaffolds documented in build-skill.**
+   ```
+   grep -c "DATA\|ARTIFACT" plugins/build/skills/build-skill/SKILL.md
+   ```
+   Returns ≥ 4.
+
+6. **skill-writing-guide has dual-invocation section.**
+   ```
+   grep -E "^## .*[Dd]ual.[Ii]nvocation|^## .*--as-tool" \
+     plugins/build/skills/build-skill/references/skill-writing-guide.md
+   ```
+   Returns ≥ 1 match.
+
+7. **Nine new Python check functions exist.**
+   ```
+   grep -c "^def _check_skill_invocable_boolean\|^def _check_contract_\|^def _check_non_invocable_pathology" \
+     plugins/build/src/check/skill.py
+   ```
+   Returns 9.
+
+8. **Tests pass including new ones.**
+   ```
+   python3 -m pytest plugins/build/tests/test_skill_audit.py -v
+   ```
+   All tests pass; at least one new test per new check function.
+
+9. **check-skill SKILL.md documents 9 new checks (23–31).**
+   ```
+   grep -E "\| 2[3-9] \||\| 3[01] \|" plugins/build/skills/check-skill/SKILL.md
+   ```
+   Returns ≥ 9 lines.
+
+10. **No regression on existing skills.**
+    ```
+    python3 plugins/wiki/scripts/lint.py --root . --no-urls 2>&1 | \
+      grep -E "(skill_invocable|contract_)" | grep -c "fail"
+    ```
+    Returns 0 on all 41 existing SKILL.md files.
+
+11. **Build plugin version bumped coherently.**
+    ```
+    grep version plugins/build/pyproject.toml plugins/build/.claude-plugin/plugin.json
+    ```
+    Both show `0.5.0`.
+
+12. **Ruff clean.**
+    ```
+    ruff check plugins/build
+    ```
+    Returns 0 warnings.
+
+13. **Manual smoke — DATA scaffold.** A mock run of `/build:build-skill` answered "yes → DATA" produces a SKILL.md with `skill-invocable: true`, `## --as-tool contract` section, `**Return shape:** DATA`, all three cases documented, workflow split into human/as-tool modes.
+
+14. **Manual smoke — ARTIFACT scaffold.** A mock run answered "yes → ARTIFACT, types: text/x-shellscript" produces a SKILL.md with `skill-invocable: true`, `**Return shape:** ARTIFACT`, `**Artifact types:** text/x-shellscript`, workflow emitting JSON envelope + single fenced ```bash block.
+
+15. **Manual smoke — multi-artifact ARTIFACT scaffold.** Same with `text/x-shellscript, application/json` — produces SKILL.md emitting JSON envelope + two fenced blocks in declared order.
+
+16. **Dummy plugin still works.** `/dummy:greet --as-tool name=bob time-of-day=morning` in a fresh session still returns `Success` JSON (no regression from the changes).
+
+17. **PR is open.** `gh pr view` returns a PR URL; CI green.

--- a/.plans/2026-04-20-build-check-skill-as-tool-support.plan.md
+++ b/.plans/2026-04-20-build-check-skill-as-tool-support.plan.md
@@ -292,7 +292,7 @@ grep version plugins/build/pyproject.toml plugins/build/.claude-plugin/plugin.js
 
 #### Task 10: Open PR
 
-- [ ] Task 10: Open PR
+- [x] Task 10: Open PR <!-- pr:#335 --> (opened against main)
 
 Push branch `feat/build-skill-as-tool-support` and open PR against `main`:
 

--- a/plugins/build/.claude-plugin/plugin.json
+++ b/plugins/build/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "build",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Skills for creating and refining Claude Code skills, rules, hooks, and subagents.",
   "author": {
     "name": "Brandon Beidel"

--- a/plugins/build/_shared/references/as-tool-contract.md
+++ b/plugins/build/_shared/references/as-tool-contract.md
@@ -1,0 +1,153 @@
+---
+name: "--as-tool Invocation Contract"
+description: Generic mechanism spec for the dual-invocation pattern. A skill that declares `skill-invocable: true` in its frontmatter becomes callable by another skill via `--as-tool` — structured args in, structured payload out, no human ceremony. This file is the authoritative contract; opt-in skills reference it from their frontmatter.
+---
+
+# `--as-tool` Invocation Contract
+
+## Purpose
+
+A skill's computation is often more reusable than its user interface. `greet` computes a greeting *and* prompts the user; but a downstream skill that just wants the greeting shouldn't inherit the prompts. The `--as-tool` pattern lets one skill invoke another at runtime with a structured payload, receive a structured return, and skip all the human ceremony the callee would otherwise perform.
+
+Opt in per-skill via `skill-invocable: true` in frontmatter — the field parallels `user-invocable`. Reach for this pattern when the skill's output is consumable by *another skill* (the caller pre-fills inputs, inspects the return, handles retries). Skip it for exploratory, interactive-by-design, or judgment-heavy skills where the ceremony is the product.
+
+## Parsing rule
+
+Every `--as-tool` skill parses `$ARGUMENTS` with one deterministic rule, regardless of the skill's domain:
+
+| Shape | Mode | Behavior |
+|---|---|---|
+| empty | human | full Elicit (ask all required fields interactively) |
+| freeform text (no `=` tokens, no `--` flags) | human | LLM-parse what it can from the text; prompt for anything still missing |
+| `key=value` tokens | human | parse named fields; prompt for anything still missing; non-kv tokens are noise |
+| `--as-tool` present (with or without `key=value` tokens) | skill-caller | require all declared fields; hard-fail via `NeedsMoreInfo` if any are missing; skip Elicit, Review Gate, and Save |
+
+Only the fourth row triggers `--as-tool` mode. The first three are human-mode variants.
+
+## Step skip/run under `--as-tool`
+
+`--as-tool` suppresses **human ceremony**, not side effects. Code execution, file reads, invocations of other `--as-tool` skills, and similar non-interactive work all run unchanged. The rule targets humans, not the machine.
+
+| Workflow step | Human mode | `--as-tool` |
+|---|---|---|
+| Route | runs | runs |
+| Scope Gate (FX.1-style) | runs; halts interactively on refusal | runs; refusal returned as structured `Refusal`, does **not** halt |
+| Elicit | runs; prompts for missing fields | **skipped**; hard-fail via `NeedsMoreInfo` if any required field missing |
+| Draft / core computation | runs | runs |
+| Safety Check | runs; revises in place | runs; findings packed into the return payload |
+| Review Gate | runs; waits for user approval | **skipped**; the caller owns approval |
+| Save (`chmod +x`, file writes) | runs | **skipped**; the caller owns writes |
+| Test handoff (offer follow-up skill) | runs | **skipped** |
+
+Rule of thumb: if the step prompts a human or writes to disk on the user's behalf, it's skipped under `--as-tool`.
+
+## Envelope — three cases
+
+Every `--as-tool` skill returns one of three control-flow cases in a JSON envelope. The envelope is always JSON; the success *payload* shape varies by skill (see DATA vs ARTIFACT below).
+
+- `Success` — the skill completed; the payload is ready.
+- `NeedsMoreInfo` — recoverable. The required fields are incomplete; the caller can fill the gap and retry. Envelope carries `missing` (array of field names) and `hint` (one-sentence guidance).
+- `Refusal` — categorical. The skill declined to compute; retry will not help (e.g., scope-gate fire, invalid input combination, permission boundary). Envelope carries `reason` (one-line explanation) and `category` (short machine-friendly tag like `scope-gate`, `permission`, `invalid-combo`).
+
+`NeedsMoreInfo` and `Refusal` are **always JSON-only**, regardless of the skill's return shape. No fenced code block follows on either failure path. This keeps the failure contract uniform across every `--as-tool` skill.
+
+## Return shape DATA
+
+For skills whose output is a structured object (greet composes a greeting struct; check-skill emits findings; scope-work emits a design summary), use Shape **DATA**.
+
+Success emission is JSON only — no fenced block follows:
+
+```
+{"type": "Success", "value": {"text": "Good morning, bob!", "name": "bob", "time_of_day": "morning"}}
+```
+
+The `value` schema is skill-declared (documented in the skill's own `## --as-tool contract` section). The caller parses the JSON and reads fields by name.
+
+`NeedsMoreInfo` / `Refusal` follow the envelope rules above (JSON only).
+
+## Return shape ARTIFACT
+
+For skills whose output is a text artifact in its native syntax (build-shell produces a shell script; build-rule produces a markdown file; build-skill produces a SKILL.md; build-hook produces both a hook script and a JSON settings entry), use Shape **ARTIFACT**.
+
+Success emission is a JSON envelope **followed by one or more fenced code blocks** carrying the artifact bodies in their native formats:
+
+```
+{"type": "Success", "artifact_types": ["text/x-shellscript"], "metadata": {"target": "bash-3.2-portable"}}
+```
+```bash
+#!/usr/bin/env bash
+set -Eeuo pipefail
+# ... the full scaffold ...
+```
+
+**Multi-artifact variant** — a single call producing multiple artifacts (e.g., a hook script + its settings.json entry):
+
+```
+{"type": "Success", "artifact_types": ["text/x-shellscript", "application/json"], "metadata": {"hook_event": "PreToolUse"}}
+```
+```bash
+#!/usr/bin/env bash
+# hook script
+```
+```json
+{"hooks": {"PreToolUse": [...]}}
+```
+
+**Rules:**
+
+- The number and order of fenced code blocks must match the `artifact_types` array exactly. A skill declaring `["text/x-shellscript", "application/json"]` emits two fenced blocks — bash first, then json.
+- Each fenced block's language tag matches the declared MIME type per the table below. Language-tag-per-MIME is what lets the caller route each block to the right consumer (mutate the shell, parse the JSON) without string-matching headers.
+- `metadata` is an optional JSON object carrying skill-specific facts that aren't the artifact itself (target shell, hook event, render variant, etc.).
+- `NeedsMoreInfo` and `Refusal` remain JSON-only. No fenced blocks follow on the failure paths — the failure envelope is identical across DATA and ARTIFACT skills.
+
+**Language tag per MIME type:**
+
+| MIME type | Fenced-block language tag |
+|---|---|
+| `application/json` | `json` |
+| `text/x-shellscript` | `bash` |
+| `text/x-python` | `python` |
+| `text/markdown` | `markdown` |
+| `text/x-yaml` / `application/yaml` | `yaml` |
+| `text/x-toml` | `toml` |
+| `text/plain` | `text` |
+
+Add entries only when a new artifact type is genuinely needed. Keep the set small; prefer existing types over inventing new ones.
+
+## When to pick DATA vs ARTIFACT
+
+Use the following rule of thumb:
+
+- **DATA** — the output is a structured record the caller will read field-by-field. Examples: `greet` (a greeting with name/time/text), `check-skill` (findings list), `scope-work` (a design summary object).
+- **ARTIFACT** — the output is code, configuration, markdown, or any text file whose value comes from its native syntax. Examples: `build-shell` (bash script), `build-rule` (markdown rule file), `build-skill` (a new SKILL.md), `build-hook` (shell script + settings.json entry).
+
+Pick ARTIFACT whenever JSON-escaping the payload would harm readability or debuggability. Multi-line code embedded in a JSON string is legal but brittle; a fenced code block is the natural medium.
+
+Hybrid case — a skill whose output includes *both* a structured record *and* a text artifact — use ARTIFACT and carry the structured part in the envelope's `metadata` object.
+
+## Parallel-safety
+
+By default, invoking an `--as-tool` skill N times from within a single outer-skill run is **safe to parallelize**. This is a free win when the caller iterates over a collection (greet-team greeting N teammates) — Claude Code will invoke them concurrently.
+
+Skills must document an exception when they are *not* parallel-safe. Common causes: shared resource acquisition (file locks, rate-limited APIs), ordering dependencies (later calls consume earlier-call state), singleton side effects (writes to a specific known path). If any of these apply, declare `**Parallel-safe:** no — <reason>` in the skill's contract section. The caller is responsible for serializing the invocations.
+
+Absence of a parallel-safety note is interpreted as "yes, safe." Declaring `**Parallel-safe:** yes` explicitly is the recommended habit.
+
+## Freeform-text human mode
+
+The parsing rule's second row (freeform text with no `=` or `--`) exists because humans speak the way they speak, not the way a CLI accepts args. A human typing `/dummy:greet blake morning welcome to the thunderdome` expects the skill to extract `name=blake` and `time_of_day=morning` from the text and get on with it. Similarly, voice-dictated inputs are a first-class shape — they arrive as freeform strings.
+
+Under freeform mode, the skill's LLM parses what it can from the text (best-effort) and prompts interactively for anything still missing. There is no hard-fail path in human mode — a user talking to the skill will always be asked to clarify.
+
+Freeform-text mode does **not** apply under `--as-tool`. Callers must pre-fill all required fields using `key=value` tokens (or supply them in `metadata` on re-invocation after `NeedsMoreInfo`). The inner skill will not LLM-parse prose under `--as-tool`.
+
+## When NOT to use the pattern
+
+Not every skill benefits from opt-in. Skip `--as-tool` when:
+
+- **The skill is exploratory or interactive by design.** `/work:scope-work` drives a divergent-then-convergent dialogue; pre-filling its intake defeats the purpose. `/consider:*` skills apply mental models through conversation. Mechanizing these produces empty motions.
+- **The deliverable is human judgment.** If the skill's value is a considered recommendation that requires human review at each step, there's nothing to return as a pure function.
+- **The output is advisory context** loaded for a human's benefit (CLAUDE.md-style conventions injected into a session). No caller wants to "invoke" advisory context.
+- **The skill is a chain orchestrator.** `/work:start-work` sequences other skills under human approval gates; it's a controller, not a computation.
+
+When in doubt, default to opt-out. The ecosystem benefits more from a small set of well-designed `--as-tool` skills than from blanket adoption. A future skill can always opt in later; unwinding premature opt-in is harder.

--- a/plugins/build/pyproject.toml
+++ b/plugins/build/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "check"
-version = "0.4.0"
+version = "0.5.0"
 description = "Claude Code plugin for auditing Claude Code skills and rules for quality issues."
 requires-python = ">=3.9"
 dependencies = []

--- a/plugins/build/skills/build-skill/SKILL.md
+++ b/plugins/build/skills/build-skill/SKILL.md
@@ -13,6 +13,7 @@ references:
   - references/platform-notes.md
   - references/skill-writing-guide.md
   - ../../_shared/references/primitive-routing.md
+  - ../../_shared/references/as-tool-contract.md
 ---
 
 # Skill Creator
@@ -78,6 +79,7 @@ Also probe for structural decisions that shape how the skill is built — derive
   - **Destructive or irreversible** (deploy, rm -rf, DROP TABLE, force-push) → **low-freedom** — scripts, explicit gates, no variation.
 
   Calibrate specificity to task fragility. Fragile tasks get low-freedom; routine tasks get high-freedom. Over-specifying a routine task produces brittle skills that break on edge cases Claude could have handled.
+- **Should this skill be invocable by other skills via `--as-tool`?** Default **no** — most skills are human-only. Set `skill-invocable: true` in frontmatter when the skill's computation is reusable by another skill as a pure function (structured args in, structured return out, no human ceremony). If yes, ask a follow-up: **does this skill return structured data (DATA) or a text artifact like a script/markdown/config (ARTIFACT)?** If ARTIFACT, also ask for the list of MIME types produced (e.g., `text/x-shellscript`, `text/markdown`, `application/json`). Skip entirely for exploratory, interactive-by-design, or judgment-heavy skills. See `../../_shared/references/as-tool-contract.md` for the full mechanism, DATA/ARTIFACT emission rules, and parallel-safety convention. *(check-skill #23–31)*
 - **Where should this skill live?** Pick a scope before drafting:
   - **project** — `.claude/skills/<name>/SKILL.md` (default when working in a repo with a `.claude/` directory; ships with the codebase)
   - **personal** — `~/.claude/skills/<name>/SKILL.md` (single-user, all projects)
@@ -108,6 +110,27 @@ Based on the user interview, fill in these components. Most skills need only `na
 - **allowed-tools** _(optional)_: Tools that run without per-use confirmation when this skill is active. Canonical forms: **space-separated string** (`Grep Read`) or **YAML list** (`[Grep, Read]` or block form). **Never comma-separated as a string** (`Grep, Read`) — YAML parses it as one literal value and the field silently does nothing.
 - **tested_with** _(optional)_: Model tiers verified against (e.g., `[sonnet, haiku]`); omit if untested. *(check-skill #2)*
 - **references** _(optional)_: Reference files or assets in the skill directory for progressive disclosure.
+- **skill-invocable** _(optional; parallels `user-invocable`)_: Default `false` — **omit** unless you opted in to the `--as-tool` dual-invocation pattern during the interview. Set `true` when the skill should be callable by another skill (see below). Independent of `user-invocable` — a skill can be both, either, or neither. *(check-skill #23–31)*
+
+**If `skill-invocable: true` (opted in during Interview):** the scaffolded SKILL.md gets additional content. Generate all of the following:
+
+- **Frontmatter:** add `skill-invocable: true`; add `../../_shared/references/as-tool-contract.md` to `references:`. If DATA was chosen, no additional hints needed. If ARTIFACT was chosen, the follow-up intake captured the artifact-type list — use it in the contract section below.
+- **Skill intro:** add a "Two invocation modes" paragraph near the top: human mode (prompts, approval, save) vs. `--as-tool` mode (structured emission per the shared contract; no prompts, no approval).
+- **Workflow split:** the final user-facing step branches into `§Xa. Human mode` (present + approve + save) and `§Xb. --as-tool mode` (emit structured return). The `--as-tool mode` step documents the specific emission format:
+  - **DATA:** "Output **only** a JSON block — no prose, no preamble. One of three envelope shapes: `Success` with a `value` object, `NeedsMoreInfo` with `missing` + `hint`, or `Refusal` with `reason` + `category`."
+  - **ARTIFACT:** "Output a JSON envelope followed by one or more fenced code blocks. The envelope declares `artifact_types` in the order the fenced blocks appear. Language tag per MIME: `text/x-shellscript` → ` ```bash `, `application/json` → ` ```json `, `text/markdown` → ` ```markdown `, etc. `NeedsMoreInfo` and `Refusal` are JSON-only (no fenced blocks) regardless of shape."
+- **`## --as-tool contract` section** — mandatory under `skill-invocable: true`. Populate from the Interview answers. Subsections:
+  - `**Required fields:**` — the named fields a caller must pre-fill (e.g., `name`, `path`, `target-shell`). List each with a one-line description.
+  - `**Return shape:** DATA` _or_ `**Return shape:** ARTIFACT`. If ARTIFACT: add `**Artifact types:** <mime>, <mime>, ...` immediately after.
+  - For each of `Success`, `NeedsMoreInfo`, `Refusal`: describe the envelope for that case (schema of `value` for DATA; metadata + artifact-role for ARTIFACT; always JSON-only for the two failure cases).
+  - `**Side effects:**` — list or `none` (files the skill reads, commands it runs, other `--as-tool` skills it invokes).
+  - `**Parallel-safe:** yes` (default) or `no — <reason>` (e.g., acquires file lock on X).
+- **Key Instructions additions:** three entries enforcing mode-specific rules.
+  - "Under `--as-tool`: emit per the contract (DATA: JSON only; ARTIFACT: JSON envelope + fenced blocks in declared order). No prose, no `input()`, no approval."
+  - "Under `--as-tool`: hard-fail with `NeedsMoreInfo` when any required field is missing. Do not prompt — the caller will retry."
+  - "`NeedsMoreInfo` and `Refusal` emit JSON only, regardless of return shape. Fenced blocks are never emitted on failure paths."
+
+The canonical DATA example is `/dummy:greet` at `plugins/dummy/skills/greet/SKILL.md`. Read it when in doubt. A canonical ARTIFACT example lands with the `#327` hook/shell refactor — until then, refer authors to the shared contract's ARTIFACT section for emission shape.
 
 **Optional toolkit sections.** Add these when trigger conditions apply — they're house-style scaffolding, not canonical requirements. See [check-skill criteria](../../check-skill/SKILL.md) for the exact triggers.
 

--- a/plugins/build/skills/build-skill/SKILL.md
+++ b/plugins/build/skills/build-skill/SKILL.md
@@ -12,6 +12,7 @@ tested_with: [sonnet]
 references:
   - references/platform-notes.md
   - references/skill-writing-guide.md
+  - references/as-tool-scaffolding.md
   - ../../_shared/references/primitive-routing.md
   - ../../_shared/references/as-tool-contract.md
 ---
@@ -110,27 +111,7 @@ Based on the user interview, fill in these components. Most skills need only `na
 - **allowed-tools** _(optional)_: Tools that run without per-use confirmation when this skill is active. Canonical forms: **space-separated string** (`Grep Read`) or **YAML list** (`[Grep, Read]` or block form). **Never comma-separated as a string** (`Grep, Read`) — YAML parses it as one literal value and the field silently does nothing.
 - **tested_with** _(optional)_: Model tiers verified against (e.g., `[sonnet, haiku]`); omit if untested. *(check-skill #2)*
 - **references** _(optional)_: Reference files or assets in the skill directory for progressive disclosure.
-- **skill-invocable** _(optional; parallels `user-invocable`)_: Default `false` — **omit** unless you opted in to the `--as-tool` dual-invocation pattern during the interview. Set `true` when the skill should be callable by another skill (see below). Independent of `user-invocable` — a skill can be both, either, or neither. *(check-skill #23–31)*
-
-**If `skill-invocable: true` (opted in during Interview):** the scaffolded SKILL.md gets additional content. Generate all of the following:
-
-- **Frontmatter:** add `skill-invocable: true`; add `../../_shared/references/as-tool-contract.md` to `references:`. If DATA was chosen, no additional hints needed. If ARTIFACT was chosen, the follow-up intake captured the artifact-type list — use it in the contract section below.
-- **Skill intro:** add a "Two invocation modes" paragraph near the top: human mode (prompts, approval, save) vs. `--as-tool` mode (structured emission per the shared contract; no prompts, no approval).
-- **Workflow split:** the final user-facing step branches into `§Xa. Human mode` (present + approve + save) and `§Xb. --as-tool mode` (emit structured return). The `--as-tool mode` step documents the specific emission format:
-  - **DATA:** "Output **only** a JSON block — no prose, no preamble. One of three envelope shapes: `Success` with a `value` object, `NeedsMoreInfo` with `missing` + `hint`, or `Refusal` with `reason` + `category`."
-  - **ARTIFACT:** "Output a JSON envelope followed by one or more fenced code blocks. The envelope declares `artifact_types` in the order the fenced blocks appear. Language tag per MIME: `text/x-shellscript` → ` ```bash `, `application/json` → ` ```json `, `text/markdown` → ` ```markdown `, etc. `NeedsMoreInfo` and `Refusal` are JSON-only (no fenced blocks) regardless of shape."
-- **`## --as-tool contract` section** — mandatory under `skill-invocable: true`. Populate from the Interview answers. Subsections:
-  - `**Required fields:**` — the named fields a caller must pre-fill (e.g., `name`, `path`, `target-shell`). List each with a one-line description.
-  - `**Return shape:** DATA` _or_ `**Return shape:** ARTIFACT`. If ARTIFACT: add `**Artifact types:** <mime>, <mime>, ...` immediately after.
-  - For each of `Success`, `NeedsMoreInfo`, `Refusal`: describe the envelope for that case (schema of `value` for DATA; metadata + artifact-role for ARTIFACT; always JSON-only for the two failure cases).
-  - `**Side effects:**` — list or `none` (files the skill reads, commands it runs, other `--as-tool` skills it invokes).
-  - `**Parallel-safe:** yes` (default) or `no — <reason>` (e.g., acquires file lock on X).
-- **Key Instructions additions:** three entries enforcing mode-specific rules.
-  - "Under `--as-tool`: emit per the contract (DATA: JSON only; ARTIFACT: JSON envelope + fenced blocks in declared order). No prose, no `input()`, no approval."
-  - "Under `--as-tool`: hard-fail with `NeedsMoreInfo` when any required field is missing. Do not prompt — the caller will retry."
-  - "`NeedsMoreInfo` and `Refusal` emit JSON only, regardless of return shape. Fenced blocks are never emitted on failure paths."
-
-The canonical DATA example is `/dummy:greet` at `plugins/dummy/skills/greet/SKILL.md`. Read it when in doubt. A canonical ARTIFACT example lands with the `#327` hook/shell refactor — until then, refer authors to the shared contract's ARTIFACT section for emission shape.
+- **skill-invocable** _(optional; parallels `user-invocable`)_: Default `false` — **omit** unless the skill opted in to the `--as-tool` dual-invocation pattern during Interview. Set `true` when the skill should be callable by another skill. Independent of `user-invocable` — a skill can be both, either, or neither. **If set to `true`, apply the scaffolding recipe in [`references/as-tool-scaffolding.md`](references/as-tool-scaffolding.md)** (frontmatter additions, workflow split, mandatory `## --as-tool contract` section, Key Instructions entries). *(check-skill #23–31)*
 
 **Optional toolkit sections.** Add these when trigger conditions apply — they're house-style scaffolding, not canonical requirements. See [check-skill criteria](../../check-skill/SKILL.md) for the exact triggers.
 

--- a/plugins/build/skills/build-skill/references/as-tool-scaffolding.md
+++ b/plugins/build/skills/build-skill/references/as-tool-scaffolding.md
@@ -1,0 +1,67 @@
+---
+name: "--as-tool Scaffolding Recipe"
+description: Template build-skill uses when `skill-invocable: true` is opted in during Interview. Documents what to generate for frontmatter, skill intro, workflow split, contract section, and Key Instructions. Paired with the shared authoritative spec at ../../_shared/references/as-tool-contract.md.
+---
+
+# `--as-tool` Scaffolding Recipe
+
+This reference is loaded by `/build:build-skill` only when the user answered **yes** to the "should this skill be invocable by other skills via `--as-tool`?" intake question. It describes what the scaffolded SKILL.md must contain to conform to the shared contract at `../../_shared/references/as-tool-contract.md`.
+
+For the authoritative mechanism (parsing rule, envelope shapes, emission rules), always consult the shared contract. This file is a **scaffolding checklist**, not the spec.
+
+## Frontmatter additions
+
+When opting in, generate the following on top of the standard frontmatter:
+
+- `skill-invocable: true`
+- Add `../../_shared/references/as-tool-contract.md` to the `references:` list.
+
+If the author chose **DATA** return shape, no further frontmatter is needed. If **ARTIFACT**, the intake captured the artifact-type list — use it in the Contract section below; no frontmatter impact.
+
+## Skill intro paragraph
+
+Near the top of the body (right after the H1 or the one-line purpose), add a short "Two invocation modes" paragraph:
+
+> Two invocation modes:
+> - **Human** — prompts for missing info, shows the result, asks for approval.
+> - **`--as-tool`** — structured emission per the shared contract. No prompts, no approval.
+
+Exact wording can vary; the paragraph must name both modes and signal that the `--as-tool` mode emits structured output.
+
+## Workflow split
+
+The final user-facing step of the skill's Workflow branches into two sub-steps keyed on mode:
+
+- **`§Xa. Human mode`** — present the result, ask for approval, save if applicable.
+- **`§Xb. --as-tool mode`** — emit the structured return. The emission prose depends on the Return shape:
+
+  - **DATA:** "Output **only** a JSON block — no prose, no preamble. One of three envelope shapes: `Success` with a `value` object, `NeedsMoreInfo` with `missing` + `hint`, or `Refusal` with `reason` + `category`."
+  - **ARTIFACT:** "Output a JSON envelope followed by one or more fenced code blocks. The envelope declares `artifact_types` in the order the fenced blocks appear. Language tag per MIME: `text/x-shellscript` → ` ```bash `, `application/json` → ` ```json `, `text/markdown` → ` ```markdown `, etc. `NeedsMoreInfo` and `Refusal` are JSON-only (no fenced blocks) regardless of shape."
+
+## `## --as-tool contract` section — mandatory
+
+Every opted-in SKILL.md must include this H2 section. Populate from the Interview answers. Subsections (in this order):
+
+- **`**Required fields:**`** — list each named field a caller must pre-fill (e.g., `name`, `path`, `target-shell`) with a one-line description. Use `none` if the skill takes no args under `--as-tool`.
+- **`**Return shape:** DATA`** _or_ **`**Return shape:** ARTIFACT`** — the declared shape.
+- For ARTIFACT only: **`**Artifact types:**`** — comma-separated MIME types in the order fenced blocks will appear (e.g., `text/x-shellscript, application/json`).
+- Three bullets for the envelope cases. For each of `Success`, `NeedsMoreInfo`, `Refusal`, describe what its envelope carries:
+  - DATA `Success` — schema of `value`.
+  - ARTIFACT `Success` — metadata shape and which fenced block plays which role.
+  - `NeedsMoreInfo` — always JSON only: `missing: [...]`, `hint: "..."`.
+  - `Refusal` — always JSON only: `reason`, `category` (enumerate the category values the skill uses).
+- **`**Side effects:**`** — list the files read, commands run, or other `--as-tool` skills invoked. Use `none` if the skill is pure.
+- **`**Parallel-safe:**`** — `yes` (default) or `no — <reason>` (e.g., "no — acquires exclusive lock on `/tmp/x`").
+
+## Key Instructions additions
+
+Generate three entries under the existing `## Key Instructions` section (create the section if the scaffolded skill doesn't already have one):
+
+- "Under `--as-tool`: emit per the contract (DATA: JSON only; ARTIFACT: JSON envelope + fenced blocks in declared order). No prose, no `input()`, no approval."
+- "Under `--as-tool`: hard-fail with `NeedsMoreInfo` when any required field is missing. Do not prompt — the caller will retry."
+- "`NeedsMoreInfo` and `Refusal` emit JSON only, regardless of return shape. Fenced blocks are never emitted on failure paths."
+
+## Canonical examples
+
+- **DATA:** `plugins/dummy/skills/greet/SKILL.md` — a minimal DATA-shape skill. Read it when in doubt.
+- **ARTIFACT:** no canonical example exists yet; one will land with the hook/shell refactor (#327). Until then, refer to the ARTIFACT emission examples in `../../_shared/references/as-tool-contract.md`.

--- a/plugins/build/skills/build-skill/references/skill-writing-guide.md
+++ b/plugins/build/skills/build-skill/references/skill-writing-guide.md
@@ -205,6 +205,63 @@ as a won't-work-without dependency in `## Key Instructions`:
 - Requires the `fetch-data` skill to be installed — won't produce useful output without it
 ```
 
+## The Dual-Invocation Pattern (`--as-tool`)
+
+Some skills benefit from being callable by *other skills* in addition to
+humans. When a skill's computation is a reusable pure function — structured
+inputs map to a structured output, the user's role is optional — opt in to
+the dual-invocation pattern by adding `skill-invocable: true` in frontmatter.
+
+The skill then supports two modes, selected by `$ARGUMENTS`:
+
+- **Human mode** — the skill elicits missing fields, presents the result,
+  asks for approval, and saves. Typical slash-command experience.
+- **`--as-tool` mode** — the skill parses structured args from `$ARGUMENTS`,
+  runs its computation without any human ceremony, and returns a structured
+  payload the caller consumes. No prompts, no approval, no file saves.
+
+The authoritative spec is
+`../../_shared/references/as-tool-contract.md` — it documents the
+`$ARGUMENTS` parsing rule, skip/run-per-step semantics, three-case envelope
+(`Success` / `NeedsMoreInfo` / `Refusal`), and both return shapes:
+
+- **DATA** — success payload is a JSON `value` object. Example:
+  `plugins/dummy/skills/greet/SKILL.md`. Read that skill when you need the
+  canonical reference for a DATA skill's SKILL.md shape.
+- **ARTIFACT** — success payload is a JSON envelope followed by one or more
+  fenced code blocks carrying text artifacts (shell scripts, markdown,
+  JSON config). A canonical ARTIFACT example will land with the hook/shell
+  refactor; until then, the shared contract's ARTIFACT emission examples
+  are the source of truth.
+
+### When to opt in
+
+Reach for `skill-invocable: true` when **all** of these are true:
+
+- The skill's output is consumed by downstream code, not just shown to a
+  human. A caller will read fields, mutate an artifact, or feed the result
+  into another step.
+- A caller can pre-fill the skill's required inputs from its own context.
+  (If the inputs require human judgment, there is nothing to pre-fill.)
+- The skill's value survives stripping the UI ceremony — the prompts and
+  approval gate aren't the deliverable.
+
+### When to skip
+
+Leave `skill-invocable` off (absent — defaults to `false`) when:
+
+- The skill is **exploratory or interactive by design** (e.g.,
+  `/work:scope-work` drives a divergent-then-convergent dialogue; mechanizing
+  its intake defeats its purpose).
+- The **deliverable is human judgment** — a considered recommendation that
+  requires human review at each step.
+- The skill is **advisory context** loaded for a human's benefit.
+- The skill is a **chain orchestrator** that sequences other skills under
+  human approval gates.
+
+When in doubt, stay opt-out. A future skill can always opt in later;
+unwinding premature opt-in is harder.
+
 ## Persistent State
 
 Data written to the skill directory may be deleted on upgrade. For state that

--- a/plugins/build/skills/check-skill/SKILL.md
+++ b/plugins/build/skills/check-skill/SKILL.md
@@ -6,11 +6,13 @@ description: >
   problems in a skill", or "improve a skill".
 argument-hint: "[path/to/SKILL.md — omit to audit all skills]"
 user-invocable: true
+references:
+  - ../../_shared/references/as-tool-contract.md
 ---
 
 # Check Skill
 
-Audit one skill or all skills against twenty-two research-backed quality criteria,
+Audit one skill or all skills against thirty-one research-backed quality criteria,
 then offer an opt-in repair loop.
 
 ## Workflow
@@ -84,6 +86,24 @@ For each skill, read the SKILL.md body and assess the remaining twenty criteria:
 | 16 | Edge case handling | best-practice | The skill explicitly addresses at least one failure mode: missing or ambiguous input, a precondition that isn't met, or a mid-workflow failure. A gate check (#5) that blocks on missing input counts; a Workflow step that says "if X is unavailable, do Y" counts. Silence on all failure modes is a fail. |
 | 21 | Reversibility | best-practice | If the skill performs irreversible or high-impact operations (file deletion, git reset, commit, deploy, external API write), `## Key Instructions` or `## Handoff` documents how to revert or recover from an unintended execution (e.g., "use `git reflog` to recover", "review with `/diff` before confirming"). |
 
+**`--as-tool` contract checks (23–31):** dual-invocation support. These checks
+only fire when a skill declares `skill-invocable: true` in frontmatter
+(default is off). Skills without the field are unaffected — no migration
+burden on the existing 41 skills. The shared mechanism spec lives at
+[`../../_shared/references/as-tool-contract.md`](../../_shared/references/as-tool-contract.md).
+
+| # | Check | Category | Severity | Pass condition |
+|---|-------|----------|----------|---------------|
+| 23 | `skill-invocable` frontmatter shape | canonical | warn | When `skill-invocable` is present, its value is boolean (`true`/`false` — YAML true/false literals or quoted strings). Non-boolean values warn. |
+| 24 | `## --as-tool contract` section present | canonical | **fail** | When `skill-invocable: true`, the body contains a `## --as-tool contract` (or `## \`--as-tool\` contract`) H2 section, and that section is not empty. A declared-but-missing contract is runtime-breaking — callers cannot know the invocation shape. |
+| 25 | Return shape declared | canonical | **fail** | Inside the contract section, a `**Return shape:**` line declares either `DATA` or `ARTIFACT`. |
+| 26 | All three envelope cases documented | canonical | **fail** | The contract section mentions all three cases by name: `Success`, `NeedsMoreInfo`, `Refusal`. Missing any case fails — the envelope is a closed-set union and every case must be declared. |
+| 27 | ARTIFACT declares `Artifact types:` | canonical | **fail** | When `**Return shape:** ARTIFACT`, the section contains a `**Artifact types:**` line with at least one MIME type (e.g., `text/x-shellscript`, `application/json`). Without it, callers can't know which language tag to expect per fenced block. |
+| 28 | Required fields documented | toolkit-opinion | warn | Contract section has a `**Required fields:**` subsection (list or `none`). |
+| 29 | Side effects documented | toolkit-opinion | warn | Contract section has a `**Side effects:**` subsection (list or `none`). |
+| 30 | Parallel-safe documented | toolkit-opinion | warn | Contract section has a `**Parallel-safe:**` subsection (default `yes`; non-default values must explain why). |
+| 31 | Non-invocable pathology | toolkit-opinion | warn | Skills declaring `user-invocable: false` without also declaring `skill-invocable: true` are not invocable by humans or other skills — likely misplaced in `skills/`. Either move to a non-skill location or set `skill-invocable: true` to make them callable programmatically. |
+
 **Note on directive density (check #2):** newer frontier models respond better
 to rationale-based instructions than directives. When flagging ALL-CAPS density
 ≥3: (a) if `tested_with` is present and lists only sub-frontier models (e.g.,
@@ -104,7 +124,7 @@ Output a findings table:
 ```
 
 Summary line at top and bottom: `N fail, N warn` across N skills.
-Sort: fail before warn; structural (checks 3–7, 11, 13–15, 17, 18, 20, 22, 23) before content-quality (8–10, 12, 16, 21).
+Sort: fail before warn; structural (checks 3–7, 11, 13–15, 17, 18, 20, 22, 23–27, 31) before content-quality (8–10, 12, 16, 21, 28–30).
 
 ### 5. Opt-In Repair Loop
 

--- a/plugins/build/src/check/skill.py
+++ b/plugins/build/src/check/skill.py
@@ -609,6 +609,244 @@ def _check_reference_toc(skill_dir: Path, file_str: str) -> List[dict]:
     return issues
 
 
+# ── --as-tool contract checks ───────────────────────────────────────
+
+_CONTRACT_HEADER_RE = re.compile(
+    r"^##\s+`?--as-tool`?\s+contract\b",
+    flags=re.IGNORECASE | re.MULTILINE,
+)
+
+
+def _extract_contract_section(body: str) -> Optional[str]:
+    """Return the `## --as-tool contract` section body, or None if absent.
+
+    Matches both ``## --as-tool contract`` and ``## `--as-tool` contract``.
+    The returned string is the content below the header, up to the next
+    ``## `` heading or end-of-file.
+    """
+    match = _CONTRACT_HEADER_RE.search(body)
+    if not match:
+        return None
+    remaining = body[match.end():]
+    next_h2 = re.search(r"^##\s+", remaining, flags=re.MULTILINE)
+    if next_h2:
+        return remaining[:next_h2.start()]
+    return remaining
+
+
+def _is_skill_invocable_true(meta: dict) -> bool:
+    """Return True only when ``skill-invocable`` is explicitly true."""
+    value = meta.get("skill-invocable")
+    if value is True:
+        return True
+    if isinstance(value, str) and value.strip().lower() == "true":
+        return True
+    return False
+
+
+def _is_user_invocable_explicitly_false(meta: dict) -> bool:
+    """Return True when ``user-invocable`` is explicitly false."""
+    value = meta.get("user-invocable")
+    if value is False:
+        return True
+    if isinstance(value, str) and value.strip().lower() == "false":
+        return True
+    return False
+
+
+def _check_skill_invocable_boolean(meta: dict, file_str: str) -> List[dict]:
+    """Check 23 (warn): ``skill-invocable`` must be boolean when present."""
+    if "skill-invocable" not in meta:
+        return []
+    value = meta["skill-invocable"]
+    if isinstance(value, bool):
+        return []
+    if isinstance(value, str) and value.strip().lower() in ("true", "false"):
+        return []
+    return [{
+        "file": file_str,
+        "issue": (
+            f"frontmatter `skill-invocable` must be boolean (true/false); "
+            f"found {value!r}"
+        ),
+        "severity": "warn",
+    }]
+
+
+def _check_contract_section_present(
+    meta: dict, body: str, file_str: str,
+) -> List[dict]:
+    """Check 24 (fail): opted-in skills must have ``## --as-tool contract``."""
+    if not _is_skill_invocable_true(meta):
+        return []
+    section = _extract_contract_section(body)
+    if section is None or not section.strip():
+        return [{
+            "file": file_str,
+            "issue": (
+                "skill declares `skill-invocable: true` but has no "
+                "`## --as-tool contract` section (or the section is empty); "
+                "callers cannot know the invocation contract"
+            ),
+            "severity": "fail",
+        }]
+    return []
+
+
+def _check_contract_return_shape_declared(
+    meta: dict, body: str, file_str: str,
+) -> List[dict]:
+    """Check 25 (fail): contract must declare Return shape DATA or ARTIFACT."""
+    if not _is_skill_invocable_true(meta):
+        return []
+    section = _extract_contract_section(body)
+    if section is None or not section.strip():
+        return []  # Check 24 already fired
+    if not re.search(
+        r"\*\*Return shape:\*\*\s+(DATA|ARTIFACT)", section, flags=re.IGNORECASE,
+    ):
+        return [{
+            "file": file_str,
+            "issue": (
+                "`## --as-tool contract` section must declare "
+                "`**Return shape:** DATA` or `**Return shape:** ARTIFACT`"
+            ),
+            "severity": "fail",
+        }]
+    return []
+
+
+def _check_contract_all_three_cases(
+    meta: dict, body: str, file_str: str,
+) -> List[dict]:
+    """Check 26 (fail): contract must document Success, NeedsMoreInfo, Refusal."""
+    if not _is_skill_invocable_true(meta):
+        return []
+    section = _extract_contract_section(body)
+    if section is None or not section.strip():
+        return []
+    missing = [
+        case for case in ("Success", "NeedsMoreInfo", "Refusal")
+        if case not in section
+    ]
+    if missing:
+        return [{
+            "file": file_str,
+            "issue": (
+                f"`## --as-tool contract` section must document all three "
+                f"envelope cases; missing: {', '.join(missing)}"
+            ),
+            "severity": "fail",
+        }]
+    return []
+
+
+def _check_contract_artifact_types(
+    meta: dict, body: str, file_str: str,
+) -> List[dict]:
+    """Check 27 (fail): ARTIFACT return shape must declare Artifact types."""
+    if not _is_skill_invocable_true(meta):
+        return []
+    section = _extract_contract_section(body)
+    if section is None or not section.strip():
+        return []
+    if not re.search(
+        r"\*\*Return shape:\*\*\s+ARTIFACT", section, flags=re.IGNORECASE,
+    ):
+        return []
+    if not re.search(r"\*\*Artifact types:\*\*\s+\S+/\S+", section):
+        return [{
+            "file": file_str,
+            "issue": (
+                "Return shape `ARTIFACT` must declare `**Artifact types:**` "
+                "with at least one MIME type (e.g., `text/x-shellscript`, "
+                "`application/json`)"
+            ),
+            "severity": "fail",
+        }]
+    return []
+
+
+def _check_contract_required_fields(
+    meta: dict, body: str, file_str: str,
+) -> List[dict]:
+    """Check 28 (warn): contract section should document Required fields."""
+    if not _is_skill_invocable_true(meta):
+        return []
+    section = _extract_contract_section(body)
+    if section is None or not section.strip():
+        return []
+    if not re.search(r"\*\*Required fields:\*\*", section, flags=re.IGNORECASE):
+        return [{
+            "file": file_str,
+            "issue": (
+                "`## --as-tool contract` section should document "
+                "`**Required fields:**` (use `none` if the skill takes no args)"
+            ),
+            "severity": "warn",
+        }]
+    return []
+
+
+def _check_contract_side_effects(
+    meta: dict, body: str, file_str: str,
+) -> List[dict]:
+    """Check 29 (warn): contract section should document Side effects."""
+    if not _is_skill_invocable_true(meta):
+        return []
+    section = _extract_contract_section(body)
+    if section is None or not section.strip():
+        return []
+    if not re.search(r"\*\*Side effects:\*\*", section, flags=re.IGNORECASE):
+        return [{
+            "file": file_str,
+            "issue": (
+                "`## --as-tool contract` section should document "
+                "`**Side effects:**` (use `none` if the skill has none)"
+            ),
+            "severity": "warn",
+        }]
+    return []
+
+
+def _check_contract_parallel_safe(
+    meta: dict, body: str, file_str: str,
+) -> List[dict]:
+    """Check 30 (warn): contract section should document Parallel-safe."""
+    if not _is_skill_invocable_true(meta):
+        return []
+    section = _extract_contract_section(body)
+    if section is None or not section.strip():
+        return []
+    if not re.search(r"\*\*Parallel-safe:\*\*", section, flags=re.IGNORECASE):
+        return [{
+            "file": file_str,
+            "issue": (
+                "`## --as-tool contract` section should document "
+                "`**Parallel-safe:**` (default `yes`; describe `no` cases)"
+            ),
+            "severity": "warn",
+        }]
+    return []
+
+
+def _check_non_invocable_pathology(meta: dict, file_str: str) -> List[dict]:
+    """Check 31 (warn): user-invocable: false + not skill-invocable is suspicious."""
+    if not _is_user_invocable_explicitly_false(meta):
+        return []
+    if _is_skill_invocable_true(meta):
+        return []
+    return [{
+        "file": file_str,
+        "issue": (
+            "skill has `user-invocable: false` and no `skill-invocable: true` "
+            "— not invocable by humans or other skills; either delete it, or "
+            "set `skill-invocable: true` to make it callable programmatically"
+        ),
+        "severity": "warn",
+    }]
+
+
 # ── SkillDocument dataclass ─────────────────────────────────────────
 
 
@@ -730,6 +968,29 @@ class SkillDocument(Document):
         result.extend(_check_embedded_scripts(self.content, self.path))
         result.extend(_check_directives(self.content, self.path))
         result.extend(_check_body_lines(self.content, self.path))
+        result.extend(_check_skill_invocable_boolean(self.meta, self.path))
+        result.extend(_check_contract_section_present(
+            self.meta, self.content, self.path,
+        ))
+        result.extend(_check_contract_return_shape_declared(
+            self.meta, self.content, self.path,
+        ))
+        result.extend(_check_contract_all_three_cases(
+            self.meta, self.content, self.path,
+        ))
+        result.extend(_check_contract_artifact_types(
+            self.meta, self.content, self.path,
+        ))
+        result.extend(_check_contract_required_fields(
+            self.meta, self.content, self.path,
+        ))
+        result.extend(_check_contract_side_effects(
+            self.meta, self.content, self.path,
+        ))
+        result.extend(_check_contract_parallel_safe(
+            self.meta, self.content, self.path,
+        ))
+        result.extend(_check_non_invocable_pathology(self.meta, self.path))
         return result
 
 

--- a/plugins/build/tests/test_skill_audit.py
+++ b/plugins/build/tests/test_skill_audit.py
@@ -784,3 +784,353 @@ class TestCheckReferenceToc:
         assert _check_reference_toc(d, "f") == []
 
 
+# ── --as-tool contract checks ───────────────────────────────────────
+
+_CONTRACT_FULL = (
+    "## `--as-tool` contract\n\n"
+    "**Required fields:**\n- `name` — who to greet\n\n"
+    "**Return shape:** DATA\n"
+    "- `Success` — `{text, name}`\n"
+    "- `NeedsMoreInfo` — `missing`, `hint`\n"
+    "- `Refusal` — `reason`, `category`\n\n"
+    "**Side effects:** none\n\n"
+    "**Parallel-safe:** yes\n"
+)
+
+_CONTRACT_ARTIFACT = (
+    "## `--as-tool` contract\n\n"
+    "**Required fields:**\n- `target` — target shell\n\n"
+    "**Return shape:** ARTIFACT\n\n"
+    "**Artifact types:** text/x-shellscript\n\n"
+    "- `Success` — envelope + bash fenced block\n"
+    "- `NeedsMoreInfo` — JSON only\n"
+    "- `Refusal` — JSON only\n\n"
+    "**Side effects:** reads reference files\n\n"
+    "**Parallel-safe:** yes\n"
+)
+
+
+class TestCheckSkillInvocableBoolean:
+    def test_absent_no_issue(self) -> None:
+        from check.skill import _check_skill_invocable_boolean
+        assert _check_skill_invocable_boolean({}, "f") == []
+
+    def test_true_boolean_no_issue(self) -> None:
+        from check.skill import _check_skill_invocable_boolean
+        assert _check_skill_invocable_boolean({"skill-invocable": True}, "f") == []
+
+    def test_false_boolean_no_issue(self) -> None:
+        from check.skill import _check_skill_invocable_boolean
+        assert _check_skill_invocable_boolean({"skill-invocable": False}, "f") == []
+
+    def test_string_true_no_issue(self) -> None:
+        from check.skill import _check_skill_invocable_boolean
+        assert _check_skill_invocable_boolean({"skill-invocable": "true"}, "f") == []
+
+    def test_non_boolean_value_warns(self) -> None:
+        from check.skill import _check_skill_invocable_boolean
+        issues = _check_skill_invocable_boolean({"skill-invocable": "maybe"}, "f")
+        assert len(issues) == 1
+        assert issues[0]["severity"] == "warn"
+        assert "boolean" in issues[0]["issue"]
+
+
+class TestCheckContractSectionPresent:
+    def test_not_opted_in_no_issue(self) -> None:
+        from check.skill import _check_contract_section_present
+        assert _check_contract_section_present({}, "body", "f") == []
+        assert _check_contract_section_present(
+            {"skill-invocable": False}, "body without contract", "f",
+        ) == []
+
+    def test_opted_in_with_contract_no_issue(self) -> None:
+        from check.skill import _check_contract_section_present
+        assert _check_contract_section_present(
+            {"skill-invocable": True}, _CONTRACT_FULL, "f",
+        ) == []
+
+    def test_opted_in_without_contract_fails(self) -> None:
+        from check.skill import _check_contract_section_present
+        issues = _check_contract_section_present(
+            {"skill-invocable": True}, "# Skill\n\n## Workflow\n\nSteps.", "f",
+        )
+        assert len(issues) == 1
+        assert issues[0]["severity"] == "fail"
+        assert "no `## --as-tool contract`" in issues[0]["issue"]
+
+    def test_opted_in_empty_contract_fails(self) -> None:
+        from check.skill import _check_contract_section_present
+        body = "## `--as-tool` contract\n\n## Next section\n"
+        issues = _check_contract_section_present(
+            {"skill-invocable": True}, body, "f",
+        )
+        assert len(issues) == 1
+        assert issues[0]["severity"] == "fail"
+
+
+class TestCheckContractReturnShapeDeclared:
+    def test_not_opted_in_no_issue(self) -> None:
+        from check.skill import _check_contract_return_shape_declared
+        assert _check_contract_return_shape_declared({}, "anything", "f") == []
+
+    def test_declared_data_no_issue(self) -> None:
+        from check.skill import _check_contract_return_shape_declared
+        assert _check_contract_return_shape_declared(
+            {"skill-invocable": True}, _CONTRACT_FULL, "f",
+        ) == []
+
+    def test_declared_artifact_no_issue(self) -> None:
+        from check.skill import _check_contract_return_shape_declared
+        assert _check_contract_return_shape_declared(
+            {"skill-invocable": True}, _CONTRACT_ARTIFACT, "f",
+        ) == []
+
+    def test_contract_without_return_shape_fails(self) -> None:
+        from check.skill import _check_contract_return_shape_declared
+        body = (
+            "## `--as-tool` contract\n\n"
+            "**Required fields:**\n- `x` — foo\n\n"
+            "- `Success` — ...\n- `NeedsMoreInfo` — ...\n- `Refusal` — ...\n"
+        )
+        issues = _check_contract_return_shape_declared(
+            {"skill-invocable": True}, body, "f",
+        )
+        assert len(issues) == 1
+        assert issues[0]["severity"] == "fail"
+        assert "Return shape" in issues[0]["issue"]
+
+
+class TestCheckContractAllThreeCases:
+    def test_not_opted_in_no_issue(self) -> None:
+        from check.skill import _check_contract_all_three_cases
+        assert _check_contract_all_three_cases({}, "anything", "f") == []
+
+    def test_all_three_present_no_issue(self) -> None:
+        from check.skill import _check_contract_all_three_cases
+        assert _check_contract_all_three_cases(
+            {"skill-invocable": True}, _CONTRACT_FULL, "f",
+        ) == []
+
+    def test_missing_needs_more_info_fails(self) -> None:
+        from check.skill import _check_contract_all_three_cases
+        body = (
+            "## `--as-tool` contract\n\n"
+            "**Return shape:** DATA\n\n"
+            "- `Success` — ok\n"
+            "- `Refusal` — nope\n"
+        )
+        issues = _check_contract_all_three_cases(
+            {"skill-invocable": True}, body, "f",
+        )
+        assert len(issues) == 1
+        assert issues[0]["severity"] == "fail"
+        assert "NeedsMoreInfo" in issues[0]["issue"]
+
+
+class TestCheckContractArtifactTypes:
+    def test_data_shape_no_issue(self) -> None:
+        from check.skill import _check_contract_artifact_types
+        assert _check_contract_artifact_types(
+            {"skill-invocable": True}, _CONTRACT_FULL, "f",
+        ) == []
+
+    def test_artifact_with_types_no_issue(self) -> None:
+        from check.skill import _check_contract_artifact_types
+        assert _check_contract_artifact_types(
+            {"skill-invocable": True}, _CONTRACT_ARTIFACT, "f",
+        ) == []
+
+    def test_artifact_without_types_fails(self) -> None:
+        from check.skill import _check_contract_artifact_types
+        body = (
+            "## `--as-tool` contract\n\n"
+            "**Return shape:** ARTIFACT\n\n"
+            "- `Success` — ...\n- `NeedsMoreInfo` — ...\n- `Refusal` — ...\n"
+        )
+        issues = _check_contract_artifact_types(
+            {"skill-invocable": True}, body, "f",
+        )
+        assert len(issues) == 1
+        assert issues[0]["severity"] == "fail"
+        assert "Artifact types" in issues[0]["issue"]
+
+
+class TestCheckContractRequiredFields:
+    def test_present_no_issue(self) -> None:
+        from check.skill import _check_contract_required_fields
+        assert _check_contract_required_fields(
+            {"skill-invocable": True}, _CONTRACT_FULL, "f",
+        ) == []
+
+    def test_missing_warns(self) -> None:
+        from check.skill import _check_contract_required_fields
+        body = (
+            "## `--as-tool` contract\n\n"
+            "**Return shape:** DATA\n\n"
+            "- `Success` — ...\n- `NeedsMoreInfo` — ...\n- `Refusal` — ...\n"
+            "**Side effects:** none\n**Parallel-safe:** yes\n"
+        )
+        issues = _check_contract_required_fields(
+            {"skill-invocable": True}, body, "f",
+        )
+        assert len(issues) == 1
+        assert issues[0]["severity"] == "warn"
+        assert "Required fields" in issues[0]["issue"]
+
+
+class TestCheckContractSideEffects:
+    def test_present_no_issue(self) -> None:
+        from check.skill import _check_contract_side_effects
+        assert _check_contract_side_effects(
+            {"skill-invocable": True}, _CONTRACT_FULL, "f",
+        ) == []
+
+    def test_missing_warns(self) -> None:
+        from check.skill import _check_contract_side_effects
+        body = (
+            "## `--as-tool` contract\n\n"
+            "**Required fields:**\n- `x` — foo\n\n"
+            "**Return shape:** DATA\n\n"
+            "- `Success` — ...\n- `NeedsMoreInfo` — ...\n- `Refusal` — ...\n"
+            "**Parallel-safe:** yes\n"
+        )
+        issues = _check_contract_side_effects(
+            {"skill-invocable": True}, body, "f",
+        )
+        assert len(issues) == 1
+        assert issues[0]["severity"] == "warn"
+        assert "Side effects" in issues[0]["issue"]
+
+
+class TestCheckContractParallelSafe:
+    def test_present_no_issue(self) -> None:
+        from check.skill import _check_contract_parallel_safe
+        assert _check_contract_parallel_safe(
+            {"skill-invocable": True}, _CONTRACT_FULL, "f",
+        ) == []
+
+    def test_missing_warns(self) -> None:
+        from check.skill import _check_contract_parallel_safe
+        body = (
+            "## `--as-tool` contract\n\n"
+            "**Required fields:**\n- `x` — foo\n\n"
+            "**Return shape:** DATA\n\n"
+            "- `Success` — ...\n- `NeedsMoreInfo` — ...\n- `Refusal` — ...\n"
+            "**Side effects:** none\n"
+        )
+        issues = _check_contract_parallel_safe(
+            {"skill-invocable": True}, body, "f",
+        )
+        assert len(issues) == 1
+        assert issues[0]["severity"] == "warn"
+        assert "Parallel-safe" in issues[0]["issue"]
+
+
+class TestCheckNonInvocablePathology:
+    def test_both_invocable_no_issue(self) -> None:
+        from check.skill import _check_non_invocable_pathology
+        assert _check_non_invocable_pathology(
+            {"user-invocable": True, "skill-invocable": True}, "f",
+        ) == []
+
+    def test_only_user_invocable_no_issue(self) -> None:
+        from check.skill import _check_non_invocable_pathology
+        assert _check_non_invocable_pathology({"user-invocable": True}, "f") == []
+
+    def test_only_skill_invocable_no_issue(self) -> None:
+        from check.skill import _check_non_invocable_pathology
+        assert _check_non_invocable_pathology(
+            {"user-invocable": False, "skill-invocable": True}, "f",
+        ) == []
+
+    def test_pathology_warns(self) -> None:
+        from check.skill import _check_non_invocable_pathology
+        issues = _check_non_invocable_pathology({"user-invocable": False}, "f")
+        assert len(issues) == 1
+        assert issues[0]["severity"] == "warn"
+        assert "not invocable" in issues[0]["issue"]
+
+    def test_both_false_warns(self) -> None:
+        from check.skill import _check_non_invocable_pathology
+        issues = _check_non_invocable_pathology(
+            {"user-invocable": False, "skill-invocable": False}, "f",
+        )
+        assert len(issues) == 1
+        assert issues[0]["severity"] == "warn"
+
+
+class TestAsToolFullFixtures:
+    """End-to-end fixtures: parse a SKILL.md and confirm issues()."""
+
+    def _make_skill(
+        self, tmp_path: Path, frontmatter: str, body: str,
+    ) -> Path:
+        d = tmp_path / "example"
+        d.mkdir()
+        (d / "SKILL.md").write_text(f"---\n{frontmatter}\n---\n\n{body}")
+        return d
+
+    def _as_tool_issues(self, issues: list) -> list:
+        keywords = (
+            "--as-tool", "skill-invocable", "contract", "Parallel-safe",
+            "Side effects", "Required fields", "Return shape",
+            "Artifact types", "NeedsMoreInfo",
+        )
+        return [
+            i for i in issues
+            if any(kw in i["issue"] for kw in keywords)
+        ]
+
+    def test_opt_out_skill_no_new_findings(self, tmp_path: Path) -> None:
+        from check.skill import check_skill_meta
+        fm = (
+            "name: example\n"
+            "description: A human-only skill. Triggers on 'do thing'.\n"
+            "user-invocable: true\n"
+        )
+        body = "# Example\n\n## Workflow\n\n1. Do the thing.\n"
+        d = self._make_skill(tmp_path, fm, body)
+        issues = check_skill_meta(d)
+        as_tool = self._as_tool_issues(issues)
+        assert as_tool == [], (
+            f"opt-out skill should produce no --as-tool findings; got: {as_tool}"
+        )
+
+    def test_data_opted_in_complete_no_new_fails(self, tmp_path: Path) -> None:
+        from check.skill import check_skill_meta
+        fm = (
+            "name: greet\n"
+            "description: Greets a person by name. Triggers on 'hello', 'greet'.\n"
+            "user-invocable: true\n"
+            "skill-invocable: true\n"
+        )
+        body = "# Greet\n\n## Workflow\n\n1. Compose greeting.\n\n" + _CONTRACT_FULL
+        d = self._make_skill(tmp_path, fm, body)
+        issues = check_skill_meta(d)
+        fails = [i for i in self._as_tool_issues(issues) if i["severity"] == "fail"]
+        assert fails == [], (
+            f"complete DATA skill should have no --as-tool fails; got: {fails}"
+        )
+
+    def test_artifact_opted_in_complete_no_new_fails(
+        self, tmp_path: Path,
+    ) -> None:
+        from check.skill import check_skill_meta
+        fm = (
+            "name: build-thing\n"
+            "description: Builds a shell script. Triggers on 'build a shell script'.\n"
+            "user-invocable: true\n"
+            "skill-invocable: true\n"
+        )
+        body = (
+            "# Build Thing\n\n## Workflow\n\n1. Emit a shell script.\n\n"
+            + _CONTRACT_ARTIFACT
+        )
+        d = self._make_skill(tmp_path, fm, body)
+        issues = check_skill_meta(d)
+        fails = [i for i in self._as_tool_issues(issues) if i["severity"] == "fail"]
+        assert fails == [], (
+            f"complete ARTIFACT skill should have no --as-tool fails; got: {fails}"
+        )
+
+


### PR DESCRIPTION
## Summary

Teaches `/build:build-skill` and `/build:check-skill` to treat the `--as-tool` dual-invocation pattern as a first-class skill shape. Pattern is **opt-in** via the new `skill-invocable: true` frontmatter field (parallels `user-invocable`); absent = human-only default.

- **New shared reference** `plugins/build/_shared/references/as-tool-contract.md` — skill-agnostic mechanism spec documenting the `$ARGUMENTS` parsing rule, step skip/run semantics, three-case envelope (`Success` / `NeedsMoreInfo` / `Refusal`), and two return shapes: **DATA** (JSON only) and **ARTIFACT** (JSON envelope + one-or-more fenced code blocks with `artifact_types` declared in envelope; language tag per MIME).
- **`/build:build-skill`** — two-level intake (opt-in y/N → if y, DATA vs ARTIFACT + artifact-type list). Scaffolding recipe extracted to `references/as-tool-scaffolding.md` (loaded only when opted in).
- **`/build:check-skill`** — 9 new checks (23–31):
  - Fail: `skill-invocable: true` without contract section; missing Return shape declaration; missing any of the three envelope cases; ARTIFACT without `Artifact types:` line.
  - Warn: `skill-invocable` non-boolean; missing Required fields/Side effects/Parallel-safe subsections; non-invocable pathology (`user-invocable: false` + not `skill-invocable: true`).
  - Opt-out skills (absent `skill-invocable` or explicitly false) skip checks 24–30 entirely — no migration burden on the existing 41 skills.
- Python static checks live in `plugins/build/src/check/skill.py` (9 new `_check_*` functions) with pass/fail pytest fixtures (59 new tests; 131 total, all pass).
- Build plugin bumps to **0.5.0** (minor — behavioral change + new feature).

Downstream consumer: [#327](https://github.com/bcbeidel/toolkit/issues/327) hook/shell refactor. Design doc: `.designs/2026-04-20-build-check-skill-as-tool-support.design.md` (in-repo; gitignored but committed on branch). Plan: `.plans/2026-04-20-build-check-skill-as-tool-support.plan.md`.

## Test plan

- [x] `python3 -m pytest plugins/build/tests/test_skill_audit.py` — 131 tests pass.
- [x] `python3 plugins/wiki/scripts/lint.py --root . --no-urls` — clean; zero new fail findings across the 41 existing skills (confirms opt-in posture holds).
- [ ] In a fresh session, run `/build:build-skill` and answer "no" to the opt-in question — confirm scaffolded SKILL.md has no new content.
- [ ] Run `/build:build-skill` and answer "yes → DATA" — confirm scaffolded SKILL.md has `skill-invocable: true`, contract section with `**Return shape:** DATA`, three envelope cases.
- [ ] Run `/build:build-skill` and answer "yes → ARTIFACT, types: text/x-shellscript" — confirm scaffolded SKILL.md has `**Return shape:** ARTIFACT` and `**Artifact types:** text/x-shellscript`.
- [ ] Dummy plugin smoke test: `/dummy:greet --as-tool name=bob time-of-day=morning` still returns `Success` JSON (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)