### PR TITLE
feat(build): hook/shell --as-tool delegation (build-0.6.0)

### DIFF
--- a/.designs/2026-04-20-hook-shell-as-tool-delegation.design.md
+++ b/.designs/2026-04-20-hook-shell-as-tool-delegation.design.md
@@ -1,0 +1,190 @@
+---
+name: Hook/Shell `--as-tool` Delegation
+description: Refactor build-hook and check-hook to delegate shell-script concerns to build-shell and check-shell via the --as-tool invocation pattern; opt all four skills into skill-invocable mode.
+type: design
+status: draft
+related:
+  - plugins/build/_shared/references/as-tool-contract.md
+  - plugins/build/skills/build-skill/references/as-tool-scaffolding.md
+  - plugins/dummy/skills/greet/SKILL.md
+---
+
+# Hook/Shell `--as-tool` Delegation
+
+## Purpose
+
+The hook pair (`build-hook`, `check-hook`) currently carries its own shell scaffolding template and its own shell-hygiene lints. The shell pair (`build-shell`, `check-shell`) already owns the authoritative version of both. This design routes the overlap through the `--as-tool` invocation contract that shipped in build-0.5.0 (PR #335): shell concerns are generated and audited once by the shell pair, and the hook pair calls into them.
+
+**Why now.** The `--as-tool` pattern is settled and empirically validated (issue #327 closed the probe via the `dummy` plugin, PR #334). The hook/shell boundary is the first real consumer — forcing the pattern's first multi-artifact caller and its first caller-of-caller delegation.
+
+**Closes #327.**
+
+## Non-goals
+
+- Re-litigating any aspect of the `--as-tool` contract (parsing rule, envelope shapes, emission rules). The shared spec is authoritative.
+- Migrating any other skill to opt into `--as-tool`.
+- Touching the `dummy` plugin.
+- Changing unrelated `build` skills (`build-skill`, `build-rule`, `build-subagent`, `refine-prompt`, and their `check-*` peers).
+
+## In scope
+
+Four skills change. One lint catalog gains one entry. One plugin version bumps.
+
+### Surface changes per skill
+
+**`build-shell`** — opts into `skill-invocable: true`; adds a `## --as-tool contract` section; splits its final workflow step into human and `--as-tool` branches. Return shape: **ARTIFACT** (`text/x-shellscript`). FX.1 scope-gate refusals return structured `Refusal` under `--as-tool` instead of halting.
+
+**`check-shell`** — opts into `skill-invocable: true`; adds a `## --as-tool contract` section; splits Report step into human (table + preamble) and `--as-tool` (DATA envelope) branches. Return shape: **DATA**. Adds lint **S11: missing strict-mode preamble (warn)** to close a delegation gap.
+
+**`build-hook`** — opts into `skill-invocable: true`; adds a `## --as-tool contract` section; Draft step becomes a caller: derives `build-shell` intake from the hook's context, invokes `/build:build-shell --as-tool`, layers hook-specific content onto the returned scaffold, and emits a MULTI-ARTIFACT Success with two fenced blocks (the hook script and the settings.json entry). Return shape: **ARTIFACT** (`text/x-shellscript, application/json`).
+
+**`check-hook`** — opts into `skill-invocable: true`; adds a `## --as-tool contract` section; Checks step becomes a caller: for each `"type": "command"` hook script, invokes `/build:check-shell --as-tool` and merges its findings with the retained hook-specific checks. Removes delegated checks (full removal of 14; partial removal of 11, 12, 15). Return shape: **DATA**.
+
+## Required fields per skill (under `--as-tool`)
+
+| Skill | Required fields | Notes |
+|---|---|---|
+| `build-shell` | `target-shell`, `purpose`, `invocation-style`, `setuid`, `deps` | `save-path` stays human-mode-only; `--as-tool` callers own the Save step. |
+| `check-shell` | `path` | Script path only; tool detection and target inference run internally. |
+| `build-hook` | `hook-event`, `handler-type`, `enforcement-goal`, `matcher` | `matcher` always required; callers pass `"*"` for non-tool events. Inner `build-shell` call is pinned to `target-shell=bash-3.2-portable`. |
+| `check-hook` | `settings-path` | Path to `.claude/settings.json` or equivalent; no default under `--as-tool` (human mode retains the dual-path default). |
+
+Missing required fields hard-fail with `NeedsMoreInfo`.
+
+## Return envelopes
+
+### `build-shell` (ARTIFACT)
+
+```
+{"type": "Success", "artifact_types": ["text/x-shellscript"], "metadata": {"target_shell": "bash-3.2-portable", "invocation_style": "cli"}}
+```
+```bash
+#!/usr/bin/env bash
+# ... scaffold ...
+```
+
+Scope-gate refusal (FX.1 signal fired) returns `Refusal` with `category: "scope-gate"`; retryable only when the caller changes the inputs that tripped the signal.
+
+### `check-shell` (DATA)
+
+```json
+{"type": "Success", "value": {
+  "path": "scripts/foo.sh",
+  "target_shell": "bash-3.2-portable",
+  "summary": {"fail": 2, "warn": 3, "total": 5},
+  "findings": [
+    {"group": "Safety", "lint": "S1", "severity": "fail", "line": 57, "message": "..."},
+    {"group": "Documentation", "lint": "D1", "severity": "warn", "line": null, "message": "..."}
+  ],
+  "external_tools": {
+    "shellcheck":     {"present": true,  "output": "..."},
+    "shfmt":          {"present": false, "install_hint": "..."},
+    "checkbashisms":  {"present": false, "install_hint": "..."}
+  }
+}}
+```
+
+Severity ∈ `{fail, warn}`; identical to the human-mode catalog. External-tool output is raw per-tool so the caller can surface it verbatim. `line` is nullable for file-level findings.
+
+### `build-hook` (MULTI-ARTIFACT)
+
+```
+{"type": "Success", "artifact_types": ["text/x-shellscript", "application/json"], "metadata": {"hook_event": "PreToolUse", "matcher": "Bash", "handler_type": "command"}}
+```
+```bash
+#!/usr/bin/env bash
+# ... hook script (inner build-shell scaffold + hook-specific injections) ...
+```
+```json
+{"hooks": {"PreToolUse": [{"matcher": "Bash", "hooks": [{"type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/<name>.sh", "timeout": 60}]}]}}
+```
+
+`metadata` carries exactly three keys: `hook_event`, `matcher`, `handler_type`. Everything else the caller needs is in the settings.json block.
+
+### `check-hook` (DATA)
+
+```json
+{"type": "Success", "value": {
+  "settings_path": ".claude/settings.json",
+  "summary": {"fail": 1, "warn": 4, "total": 5},
+  "findings": [
+    {"source": "check-hook", "check": "4", "severity": "fail", "event": "Stop", "hook": ".claude/hooks/stop.sh", "message": "..."},
+    {"source": "check-shell", "lint": "S1", "severity": "fail", "hook": ".claude/hooks/gate.sh", "line": 12, "message": "..."}
+  ]
+}}
+```
+
+Findings merge hook-retained checks with `check-shell` output per script. `source` field identifies which skill authored each finding so the reader can trace ownership.
+
+## Delegation boundary (`check-hook` Option X)
+
+**Delegated to `check-shell` (fully removed from `check-hook`):**
+- Check 14 (ShellCheck / shfmt)
+- Check 11 (strict-mode preamble + `|| true` guards)
+- Check 15 (script style: stderr, `[[` vs `[`, `set -x`, shebang form)
+- Check 12's unquoted-variable portion (maps to `check-shell` S1)
+
+**Retained in `check-hook` (hook-specific semantics):**
+- 1 PreToolUse gap
+- 2 Destructive operations (`rm -rf`, `git push --force`, etc.)
+- 3 Async + blocking contradiction
+- 4 Stop hook loop risk
+- 5 `INPUT=$(cat)` and executable bit
+- 6 Tool-name case + `$HOME`/`~` path expansion
+- 7 PostToolUse enforcement intent
+- 8 Rule overlap vs. CLAUDE.md
+- 9 Idempotency (hook-frequency-sensitive)
+- 10 Latency risk
+- 12 (eval-on-payload portion only)
+- 13 `jq` availability + `tool_input` field-path correctness
+- 16 settings.json attack surface
+
+Shell-hygiene findings surface under `source: "check-shell"`; hook-specific findings under `source: "check-hook"`. Single ownership per lint — no duplication, no "amplifier" framing.
+
+## New lint: `check-shell` S11
+
+Category: Safety. Severity: warn.
+
+**S11. Missing strict-mode preamble.** Script does not begin (after the shebang and header) with `set -Eeuo pipefail` (bash) or `set -eu` (posix-sh). Without strict mode, commands that exit non-zero proceed silently and unset-variable dereferences expand to empty strings, producing actions on wrong inputs. Fix: add the appropriate strict-mode line near the top of the script. The `check-shell` scaffold template already emits it; S11 catches hand-rolled or legacy scripts that skipped it.
+
+This lint closes the delegation gap: `check-hook` check 11 had this as part of its preamble audit; without an equivalent in `check-shell`, full delegation would lose coverage.
+
+## Parallel-safety
+
+- `build-shell`, `build-hook`: **parallel-safe** (pure computation; Save is skipped under `--as-tool`).
+- `check-shell`: **parallel-safe** (read-only file inspection; no shared state).
+- `check-hook`: **not parallel-safe when invoked with overlapping `settings-path` values** — multiple concurrent calls against the same settings file produce redundant work but no correctness issue; document as "safe, but redundant" rather than serialize.
+
+## Plugin version bump
+
+`plugins/build` 0.5.0 → **0.6.0**. Minor bump — behavioral change to four existing skills, no breaking change to the human-mode invocation surface.
+
+Updates: `plugins/build/.claude-plugin/plugin.json`, `plugins/build/pyproject.toml`.
+
+## Acceptance criteria
+
+1. All four skills declare `skill-invocable: true` and carry a conforming `## --as-tool contract` section.
+2. `/build:check-skill --as-tool` passes checks 23-31 on all four SKILL.md files.
+3. `build-shell --as-tool target-shell=bash-3.2-portable purpose="demo" invocation-style=cli setuid=no deps=jq,curl` emits a valid ARTIFACT envelope + one `bash` fenced block.
+4. `check-shell --as-tool path=<script>` emits a DATA envelope matching the schema above.
+5. `build-hook --as-tool hook-event=PreToolUse handler-type=command enforcement-goal="block rm -rf" matcher=Bash` emits a valid MULTI-ARTIFACT envelope + `bash` and `json` fenced blocks in that order.
+6. `check-hook --as-tool settings-path=.claude/settings.json` emits a DATA envelope merging `check-shell` and `check-hook` findings, labeled by `source`.
+7. `check-shell` human-mode report surfaces S11 as a warn when the preamble is missing.
+8. `check-hook` no longer runs delegated checks in its own scan; those findings appear only via the inner `check-shell` call.
+9. Plugin version at `0.6.0` in both manifests.
+10. Superseded plan `.plans/2026-04-19-hook-shell-structured-invocation.plan.md` referenced in the new plan's history as pre-refinement (branch `explore/327-structured-invocation-thinking`).
+
+## Constraints
+
+- No changes to the shared `--as-tool` contract file; this design consumes the contract as-is.
+- No auto-patching of `settings.json` in either mode — `build-hook` emits the settings block but the write step stays with the user (human) or caller (`--as-tool`).
+- `build-hook`'s inner `build-shell` invocation pins `target-shell=bash-3.2-portable`. A future revision may expose this as a caller-supplied field; out of scope here.
+- `check-hook` S11 passes through from `check-shell` under `source: "check-shell"` — do not re-surface it as a native `check-hook` finding.
+
+## Open questions
+
+None. All four surfaced decisions settled during scoping:
+1. Required fields per skill → five/one/four/one (A, A, B, single-field).
+2. Multi-artifact metadata → three keys only (A).
+3. `check-shell` findings schema → flat, two-tier severity (A).
+4. Delegation boundary → full delegation on overlap, add S11 (X).

--- a/.plans/2026-04-20-hook-shell-as-tool-delegation.plan.md
+++ b/.plans/2026-04-20-hook-shell-as-tool-delegation.plan.md
@@ -92,38 +92,44 @@ No files created. No files deleted. No Python source changes.
 **Files:**
 - Modify: `plugins/build/skills/build-shell/SKILL.md`
 
-- [ ] **Step 1:** Add `skill-invocable: true` to frontmatter. Add `../../_shared/references/as-tool-contract.md` to `references:`.
-- [ ] **Step 2:** Insert two-modes intro paragraph immediately after the H1/one-line purpose, per `as-tool-scaffolding.md`: "Two invocation modes: Human — prompts for missing info, shows the result, asks for approval. `--as-tool` — structured emission per the shared contract. No prompts, no approval."
-- [ ] **Step 3:** Add `## --as-tool contract` H2 near the end of the body (before `## Anti-Pattern Guards`). Populate subsections: **Required fields:** `target-shell`, `purpose`, `invocation-style`, `setuid`, `deps` (one-line description each); **Return shape:** ARTIFACT; **Artifact types:** `text/x-shellscript`; three bullets for Success (metadata shape + one fenced ```bash block carries the scaffold), NeedsMoreInfo (JSON only; `missing`, `hint`), Refusal (JSON only; `reason`, `category`; enumerate categories: `scope-gate`, `invalid-combo`); **Side effects:** reads intake; no file writes under `--as-tool`; **Parallel-safe:** yes.
-- [ ] **Step 4:** Modify §2 FX.1 Scope Gate: add a sub-note that under `--as-tool`, a tripped signal returns a structured `Refusal` (category `scope-gate`, reason citing the signal) instead of halting interactively.
-- [ ] **Step 5:** Split §6 Review Gate → §6a Human (current prose) and §6b `--as-tool` ("skipped; caller owns approval"). Same for §7 Save → §7a Human / §7b `--as-tool` (emission: output the JSON envelope with `artifact_types: ["text/x-shellscript"]` and `metadata: {target_shell, invocation_style}`, followed by one fenced ```bash block carrying the scaffold). Same for §8 Test → §8a/8b ("skipped under `--as-tool`").
-- [ ] **Step 6:** Add three Key Instructions entries per the scaffolding recipe: (a) under `--as-tool` emit per the contract (JSON envelope + one fenced ```bash block); (b) hard-fail with `NeedsMoreInfo` when any required field is missing; (c) `NeedsMoreInfo` and `Refusal` emit JSON only, never fenced blocks.
-- [ ] **Step 7:** Verify: `grep -c "skill-invocable: true" plugins/build/skills/build-shell/SKILL.md` returns 1; `grep -c "^## --as-tool contract" plugins/build/skills/build-shell/SKILL.md` returns 1; `grep -c "Required fields\|Return shape\|Artifact types\|Side effects\|Parallel-safe" plugins/build/skills/build-shell/SKILL.md` returns ≥ 5.
-- [ ] **Step 8:** Commit: `feat(build-shell): opt into --as-tool as ARTIFACT provider (text/x-shellscript)`.
+- [x] Task 1 complete <!-- sha:4d91093 -->
+
+- [x] **Step 1:** Add `skill-invocable: true` to frontmatter. Add `../../_shared/references/as-tool-contract.md` to `references:`.
+- [x] **Step 2:** Insert two-modes intro paragraph immediately after the H1/one-line purpose, per `as-tool-scaffolding.md`: "Two invocation modes: Human — prompts for missing info, shows the result, asks for approval. `--as-tool` — structured emission per the shared contract. No prompts, no approval."
+- [x] **Step 3:** Add `## --as-tool contract` H2 near the end of the body (before `## Anti-Pattern Guards`). Populate subsections: **Required fields:** `target-shell`, `purpose`, `invocation-style`, `setuid`, `deps` (one-line description each); **Return shape:** ARTIFACT; **Artifact types:** `text/x-shellscript`; three bullets for Success (metadata shape + one fenced ```bash block carries the scaffold), NeedsMoreInfo (JSON only; `missing`, `hint`), Refusal (JSON only; `reason`, `category`; enumerate categories: `scope-gate`, `invalid-combo`); **Side effects:** reads intake; no file writes under `--as-tool`; **Parallel-safe:** yes.
+- [x] **Step 4:** Modify §2 FX.1 Scope Gate: add a sub-note that under `--as-tool`, a tripped signal returns a structured `Refusal` (category `scope-gate`, reason citing the signal) instead of halting interactively.
+- [x] **Step 5:** Split §6 Review Gate → §6a Human (current prose) and §6b `--as-tool` ("skipped; caller owns approval"). Same for §7 Save → §7a Human / §7b `--as-tool` (emission: output the JSON envelope with `artifact_types: ["text/x-shellscript"]` and `metadata: {target_shell, invocation_style}`, followed by one fenced ```bash block carrying the scaffold). Same for §8 Test → §8a/8b ("skipped under `--as-tool`").
+- [x] **Step 6:** Add three Key Instructions entries per the scaffolding recipe: (a) under `--as-tool` emit per the contract (JSON envelope + one fenced ```bash block); (b) hard-fail with `NeedsMoreInfo` when any required field is missing; (c) `NeedsMoreInfo` and `Refusal` emit JSON only, never fenced blocks.
+- [x] **Step 7:** Verify: `grep -c "skill-invocable: true" plugins/build/skills/build-shell/SKILL.md` returns 1; `grep -c "^## --as-tool contract" plugins/build/skills/build-shell/SKILL.md` returns 1; `grep -c "Required fields\|Return shape\|Artifact types\|Side effects\|Parallel-safe" plugins/build/skills/build-shell/SKILL.md` returns ≥ 5.
+- [x] **Step 8:** Commit: `feat(build-shell): opt into --as-tool as ARTIFACT provider (text/x-shellscript)`.
 
 #### Task 2: Opt `check-shell` into `--as-tool` and add S11 lint
 
 **Files:**
 - Modify: `plugins/build/skills/check-shell/SKILL.md`
 
-- [ ] **Step 1:** Add `skill-invocable: true` to frontmatter. Add `../../_shared/references/as-tool-contract.md` to `references:`.
-- [ ] **Step 2:** Insert two-modes intro paragraph after the H1/purpose.
-- [ ] **Step 3:** Add new lint **S11: Missing strict-mode preamble (warn)** under §4 Checks → Safety subsection (after S10). Body per design: "Script does not begin (after the shebang and header) with `set -Eeuo pipefail` (bash) or `set -eu` (posix-sh). Without strict mode, commands that exit non-zero proceed silently and unset-variable dereferences expand to empty strings, producing actions on wrong inputs. Fix: add the appropriate strict-mode line near the top of the script."
-- [ ] **Step 4:** Split §5 Report into §5a Human (current table + Missing Tools preamble prose) and §5b `--as-tool` (emit a single JSON envelope — no fenced blocks — per the DATA schema in the design: `{type: "Success", value: {path, target_shell, summary, findings: [...], external_tools: {...}}}`, with severity ∈ `{fail, warn}`, line nullable for file-level findings, `external_tools` keyed per tool with `present`/`output`/`install_hint`).
-- [ ] **Step 5:** Add `## --as-tool contract` H2 before `## Anti-Pattern Guards`: **Required fields:** `path`; **Return shape:** DATA; three bullets (Success with `value` schema; NeedsMoreInfo; Refusal — category examples: `file-not-found`, `not-a-shell-script`); **Side effects:** reads the script at `path`, probes `PATH` for `shellcheck`/`shfmt`/`checkbashisms`, runs whichever are present; **Parallel-safe:** yes.
-- [ ] **Step 6:** Add three Key Instructions entries per the scaffolding recipe (DATA variant).
-- [ ] **Step 7:** Verify: `grep -c "skill-invocable: true" plugins/build/skills/check-shell/SKILL.md` returns 1; `grep -c "^## --as-tool contract" plugins/build/skills/check-shell/SKILL.md` returns 1; `grep -c "S11\." plugins/build/skills/check-shell/SKILL.md` returns ≥ 1; `grep "strict-mode preamble" plugins/build/skills/check-shell/SKILL.md` non-empty.
-- [ ] **Step 8:** Commit: `feat(check-shell): opt into --as-tool as DATA provider; add S11 strict-mode preamble lint`.
+- [x] Task 2 complete <!-- sha:cf7cbbe -->
+
+- [x] **Step 1:** Add `skill-invocable: true` to frontmatter. Add `../../_shared/references/as-tool-contract.md` to `references:`.
+- [x] **Step 2:** Insert two-modes intro paragraph after the H1/purpose.
+- [x] **Step 3:** Add new lint **S11: Missing strict-mode preamble (warn)** under §4 Checks → Safety subsection (after S10). Body per design: "Script does not begin (after the shebang and header) with `set -Eeuo pipefail` (bash) or `set -eu` (posix-sh). Without strict mode, commands that exit non-zero proceed silently and unset-variable dereferences expand to empty strings, producing actions on wrong inputs. Fix: add the appropriate strict-mode line near the top of the script."
+- [x] **Step 4:** Split §5 Report into §5a Human (current table + Missing Tools preamble prose) and §5b `--as-tool` (emit a single JSON envelope — no fenced blocks — per the DATA schema in the design: `{type: "Success", value: {path, target_shell, summary, findings: [...], external_tools: {...}}}`, with severity ∈ `{fail, warn}`, line nullable for file-level findings, `external_tools` keyed per tool with `present`/`output`/`install_hint`).
+- [x] **Step 5:** Add `## --as-tool contract` H2 before `## Anti-Pattern Guards`: **Required fields:** `path`; **Return shape:** DATA; three bullets (Success with `value` schema; NeedsMoreInfo; Refusal — category examples: `file-not-found`, `not-a-shell-script`); **Side effects:** reads the script at `path`, probes `PATH` for `shellcheck`/`shfmt`/`checkbashisms`, runs whichever are present; **Parallel-safe:** yes.
+- [x] **Step 6:** Add three Key Instructions entries per the scaffolding recipe (DATA variant).
+- [x] **Step 7:** Verify: `grep -c "skill-invocable: true" plugins/build/skills/check-shell/SKILL.md` returns 1; `grep -c "^## --as-tool contract" plugins/build/skills/check-shell/SKILL.md` returns 1; `grep -c "S11\." plugins/build/skills/check-shell/SKILL.md` returns ≥ 1; `grep "strict-mode preamble" plugins/build/skills/check-shell/SKILL.md` non-empty.
+- [x] **Step 8:** Commit: `feat(check-shell): opt into --as-tool as DATA provider; add S11 strict-mode preamble lint`.
 
 #### Task 3: Self-audit Chunk 1 SKILL.md files
 
 **Depends on:** Task 1, Task 2
 
-- [ ] **Step 1:** Invoke `/build:check-skill --as-tool path=plugins/build/skills/build-shell/SKILL.md` and confirm zero fail-level findings on checks 23-31.
-- [ ] **Step 2:** Invoke `/build:check-skill --as-tool path=plugins/build/skills/check-shell/SKILL.md` and confirm zero fail-level findings on checks 23-31.
-- [ ] **Step 3:** If fails: fix in place. Re-audit. If warnings are acceptable (pre-existing or explicit), document in Notes.
-- [ ] **Step 4:** Verify: the two `/build:check-skill` invocations each show 0 fail findings on 23-31.
-- [ ] **Step 5:** Commit (only if fixes needed): `fix(build): resolve check-skill findings on build-shell/check-shell opt-in`.
+- [x] Task 3 complete <!-- sha:72f7e55 -->
+
+- [x] **Step 1:** Invoke `/build:check-skill --as-tool path=plugins/build/skills/build-shell/SKILL.md` and confirm zero fail-level findings on checks 23-31.
+- [x] **Step 2:** Invoke `/build:check-skill --as-tool path=plugins/build/skills/check-shell/SKILL.md` and confirm zero fail-level findings on checks 23-31.
+- [x] **Step 3:** If fails: fix in place. Re-audit. If warnings are acceptable (pre-existing or explicit), document in Notes.
+- [x] **Step 4:** Verify: the two `/build:check-skill` invocations each show 0 fail findings on 23-31.
+- [x] **Step 5:** Commit (only if fixes needed): `fix(build): resolve check-skill findings on build-shell/check-shell opt-in`.
 
 ### Chunk 2: build-hook Draft step refactor
 
@@ -134,25 +140,29 @@ No files created. No files deleted. No Python source changes.
 
 **Depends on:** Task 1 (inner `build-shell --as-tool` must exist).
 
-- [ ] **Step 1:** Add `skill-invocable: true` to frontmatter. Add `../../_shared/references/as-tool-contract.md` to `references:`.
-- [ ] **Step 2:** Insert two-modes intro paragraph after the H1/purpose.
-- [ ] **Step 3:** Refactor §3 Draft:
+- [x] Task 4 complete <!-- sha:846da0e -->
+
+- [x] **Step 1:** Add `skill-invocable: true` to frontmatter. Add `../../_shared/references/as-tool-contract.md` to `references:`.
+- [x] **Step 2:** Insert two-modes intro paragraph after the H1/purpose.
+- [x] **Step 3:** Refactor §3 Draft:
   - Artifact 1 (hook script): under human mode, retain current scaffold. Under both modes, the scaffold is now generated by invoking `/build:build-shell --as-tool target-shell=bash-3.2-portable purpose="<derived from enforcement-goal>" invocation-style=glue setuid=no deps=jq`; receive the ARTIFACT envelope + fenced ```bash block; layer hook-specific content onto it: `INPUT=$(cat)` near the top, `jq -r '.tool_input.<field>'` extraction per `tool_name` (table preserved), optional ERR/EXIT traps, `updatedInput` JSON output contract (preserved), tool-name case/matcher handling.
   - Artifact 2 (settings.json entry): unchanged generation; emitted as a fenced ```json block under `--as-tool`.
   - Document that a `NeedsMoreInfo` or `Refusal` from the inner `build-shell` invocation propagates up as the outer skill's own envelope.
-- [ ] **Step 4:** Split §7 Review Gate → §7a Human / §7b `--as-tool` ("skipped; caller owns approval"). §8 Save → §8a Human (retain current: write script, chmod +x, show settings snippet) / §8b `--as-tool` (skipped; emit MULTI-ARTIFACT Success with `artifact_types: ["text/x-shellscript", "application/json"]` and `metadata: {hook_event, matcher, handler_type}`, then the two fenced blocks in declared order: ```bash hook script first, ```json settings entry second). §9 Test → §9a/9b.
-- [ ] **Step 5:** Add `## --as-tool contract` H2 before `## Anti-Pattern Guards`: **Required fields:** `hook-event`, `handler-type`, `enforcement-goal`, `matcher` (note: pass `"*"` for non-tool events); **Return shape:** ARTIFACT; **Artifact types:** `text/x-shellscript, application/json`; three bullets (Success with metadata = 3 keys and two fenced blocks; NeedsMoreInfo; Refusal — categories: `wrong-primitive`, `inner-refusal`); **Side effects:** invokes `/build:build-shell --as-tool` with pinned `target-shell=bash-3.2-portable`; **Parallel-safe:** yes.
-- [ ] **Step 6:** Add three Key Instructions entries per the scaffolding recipe (ARTIFACT variant).
-- [ ] **Step 7:** Verify: `grep -c "skill-invocable: true" plugins/build/skills/build-hook/SKILL.md` returns 1; `grep -c "^## --as-tool contract" plugins/build/skills/build-hook/SKILL.md` returns 1; `grep -c "/build:build-shell --as-tool" plugins/build/skills/build-hook/SKILL.md` returns ≥ 1; `grep -c "text/x-shellscript.*application/json\|application/json.*text/x-shellscript" plugins/build/skills/build-hook/SKILL.md` returns ≥ 1.
-- [ ] **Step 8:** Commit: `feat(build-hook): opt into --as-tool as MULTI-ARTIFACT provider; delegate scaffold to build-shell`.
+- [x] **Step 4:** Split §7 Review Gate → §7a Human / §7b `--as-tool` ("skipped; caller owns approval"). §8 Save → §8a Human (retain current: write script, chmod +x, show settings snippet) / §8b `--as-tool` (skipped; emit MULTI-ARTIFACT Success with `artifact_types: ["text/x-shellscript", "application/json"]` and `metadata: {hook_event, matcher, handler_type}`, then the two fenced blocks in declared order: ```bash hook script first, ```json settings entry second). §9 Test → §9a/9b.
+- [x] **Step 5:** Add `## --as-tool contract` H2 before `## Anti-Pattern Guards`: **Required fields:** `hook-event`, `handler-type`, `enforcement-goal`, `matcher` (note: pass `"*"` for non-tool events); **Return shape:** ARTIFACT; **Artifact types:** `text/x-shellscript, application/json`; three bullets (Success with metadata = 3 keys and two fenced blocks; NeedsMoreInfo; Refusal — categories: `wrong-primitive`, `inner-refusal`); **Side effects:** invokes `/build:build-shell --as-tool` with pinned `target-shell=bash-3.2-portable`; **Parallel-safe:** yes.
+- [x] **Step 6:** Add three Key Instructions entries per the scaffolding recipe (ARTIFACT variant).
+- [x] **Step 7:** Verify: `grep -c "skill-invocable: true" plugins/build/skills/build-hook/SKILL.md` returns 1; `grep -c "^## --as-tool contract" plugins/build/skills/build-hook/SKILL.md` returns 1; `grep -c "/build:build-shell --as-tool" plugins/build/skills/build-hook/SKILL.md` returns ≥ 1; `grep -c "text/x-shellscript.*application/json\|application/json.*text/x-shellscript" plugins/build/skills/build-hook/SKILL.md` returns ≥ 1.
+- [x] **Step 8:** Commit: `feat(build-hook): opt into --as-tool as MULTI-ARTIFACT provider; delegate scaffold to build-shell`.
 
 #### Task 5: Self-audit `build-hook` SKILL.md
 
 **Depends on:** Task 4
 
-- [ ] **Step 1:** Invoke `/build:check-skill --as-tool path=plugins/build/skills/build-hook/SKILL.md`; confirm zero fail findings on checks 23-31.
-- [ ] **Step 2:** If fails: fix in place. Re-audit.
-- [ ] **Step 3:** Commit (only if fixes): `fix(build-hook): resolve check-skill findings on --as-tool opt-in`.
+- [x] Task 5 complete <!-- sha:846da0e verified — 0 fail, 2 pre-existing warn -->
+
+- [x] **Step 1:** Invoke `/build:check-skill --as-tool path=plugins/build/skills/build-hook/SKILL.md`; confirm zero fail findings on checks 23-31.
+- [x] **Step 2:** If fails: fix in place. Re-audit.
+- [x] **Step 3:** Commit (only if fixes): `fix(build-hook): resolve check-skill findings on --as-tool opt-in`.
 
 ### Chunk 3: check-hook Checks step refactor
 
@@ -163,26 +173,30 @@ No files created. No files deleted. No Python source changes.
 
 **Depends on:** Task 2 (inner `check-shell --as-tool` must exist).
 
-- [ ] **Step 1:** Add `skill-invocable: true` to frontmatter. Add `../../_shared/references/as-tool-contract.md` to `references:`.
-- [ ] **Step 2:** Insert two-modes intro paragraph after the H1/purpose.
-- [ ] **Step 3:** Refactor §4 Checks:
+- [x] Task 6 complete <!-- sha:ec5269d -->
+
+- [x] **Step 1:** Add `skill-invocable: true` to frontmatter. Add `../../_shared/references/as-tool-contract.md` to `references:`.
+- [x] **Step 2:** Insert two-modes intro paragraph after the H1/purpose.
+- [x] **Step 3:** Refactor §4 Checks:
   - For each `"type": "command"` hook script found in `settings-path`: invoke `/build:check-shell --as-tool path=<hook-script-path>`; collect its findings (labeled `source: "check-shell"` on merge).
   - Remove delegated check bodies: **14** (ShellCheck + shfmt) fully; **11** (script safety preamble) fully — the generic `set -Eeuo pipefail` concern is now owned by `check-shell` S11; the `|| true` guards on `grep`/`diff` etc. also belong to `check-shell`; **15** (script style — stderr, `[[` vs `[`, `set -x`, shebang form) fully; **12's unquoted-variable portion** — map to `check-shell` S1; retain only the `eval`-on-payload branch and PATH-override branch under `check-hook` 12 (since these depend on `tool_input` semantics).
   - Renumber remaining checks OR preserve original IDs with explicit "delegated" notes per existing convention — pick whichever yields a cleaner file; document choice in Notes.
   - Retained checks: 1 (PreToolUse gap), 2 (destructive ops), 3 (async+blocking), 4 (Stop hook loop), 5 (stdin + executable bit), 6 (tool-name case + path expansion), 7 (PostToolUse enforcement intent), 8 (rule overlap vs CLAUDE.md), 9 (idempotency), 10 (latency), 12 (eval-on-payload + PATH-override only), 13 (jq availability + `tool_input` field-path), 16 (settings.json attack surface).
-- [ ] **Step 4:** Split §5 Report into §5a Human (current table, with a new `source` column prepended; include `check-shell` findings interleaved; external-tool preamble preserved) and §5b `--as-tool` (emit single JSON envelope per design DATA schema: `{type: "Success", value: {settings_path, summary, findings: [{source, check|lint, severity, event|null, hook, line|null, message}, ...]}}`).
-- [ ] **Step 5:** Add `## --as-tool contract` H2 before `## Anti-Pattern Guards`: **Required fields:** `settings-path`; **Return shape:** DATA; three bullets (Success schema; NeedsMoreInfo; Refusal — categories: `file-not-found`, `no-hooks`, `parse-error`); **Side effects:** reads `settings-path`; invokes `/build:check-shell --as-tool` once per `"type": "command"` hook script; **Parallel-safe:** yes (inner `check-shell` calls are parallel-safe; document that concurrent outer calls on the same `settings-path` are redundant but correct).
-- [ ] **Step 6:** Add three Key Instructions entries per the scaffolding recipe (DATA variant). Plus one skill-specific instruction: "Under `--as-tool`, every finding carries a `source` field — `check-hook` or `check-shell` — so callers can trace ownership."
-- [ ] **Step 7:** Verify: `grep -c "skill-invocable: true" plugins/build/skills/check-hook/SKILL.md` returns 1; `grep -c "^## --as-tool contract" plugins/build/skills/check-hook/SKILL.md` returns 1; `grep -c "/build:check-shell --as-tool" plugins/build/skills/check-hook/SKILL.md` returns ≥ 1; `grep -c "source.*check-shell\|source.*check-hook" plugins/build/skills/check-hook/SKILL.md` returns ≥ 2.
-- [ ] **Step 8:** Commit: `feat(check-hook): opt into --as-tool as DATA provider; delegate shell-hygiene to check-shell`.
+- [x] **Step 4:** Split §5 Report into §5a Human (current table, with a new `source` column prepended; include `check-shell` findings interleaved; external-tool preamble preserved) and §5b `--as-tool` (emit single JSON envelope per design DATA schema: `{type: "Success", value: {settings_path, summary, findings: [{source, check|lint, severity, event|null, hook, line|null, message}, ...]}}`).
+- [x] **Step 5:** Add `## --as-tool contract` H2 before `## Anti-Pattern Guards`: **Required fields:** `settings-path`; **Return shape:** DATA; three bullets (Success schema; NeedsMoreInfo; Refusal — categories: `file-not-found`, `no-hooks`, `parse-error`); **Side effects:** reads `settings-path`; invokes `/build:check-shell --as-tool` once per `"type": "command"` hook script; **Parallel-safe:** yes (inner `check-shell` calls are parallel-safe; document that concurrent outer calls on the same `settings-path` are redundant but correct).
+- [x] **Step 6:** Add three Key Instructions entries per the scaffolding recipe (DATA variant). Plus one skill-specific instruction: "Under `--as-tool`, every finding carries a `source` field — `check-hook` or `check-shell` — so callers can trace ownership."
+- [x] **Step 7:** Verify: `grep -c "skill-invocable: true" plugins/build/skills/check-hook/SKILL.md` returns 1; `grep -c "^## --as-tool contract" plugins/build/skills/check-hook/SKILL.md` returns 1; `grep -c "/build:check-shell --as-tool" plugins/build/skills/check-hook/SKILL.md` returns ≥ 1; `grep -c "source.*check-shell\|source.*check-hook" plugins/build/skills/check-hook/SKILL.md` returns ≥ 2.
+- [x] **Step 8:** Commit: `feat(check-hook): opt into --as-tool as DATA provider; delegate shell-hygiene to check-shell`.
 
 #### Task 7: Self-audit `check-hook` SKILL.md
 
 **Depends on:** Task 6
 
-- [ ] **Step 1:** Invoke `/build:check-skill --as-tool path=plugins/build/skills/check-hook/SKILL.md`; confirm zero fail findings on checks 23-31.
-- [ ] **Step 2:** If fails: fix in place. Re-audit.
-- [ ] **Step 3:** Commit (only if fixes): `fix(check-hook): resolve check-skill findings on --as-tool opt-in`.
+- [x] Task 7 complete <!-- sha:ec5269d verified — 0 fail, 1 pre-existing warn -->
+
+- [x] **Step 1:** Invoke `/build:check-skill --as-tool path=plugins/build/skills/check-hook/SKILL.md`; confirm zero fail findings on checks 23-31.
+- [x] **Step 2:** If fails: fix in place. Re-audit.
+- [x] **Step 3:** Commit (only if fixes): `fix(check-hook): resolve check-skill findings on --as-tool opt-in`.
 
 ### Chunk 4: Release
 
@@ -190,10 +204,12 @@ No files created. No files deleted. No Python source changes.
 
 **Depends on:** Task 3, Task 5, Task 7
 
-- [ ] **Step 1:** Invoke `/build:check-skill` (human mode) or run the lint script (`python3 plugins/wiki/scripts/lint.py --root . --no-urls`) across the full repo.
-- [ ] **Step 2:** Confirm zero new fail-level findings on the 41 pre-existing non-hook/non-shell SKILL.md files that are attributable to checks 23-31. Existing warn-level findings that predate this plan are acceptable.
-- [ ] **Step 3:** Verify: `python3 plugins/wiki/scripts/lint.py --root . --no-urls 2>&1 | grep -E "(skill_invocable|contract_|check_2[3-9]|check_3[01])" | grep -c "fail"` returns 0.
-- [ ] **Step 4:** Commit (only if regressions require a fix): `fix(build): resolve regressions from --as-tool opt-ins`.
+- [x] Task 8 complete <!-- sha:4728b99 verified — repo-wide 0 fails; 140 tests pass -->
+
+- [x] **Step 1:** Invoke `/build:check-skill` (human mode) or run the lint script (`python3 plugins/wiki/scripts/lint.py --root . --no-urls`) across the full repo.
+- [x] **Step 2:** Confirm zero new fail-level findings on the 41 pre-existing non-hook/non-shell SKILL.md files that are attributable to checks 23-31. Existing warn-level findings that predate this plan are acceptable.
+- [x] **Step 3:** Verify: `python3 plugins/wiki/scripts/lint.py --root . --no-urls 2>&1 | grep -E "(skill_invocable|contract_|check_2[3-9]|check_3[01])" | grep -c "fail"` returns 0.
+- [x] **Step 4:** Commit (only if regressions require a fix): `fix(build): resolve regressions from --as-tool opt-ins`.
 
 #### Task 9: Bump build plugin version to 0.6.0
 
@@ -203,10 +219,12 @@ No files created. No files deleted. No Python source changes.
 
 **Depends on:** Tasks 1–8
 
-- [ ] **Step 1:** Edit `plugins/build/pyproject.toml`: `version = "0.5.0"` → `version = "0.6.0"`.
-- [ ] **Step 2:** Edit `plugins/build/.claude-plugin/plugin.json`: `"version": "0.5.0"` → `"version": "0.6.0"`.
-- [ ] **Step 3:** Verify: `grep version plugins/build/pyproject.toml plugins/build/.claude-plugin/plugin.json` — both show `0.6.0`.
-- [ ] **Step 4:** Commit: `chore(build): bump to 0.6.0 for hook/shell --as-tool delegation`.
+- [x] Task 9 complete <!-- sha:4728b99 -->
+
+- [x] **Step 1:** Edit `plugins/build/pyproject.toml`: `version = "0.5.0"` → `version = "0.6.0"`.
+- [x] **Step 2:** Edit `plugins/build/.claude-plugin/plugin.json`: `"version": "0.5.0"` → `"version": "0.6.0"`.
+- [x] **Step 3:** Verify: `grep version plugins/build/pyproject.toml plugins/build/.claude-plugin/plugin.json` — both show `0.6.0`.
+- [x] **Step 4:** Commit: `chore(build): bump to 0.6.0 for hook/shell --as-tool delegation`.
 
 #### Task 10: Open PR
 
@@ -326,5 +344,17 @@ After all tasks complete:
 ## Notes
 
 - **Superseded plan.** `.plans/2026-04-19-hook-shell-structured-invocation.plan.md` (branch `explore/327-structured-invocation-thinking`) is pre-refinement exploration. Do not use it as implementation basis. This plan is the authoritative one for #327.
-- **Renumbering vs preserving check IDs in `check-hook`.** Task 6 Step 3 leaves this as an execution-time judgment call. Document the choice here once made.
-- **Inner-skill `Refusal` propagation.** When `/build:build-shell --as-tool` returns a `Refusal` (e.g., FX.1 scope gate fires for an inner call), `build-hook --as-tool` must wrap it as its own `Refusal` with `category: "inner-refusal"` and `reason` citing the inner refusal. Document the wrapping behavior explicitly in `build-hook`'s contract section (Task 4 Step 5).
+- **Renumbering in `check-hook`.** Chose to renumber checks rather than
+  preserve original IDs with "delegated" stubs. Old → new mapping:
+  1-10 unchanged; old 11 (script safety preamble) removed; old 12
+  (injection safety) reshaped to keep eval-on-payload + PATH-override
+  only, renumbered to 11; old 13 (jq availability) → 12; old 14
+  (ShellCheck/shfmt) removed; old 15 (script style) removed; old 16
+  (settings.json attack surface) → 13. A short delegation note under
+  §4 Checks lists what moved to `check-shell`.
+- **Pre-existing D6 false-positive fix.** Task 3 self-audit surfaced a
+  pre-existing fail on `check-shell` line 217 (on main): the D6
+  example `printf '...\n' >&2` tripped `_check_body_paths`'s Windows-
+  path regex because `..\n` matches the `..\<name>` pattern. Fixed by
+  rewording to `printf 'message\n' >&2`; SHA 72f7e55.
+- **Inner-skill `Refusal` propagation.** When `/build:build-shell --as-tool` returns a `Refusal` (e.g., FX.1 scope gate fires for an inner call), `build-hook --as-tool` wraps it as its own `Refusal` with `category: "inner-refusal"` and `reason` echoing the inner envelope. Documented in `build-hook`'s contract section.

--- a/.plans/2026-04-20-hook-shell-as-tool-delegation.plan.md
+++ b/.plans/2026-04-20-hook-shell-as-tool-delegation.plan.md
@@ -360,3 +360,10 @@ After all tasks complete:
   path regex because `..\n` matches the `..\<name>` pattern. Fixed by
   rewording to `printf 'message\n' >&2`; SHA 72f7e55.
 - **Inner-skill `Refusal` propagation.** When `/build:build-shell --as-tool` returns a `Refusal` (e.g., FX.1 scope gate fires for an inner call), `build-hook --as-tool` wraps it as its own `Refusal` with `category: "inner-refusal"` and `reason` echoing the inner envelope. Documented in `build-hook`'s contract section.
+- **Post-deploy validation pending.** Verify-work run on 2026-04-21 confirmed 16 of 24 criteria automatically; the remaining 8 (criteria 8-16: four `--as-tool` envelope smokes + four human-mode regressions) require the plugin to be installed from main (or this branch) before they can be executed. `/build:*` commands resolve against the installed plugin, not the working tree, so a fresh session after merge + reinstall is needed. Plan stays in `executing` until those smokes run.
+  - Criterion 8: `/build:build-shell --as-tool target-shell=bash-3.2-portable purpose="echo hello" invocation-style=glue setuid=no deps=` → ARTIFACT envelope + one ```bash block with `#!/usr/bin/env bash` and `set -Eeuo pipefail`.
+  - Criterion 9: `/build:check-shell --as-tool path=<script-without-preamble>` → DATA envelope with an S11 warn finding.
+  - Criterion 10: `/build:build-hook --as-tool hook-event=PreToolUse handler-type=command enforcement-goal="block rm -rf" matcher=Bash` → MULTI-ARTIFACT envelope + ```bash then ```json blocks; metadata exactly `{hook_event, matcher, handler_type}`.
+  - Criterion 11: `/build:check-hook --as-tool settings-path=<fixture>` against a fixture containing a command hook with an unquoted variable → DATA envelope with `findings` containing both `source: "check-hook"` and `source: "check-shell"` entries.
+  - Criterion 12: NeedsMoreInfo for each skill when a required field is omitted.
+  - Criteria 13-16: human-mode spot-check each of the four skills (intake flow, Review Gate, Save, and report rendering unchanged).

--- a/.plans/2026-04-20-hook-shell-as-tool-delegation.plan.md
+++ b/.plans/2026-04-20-hook-shell-as-tool-delegation.plan.md
@@ -1,0 +1,330 @@
+---
+name: Hook/Shell --as-tool Delegation
+description: Opt build-shell, check-shell, build-hook, and check-hook into skill-invocable mode; route hook-pair shell concerns through the shell pair; add check-shell S11; bump build plugin to 0.6.0.
+type: plan
+status: executing
+branch: feat/327-hook-shell-as-tool-delegation
+related:
+  - .designs/2026-04-20-hook-shell-as-tool-delegation.design.md
+  - plugins/build/_shared/references/as-tool-contract.md
+  - plugins/build/skills/build-skill/references/as-tool-scaffolding.md
+  - plugins/dummy/skills/greet/SKILL.md
+---
+
+# Hook/Shell `--as-tool` Delegation
+
+## Goal
+
+Four skills in the `build` plugin change shape in concert:
+
+- `build-shell` and `check-shell` opt into `--as-tool` as providers.
+- `build-hook` and `check-hook` opt in as providers *and* become callers — `build-hook` invokes `/build:build-shell --as-tool` to generate its scaffold; `check-hook` invokes `/build:check-shell --as-tool` per hook script and merges findings.
+- `check-shell` gains one new lint (**S11: missing strict-mode preamble, warn**) to close the delegation gap left when `check-hook` drops its preamble audit.
+- Build plugin bumps 0.5.0 → 0.6.0.
+
+After this plan lands, shell-hygiene concerns have a single owner, and the hook pair is a consumer of the shell pair via the settled `--as-tool` contract.
+
+**Closes #327.**
+
+## Scope
+
+### Must have
+
+- `plugins/build/skills/build-shell/SKILL.md`: `skill-invocable: true`; `## --as-tool contract` section (Required fields = five; Return shape = ARTIFACT; Artifact types = `text/x-shellscript`); intro paragraph naming both modes; workflow split into `§Xa. Human` and `§Xb. --as-tool`; FX.1 scope-gate fires return structured `Refusal` under `--as-tool` instead of halting; shared contract added to `references:`.
+- `plugins/build/skills/check-shell/SKILL.md`: `skill-invocable: true`; `## --as-tool contract` section (Required fields = `path`; Return shape = DATA); Report step split into human (table + preamble) and `--as-tool` (DATA envelope) branches; new **S11** lint entry added to the Safety subsection; `external_tools` payload shape documented; shared contract added to `references:`.
+- `plugins/build/skills/build-hook/SKILL.md`: `skill-invocable: true`; `## --as-tool contract` section (Required fields = four; Return shape = ARTIFACT; Artifact types = `text/x-shellscript, application/json`); Draft step becomes a caller of `/build:build-shell --as-tool` with pinned `target-shell=bash-3.2-portable`; hook-specific content (`INPUT=$(cat)`, `jq tool_input` extraction, `updatedInput` contract) layered onto the returned scaffold; emits MULTI-ARTIFACT Success with `metadata = {hook_event, matcher, handler_type}`; shared contract added to `references:`.
+- `plugins/build/skills/check-hook/SKILL.md`: `skill-invocable: true`; `## --as-tool contract` section (Required fields = `settings-path`; Return shape = DATA); Checks step becomes a caller of `/build:check-shell --as-tool` per `"type": "command"` hook script; delegated checks removed (14 fully; 11, 15 fully; 12's unquoted-variable portion); findings merged with `source: "check-hook"` / `source: "check-shell"` labels; shared contract added to `references:`.
+- `plugins/build/pyproject.toml` and `plugins/build/.claude-plugin/plugin.json` bump to 0.6.0.
+- `/build:check-skill` self-audit: zero fail-level findings on all four modified SKILL.md files (checks 23-31 pass).
+- No regression on the other 41 existing SKILL.md files (checks 23-31 still pass; no new fails introduced by this change).
+- PR opened against `main`; CI green (ruff + pytest).
+
+### Won't have
+
+- Changes to `plugins/build/_shared/references/as-tool-contract.md`. The contract is consumed as-is.
+- Changes to `plugins/build/skills/build-skill/references/as-tool-scaffolding.md`. The scaffolding recipe is consumed as-is.
+- Dummy plugin edits. `/dummy:greet` remains the canonical DATA example.
+- Changes to any other `build` skill (`build-skill`, `build-rule`, `build-subagent`, `refine-prompt`, `check-skill`, `check-rule`, `check-subagent`, `check-skill-chain`).
+- Changes to wiki, work, or consider plugins.
+- Python source changes. `check-shell` and `check-hook` are LLM-driven markdown skills; S11 is documented in SKILL.md prose, not in Python lint code.
+- Migration of `target-shell` for `build-hook`'s inner `build-shell` call to a caller-supplied field. Pinned to `bash-3.2-portable` for now; future revision out of scope.
+- New skill creation. No new skills in this plan.
+- Auto-patching of `settings.json` by `build-hook`. The write step stays with the user (human mode) or caller (`--as-tool` mode).
+- "Amplifier" findings in `check-hook` that duplicate `check-shell`'s shell-hygiene output. Single ownership per lint is the refactor's point.
+- Changes to `.claude-plugin/marketplace.json`. Marketplace references the plugin, not per-skill.
+
+## Approach
+
+**Bottom-up order, chunked.** The hook pair depends on the shell pair being `--as-tool`-ready; ship the providers first, then the callers.
+
+- **Chunk 1** — opt-in for `build-shell` + `check-shell`, plus the new S11 lint. Self-contained and verifiable in isolation: each SKILL.md passes `/build:check-skill` checks 23-31, and each skill emits a valid `--as-tool` envelope when given valid inputs.
+- **Chunk 2** — `build-hook` Draft step refactor. Now callable: the inner `build-shell --as-tool` call exists and works. Verifiable by invoking `/build:build-hook --as-tool` and inspecting the multi-artifact envelope.
+- **Chunk 3** — `check-hook` Checks step refactor. Now callable: the inner `check-shell --as-tool` call exists and works. Verifiable by invoking `/build:check-hook --as-tool` against a fixture settings.json and confirming findings carry `source:` labels.
+- **Chunk 4** — release gates. Self-audit all four files, bump version, open PR.
+
+**No migration of existing skills.** The 41 non-hook/non-shell skills stay as-is. Regression test is "no new fails from checks 23-31 on existing skills" — a strict bound.
+
+**Settings.json write-step stays with the caller.** `build-hook` emits the settings.json block in the fenced artifact; it never writes. Preserves existing behavior (the skill has never auto-patched `settings.json`) and matches the contract's rule that Save is skipped under `--as-tool`.
+
+**`metadata` kept minimal.** Three keys for `build-hook` Success (`hook_event`, `matcher`, `handler_type`) — per design Question 5, everything else the caller needs is parseable from the settings.json fenced block. Resist the urge to duplicate.
+
+**Test discipline.** For `check-shell` S11, the lint is documented in SKILL.md prose (markdown lint skill, not Python). Regression test is `/build:check-shell` against a fixture script missing `set -Eeuo pipefail` producing an S11 warn finding. For `build-hook` multi-artifact emission, the test is an actual `--as-tool` invocation with a smoke-check on the two fenced-block shape.
+
+## File Changes
+
+| File | Change |
+|---|---|
+| `plugins/build/skills/build-shell/SKILL.md` | **Modify** — add `skill-invocable: true` to frontmatter; add shared contract to `references:`; add two-modes intro paragraph; add `## --as-tool contract` section (Required fields / Return shape / Artifact types / three cases / Side effects / Parallel-safe); split §6 Review Gate and §7 Save + §8 Test into `§6a/b`, `§7a/b`, `§8a/b` (human vs `--as-tool`); modify §2 Scope Gate to return structured `Refusal` under `--as-tool`. |
+| `plugins/build/skills/check-shell/SKILL.md` | **Modify** — add `skill-invocable: true` to frontmatter; add shared contract to `references:`; add two-modes intro paragraph; add `## --as-tool contract` section (Required fields = `path`; Return shape = DATA; three cases; DATA schema documented; Side effects; Parallel-safe); add **S11** lint under Safety subsection (warn; body wording per design); split §5 Report into `§5a/b`. |
+| `plugins/build/skills/build-hook/SKILL.md` | **Modify** — add `skill-invocable: true` to frontmatter; add shared contract to `references:`; add two-modes intro paragraph; add `## --as-tool contract` section (Required fields = four; Return shape = ARTIFACT; Artifact types = `text/x-shellscript, application/json`; multi-artifact emission rule; three cases; Side effects = invokes `build-shell`; Parallel-safe); refactor §3 Draft to invoke `/build:build-shell --as-tool target-shell=bash-3.2-portable purpose=... invocation-style=glue setuid=no deps=jq,...`, receive the scaffold, layer hook-specific content; split §7 Review Gate + §8 Save + §9 Test into human/`--as-tool` branches; under `--as-tool` emit MULTI-ARTIFACT Success with the two fenced blocks in declared order. |
+| `plugins/build/skills/check-hook/SKILL.md` | **Modify** — add `skill-invocable: true` to frontmatter; add shared contract to `references:`; add two-modes intro paragraph; add `## --as-tool contract` section (Required fields = `settings-path`; Return shape = DATA; DATA schema with `source:` labels documented; three cases; Side effects = invokes `check-shell` per script; Parallel-safe); refactor §4 Checks to invoke `/build:check-shell --as-tool path=<hook-script-path>` per `"type": "command"` hook, merge findings with retained hook-specific checks; delete delegated check bodies (11, 14, 15 fully; 12's unquoted-variable portion); renumber or preserve check IDs per existing convention; split §5 Report into human (table) and `--as-tool` (DATA envelope) branches. |
+| `plugins/build/pyproject.toml` | **Modify** — version `0.5.0` → `0.6.0`. |
+| `plugins/build/.claude-plugin/plugin.json` | **Modify** — version `0.5.0` → `0.6.0`. |
+
+No files created. No files deleted. No Python source changes.
+
+## Tasks
+
+### Chunk 1: build-shell + check-shell opt-in
+
+#### Task 1: Opt `build-shell` into `--as-tool`
+
+**Files:**
+- Modify: `plugins/build/skills/build-shell/SKILL.md`
+
+- [ ] **Step 1:** Add `skill-invocable: true` to frontmatter. Add `../../_shared/references/as-tool-contract.md` to `references:`.
+- [ ] **Step 2:** Insert two-modes intro paragraph immediately after the H1/one-line purpose, per `as-tool-scaffolding.md`: "Two invocation modes: Human — prompts for missing info, shows the result, asks for approval. `--as-tool` — structured emission per the shared contract. No prompts, no approval."
+- [ ] **Step 3:** Add `## --as-tool contract` H2 near the end of the body (before `## Anti-Pattern Guards`). Populate subsections: **Required fields:** `target-shell`, `purpose`, `invocation-style`, `setuid`, `deps` (one-line description each); **Return shape:** ARTIFACT; **Artifact types:** `text/x-shellscript`; three bullets for Success (metadata shape + one fenced ```bash block carries the scaffold), NeedsMoreInfo (JSON only; `missing`, `hint`), Refusal (JSON only; `reason`, `category`; enumerate categories: `scope-gate`, `invalid-combo`); **Side effects:** reads intake; no file writes under `--as-tool`; **Parallel-safe:** yes.
+- [ ] **Step 4:** Modify §2 FX.1 Scope Gate: add a sub-note that under `--as-tool`, a tripped signal returns a structured `Refusal` (category `scope-gate`, reason citing the signal) instead of halting interactively.
+- [ ] **Step 5:** Split §6 Review Gate → §6a Human (current prose) and §6b `--as-tool` ("skipped; caller owns approval"). Same for §7 Save → §7a Human / §7b `--as-tool` (emission: output the JSON envelope with `artifact_types: ["text/x-shellscript"]` and `metadata: {target_shell, invocation_style}`, followed by one fenced ```bash block carrying the scaffold). Same for §8 Test → §8a/8b ("skipped under `--as-tool`").
+- [ ] **Step 6:** Add three Key Instructions entries per the scaffolding recipe: (a) under `--as-tool` emit per the contract (JSON envelope + one fenced ```bash block); (b) hard-fail with `NeedsMoreInfo` when any required field is missing; (c) `NeedsMoreInfo` and `Refusal` emit JSON only, never fenced blocks.
+- [ ] **Step 7:** Verify: `grep -c "skill-invocable: true" plugins/build/skills/build-shell/SKILL.md` returns 1; `grep -c "^## --as-tool contract" plugins/build/skills/build-shell/SKILL.md` returns 1; `grep -c "Required fields\|Return shape\|Artifact types\|Side effects\|Parallel-safe" plugins/build/skills/build-shell/SKILL.md` returns ≥ 5.
+- [ ] **Step 8:** Commit: `feat(build-shell): opt into --as-tool as ARTIFACT provider (text/x-shellscript)`.
+
+#### Task 2: Opt `check-shell` into `--as-tool` and add S11 lint
+
+**Files:**
+- Modify: `plugins/build/skills/check-shell/SKILL.md`
+
+- [ ] **Step 1:** Add `skill-invocable: true` to frontmatter. Add `../../_shared/references/as-tool-contract.md` to `references:`.
+- [ ] **Step 2:** Insert two-modes intro paragraph after the H1/purpose.
+- [ ] **Step 3:** Add new lint **S11: Missing strict-mode preamble (warn)** under §4 Checks → Safety subsection (after S10). Body per design: "Script does not begin (after the shebang and header) with `set -Eeuo pipefail` (bash) or `set -eu` (posix-sh). Without strict mode, commands that exit non-zero proceed silently and unset-variable dereferences expand to empty strings, producing actions on wrong inputs. Fix: add the appropriate strict-mode line near the top of the script."
+- [ ] **Step 4:** Split §5 Report into §5a Human (current table + Missing Tools preamble prose) and §5b `--as-tool` (emit a single JSON envelope — no fenced blocks — per the DATA schema in the design: `{type: "Success", value: {path, target_shell, summary, findings: [...], external_tools: {...}}}`, with severity ∈ `{fail, warn}`, line nullable for file-level findings, `external_tools` keyed per tool with `present`/`output`/`install_hint`).
+- [ ] **Step 5:** Add `## --as-tool contract` H2 before `## Anti-Pattern Guards`: **Required fields:** `path`; **Return shape:** DATA; three bullets (Success with `value` schema; NeedsMoreInfo; Refusal — category examples: `file-not-found`, `not-a-shell-script`); **Side effects:** reads the script at `path`, probes `PATH` for `shellcheck`/`shfmt`/`checkbashisms`, runs whichever are present; **Parallel-safe:** yes.
+- [ ] **Step 6:** Add three Key Instructions entries per the scaffolding recipe (DATA variant).
+- [ ] **Step 7:** Verify: `grep -c "skill-invocable: true" plugins/build/skills/check-shell/SKILL.md` returns 1; `grep -c "^## --as-tool contract" plugins/build/skills/check-shell/SKILL.md` returns 1; `grep -c "S11\." plugins/build/skills/check-shell/SKILL.md` returns ≥ 1; `grep "strict-mode preamble" plugins/build/skills/check-shell/SKILL.md` non-empty.
+- [ ] **Step 8:** Commit: `feat(check-shell): opt into --as-tool as DATA provider; add S11 strict-mode preamble lint`.
+
+#### Task 3: Self-audit Chunk 1 SKILL.md files
+
+**Depends on:** Task 1, Task 2
+
+- [ ] **Step 1:** Invoke `/build:check-skill --as-tool path=plugins/build/skills/build-shell/SKILL.md` and confirm zero fail-level findings on checks 23-31.
+- [ ] **Step 2:** Invoke `/build:check-skill --as-tool path=plugins/build/skills/check-shell/SKILL.md` and confirm zero fail-level findings on checks 23-31.
+- [ ] **Step 3:** If fails: fix in place. Re-audit. If warnings are acceptable (pre-existing or explicit), document in Notes.
+- [ ] **Step 4:** Verify: the two `/build:check-skill` invocations each show 0 fail findings on 23-31.
+- [ ] **Step 5:** Commit (only if fixes needed): `fix(build): resolve check-skill findings on build-shell/check-shell opt-in`.
+
+### Chunk 2: build-hook Draft step refactor
+
+#### Task 4: Opt `build-hook` into `--as-tool` and refactor Draft to call `build-shell`
+
+**Files:**
+- Modify: `plugins/build/skills/build-hook/SKILL.md`
+
+**Depends on:** Task 1 (inner `build-shell --as-tool` must exist).
+
+- [ ] **Step 1:** Add `skill-invocable: true` to frontmatter. Add `../../_shared/references/as-tool-contract.md` to `references:`.
+- [ ] **Step 2:** Insert two-modes intro paragraph after the H1/purpose.
+- [ ] **Step 3:** Refactor §3 Draft:
+  - Artifact 1 (hook script): under human mode, retain current scaffold. Under both modes, the scaffold is now generated by invoking `/build:build-shell --as-tool target-shell=bash-3.2-portable purpose="<derived from enforcement-goal>" invocation-style=glue setuid=no deps=jq`; receive the ARTIFACT envelope + fenced ```bash block; layer hook-specific content onto it: `INPUT=$(cat)` near the top, `jq -r '.tool_input.<field>'` extraction per `tool_name` (table preserved), optional ERR/EXIT traps, `updatedInput` JSON output contract (preserved), tool-name case/matcher handling.
+  - Artifact 2 (settings.json entry): unchanged generation; emitted as a fenced ```json block under `--as-tool`.
+  - Document that a `NeedsMoreInfo` or `Refusal` from the inner `build-shell` invocation propagates up as the outer skill's own envelope.
+- [ ] **Step 4:** Split §7 Review Gate → §7a Human / §7b `--as-tool` ("skipped; caller owns approval"). §8 Save → §8a Human (retain current: write script, chmod +x, show settings snippet) / §8b `--as-tool` (skipped; emit MULTI-ARTIFACT Success with `artifact_types: ["text/x-shellscript", "application/json"]` and `metadata: {hook_event, matcher, handler_type}`, then the two fenced blocks in declared order: ```bash hook script first, ```json settings entry second). §9 Test → §9a/9b.
+- [ ] **Step 5:** Add `## --as-tool contract` H2 before `## Anti-Pattern Guards`: **Required fields:** `hook-event`, `handler-type`, `enforcement-goal`, `matcher` (note: pass `"*"` for non-tool events); **Return shape:** ARTIFACT; **Artifact types:** `text/x-shellscript, application/json`; three bullets (Success with metadata = 3 keys and two fenced blocks; NeedsMoreInfo; Refusal — categories: `wrong-primitive`, `inner-refusal`); **Side effects:** invokes `/build:build-shell --as-tool` with pinned `target-shell=bash-3.2-portable`; **Parallel-safe:** yes.
+- [ ] **Step 6:** Add three Key Instructions entries per the scaffolding recipe (ARTIFACT variant).
+- [ ] **Step 7:** Verify: `grep -c "skill-invocable: true" plugins/build/skills/build-hook/SKILL.md` returns 1; `grep -c "^## --as-tool contract" plugins/build/skills/build-hook/SKILL.md` returns 1; `grep -c "/build:build-shell --as-tool" plugins/build/skills/build-hook/SKILL.md` returns ≥ 1; `grep -c "text/x-shellscript.*application/json\|application/json.*text/x-shellscript" plugins/build/skills/build-hook/SKILL.md` returns ≥ 1.
+- [ ] **Step 8:** Commit: `feat(build-hook): opt into --as-tool as MULTI-ARTIFACT provider; delegate scaffold to build-shell`.
+
+#### Task 5: Self-audit `build-hook` SKILL.md
+
+**Depends on:** Task 4
+
+- [ ] **Step 1:** Invoke `/build:check-skill --as-tool path=plugins/build/skills/build-hook/SKILL.md`; confirm zero fail findings on checks 23-31.
+- [ ] **Step 2:** If fails: fix in place. Re-audit.
+- [ ] **Step 3:** Commit (only if fixes): `fix(build-hook): resolve check-skill findings on --as-tool opt-in`.
+
+### Chunk 3: check-hook Checks step refactor
+
+#### Task 6: Opt `check-hook` into `--as-tool` and refactor Checks to call `check-shell`
+
+**Files:**
+- Modify: `plugins/build/skills/check-hook/SKILL.md`
+
+**Depends on:** Task 2 (inner `check-shell --as-tool` must exist).
+
+- [ ] **Step 1:** Add `skill-invocable: true` to frontmatter. Add `../../_shared/references/as-tool-contract.md` to `references:`.
+- [ ] **Step 2:** Insert two-modes intro paragraph after the H1/purpose.
+- [ ] **Step 3:** Refactor §4 Checks:
+  - For each `"type": "command"` hook script found in `settings-path`: invoke `/build:check-shell --as-tool path=<hook-script-path>`; collect its findings (labeled `source: "check-shell"` on merge).
+  - Remove delegated check bodies: **14** (ShellCheck + shfmt) fully; **11** (script safety preamble) fully — the generic `set -Eeuo pipefail` concern is now owned by `check-shell` S11; the `|| true` guards on `grep`/`diff` etc. also belong to `check-shell`; **15** (script style — stderr, `[[` vs `[`, `set -x`, shebang form) fully; **12's unquoted-variable portion** — map to `check-shell` S1; retain only the `eval`-on-payload branch and PATH-override branch under `check-hook` 12 (since these depend on `tool_input` semantics).
+  - Renumber remaining checks OR preserve original IDs with explicit "delegated" notes per existing convention — pick whichever yields a cleaner file; document choice in Notes.
+  - Retained checks: 1 (PreToolUse gap), 2 (destructive ops), 3 (async+blocking), 4 (Stop hook loop), 5 (stdin + executable bit), 6 (tool-name case + path expansion), 7 (PostToolUse enforcement intent), 8 (rule overlap vs CLAUDE.md), 9 (idempotency), 10 (latency), 12 (eval-on-payload + PATH-override only), 13 (jq availability + `tool_input` field-path), 16 (settings.json attack surface).
+- [ ] **Step 4:** Split §5 Report into §5a Human (current table, with a new `source` column prepended; include `check-shell` findings interleaved; external-tool preamble preserved) and §5b `--as-tool` (emit single JSON envelope per design DATA schema: `{type: "Success", value: {settings_path, summary, findings: [{source, check|lint, severity, event|null, hook, line|null, message}, ...]}}`).
+- [ ] **Step 5:** Add `## --as-tool contract` H2 before `## Anti-Pattern Guards`: **Required fields:** `settings-path`; **Return shape:** DATA; three bullets (Success schema; NeedsMoreInfo; Refusal — categories: `file-not-found`, `no-hooks`, `parse-error`); **Side effects:** reads `settings-path`; invokes `/build:check-shell --as-tool` once per `"type": "command"` hook script; **Parallel-safe:** yes (inner `check-shell` calls are parallel-safe; document that concurrent outer calls on the same `settings-path` are redundant but correct).
+- [ ] **Step 6:** Add three Key Instructions entries per the scaffolding recipe (DATA variant). Plus one skill-specific instruction: "Under `--as-tool`, every finding carries a `source` field — `check-hook` or `check-shell` — so callers can trace ownership."
+- [ ] **Step 7:** Verify: `grep -c "skill-invocable: true" plugins/build/skills/check-hook/SKILL.md` returns 1; `grep -c "^## --as-tool contract" plugins/build/skills/check-hook/SKILL.md` returns 1; `grep -c "/build:check-shell --as-tool" plugins/build/skills/check-hook/SKILL.md` returns ≥ 1; `grep -c "source.*check-shell\|source.*check-hook" plugins/build/skills/check-hook/SKILL.md` returns ≥ 2.
+- [ ] **Step 8:** Commit: `feat(check-hook): opt into --as-tool as DATA provider; delegate shell-hygiene to check-shell`.
+
+#### Task 7: Self-audit `check-hook` SKILL.md
+
+**Depends on:** Task 6
+
+- [ ] **Step 1:** Invoke `/build:check-skill --as-tool path=plugins/build/skills/check-hook/SKILL.md`; confirm zero fail findings on checks 23-31.
+- [ ] **Step 2:** If fails: fix in place. Re-audit.
+- [ ] **Step 3:** Commit (only if fixes): `fix(check-hook): resolve check-skill findings on --as-tool opt-in`.
+
+### Chunk 4: Release
+
+#### Task 8: Regression check across all existing SKILL.md files
+
+**Depends on:** Task 3, Task 5, Task 7
+
+- [ ] **Step 1:** Invoke `/build:check-skill` (human mode) or run the lint script (`python3 plugins/wiki/scripts/lint.py --root . --no-urls`) across the full repo.
+- [ ] **Step 2:** Confirm zero new fail-level findings on the 41 pre-existing non-hook/non-shell SKILL.md files that are attributable to checks 23-31. Existing warn-level findings that predate this plan are acceptable.
+- [ ] **Step 3:** Verify: `python3 plugins/wiki/scripts/lint.py --root . --no-urls 2>&1 | grep -E "(skill_invocable|contract_|check_2[3-9]|check_3[01])" | grep -c "fail"` returns 0.
+- [ ] **Step 4:** Commit (only if regressions require a fix): `fix(build): resolve regressions from --as-tool opt-ins`.
+
+#### Task 9: Bump build plugin version to 0.6.0
+
+**Files:**
+- Modify: `plugins/build/pyproject.toml`
+- Modify: `plugins/build/.claude-plugin/plugin.json`
+
+**Depends on:** Tasks 1–8
+
+- [ ] **Step 1:** Edit `plugins/build/pyproject.toml`: `version = "0.5.0"` → `version = "0.6.0"`.
+- [ ] **Step 2:** Edit `plugins/build/.claude-plugin/plugin.json`: `"version": "0.5.0"` → `"version": "0.6.0"`.
+- [ ] **Step 3:** Verify: `grep version plugins/build/pyproject.toml plugins/build/.claude-plugin/plugin.json` — both show `0.6.0`.
+- [ ] **Step 4:** Commit: `chore(build): bump to 0.6.0 for hook/shell --as-tool delegation`.
+
+#### Task 10: Open PR
+
+**Depends on:** Task 9
+
+- [ ] **Step 1:** Push branch `feat/327-hook-shell-as-tool-delegation` with `-u origin`.
+- [ ] **Step 2:** Open PR against `main`. Title: `feat(build): hook/shell --as-tool delegation (build-0.6.0)`. Body: Summary (4 skills opt in; hook pair delegates to shell pair; check-shell S11; no migration of other skills; version bump). Test plan bullets: Chunk 1 self-audits, Chunk 2/3 invocation smoke, regression check, human-mode regression spot-check. Link #327 (closes) and the design doc.
+- [ ] **Step 3:** Verify: `gh pr view` returns a PR URL; CI (ruff + pytest) green.
+- [ ] **Step 4:** No commit (PR creation is not a commit).
+
+## Validation
+
+After all tasks complete:
+
+1. **All four SKILL.md files declare `skill-invocable: true`.**
+   ```
+   grep -l "skill-invocable: true" \
+     plugins/build/skills/build-shell/SKILL.md \
+     plugins/build/skills/check-shell/SKILL.md \
+     plugins/build/skills/build-hook/SKILL.md \
+     plugins/build/skills/check-hook/SKILL.md | wc -l
+   ```
+   Returns `4`.
+
+2. **All four SKILL.md files carry a `## --as-tool contract` H2.**
+   ```
+   for f in plugins/build/skills/{build-shell,check-shell,build-hook,check-hook}/SKILL.md; do
+     grep -c "^## --as-tool contract" "$f"
+   done
+   ```
+   Each line prints `1`.
+
+3. **All four SKILL.md files reference the shared contract.**
+   ```
+   for f in plugins/build/skills/{build-shell,check-shell,build-hook,check-hook}/SKILL.md; do
+     grep -c "as-tool-contract.md" "$f"
+   done
+   ```
+   Each line prints ≥ 1.
+
+4. **`/build:check-skill` passes checks 23-31 on all four files.**
+   For each of the four SKILL.md paths, `/build:check-skill --as-tool path=<file>` returns `Success` with zero findings where `check_id` ∈ 23..31 and `severity == "fail"`.
+
+5. **`check-shell` documents S11.**
+   ```
+   grep -E "^#### S11\.|S11: Missing strict-mode preamble" plugins/build/skills/check-shell/SKILL.md
+   ```
+   Non-empty.
+
+6. **`check-hook` no longer documents check 14, check 11, check 15, or the unquoted-variable portion of check 12.**
+   ```
+   grep -cE "^### 11\. Script safety preamble|^### 14\. ShellCheck|^### 15\. Script style conventions" \
+     plugins/build/skills/check-hook/SKILL.md
+   ```
+   Returns `0`.
+
+7. **`check-hook` still documents retained checks 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12 (eval/PATH only), 13, 16.**
+   ```
+   grep -cE "^### [0-9]+\." plugins/build/skills/check-hook/SKILL.md
+   ```
+   Returns ≥ 13 (count equals the retained set; exact value depends on renumbering choice in Task 6 Step 3).
+
+8. **Smoke — `build-shell --as-tool`.** A mock invocation `/build:build-shell --as-tool target-shell=bash-3.2-portable purpose="echo hello" invocation-style=glue setuid=no deps=` returns a single JSON envelope `{type: "Success", artifact_types: ["text/x-shellscript"], metadata: {...}}` followed by exactly one fenced ```bash block containing a scaffold that starts with `#!/usr/bin/env bash` and includes `set -Eeuo pipefail`.
+
+9. **Smoke — `check-shell --as-tool`.** `/build:check-shell --as-tool path=<script-without-preamble>` returns a single JSON envelope `{type: "Success", value: {..., findings: [..., {"lint": "S11", "severity": "warn", ...}, ...]}}` — no fenced blocks.
+
+10. **Smoke — `build-hook --as-tool`.** `/build:build-hook --as-tool hook-event=PreToolUse handler-type=command enforcement-goal="block rm -rf" matcher=Bash` returns a JSON envelope `{type: "Success", artifact_types: ["text/x-shellscript", "application/json"], metadata: {hook_event: "PreToolUse", matcher: "Bash", handler_type: "command"}}` followed by exactly two fenced blocks in order: ```bash (hook script; contains `INPUT=$(cat)` and `set -Eeuo pipefail`) then ```json (settings entry; `hooks.PreToolUse[].matcher == "Bash"`).
+
+11. **Smoke — `check-hook --as-tool`.** Against a fixture settings.json referencing at least one command hook whose script has an unquoted variable expansion (triggers `check-shell` S1), `/build:check-hook --as-tool settings-path=<path>` returns a single JSON envelope with `value.findings` containing at least one finding with `source: "check-shell"` and at least one with `source: "check-hook"` — no fenced blocks.
+
+12. **Smoke — `NeedsMoreInfo` envelopes.** Each of the four skills, invoked with `--as-tool` and a required field omitted, returns `{"type": "NeedsMoreInfo", "missing": [...], "hint": "..."}` — no fenced blocks.
+
+13. **Human-mode regression — `build-shell`.** A mock human-mode run completes the current §1–§8 flow unchanged (Elicit asks six fields including `save-path`; Save writes the file; `chmod +x` runs).
+
+14. **Human-mode regression — `check-shell`.** A mock human-mode run produces the current report format (table + Missing Tools preamble) against a sample script. S11 surfaces as a new warn when the script lacks `set -Eeuo pipefail`.
+
+15. **Human-mode regression — `build-hook`.** A mock human-mode run for a PreToolUse blocker produces the current two artifacts (hook script + settings.json snippet) and waits for Review Gate approval before Save. The inner `build-shell --as-tool` call is used internally; no user-visible change to the human flow.
+
+16. **Human-mode regression — `check-hook`.** A mock human-mode run against a sample `settings.json` produces the current report format (table with findings per hook). Shell-hygiene findings appear under `source: check-shell` (new column); hook-specific findings under `source: check-hook`.
+
+17. **Build plugin version is 0.6.0.**
+    ```
+    grep version plugins/build/pyproject.toml plugins/build/.claude-plugin/plugin.json
+    ```
+    Both show `0.6.0`.
+
+18. **Shared contract unchanged.**
+    ```
+    git diff main -- plugins/build/_shared/references/as-tool-contract.md
+    ```
+    Returns no output.
+
+19. **`as-tool-scaffolding.md` unchanged.**
+    ```
+    git diff main -- plugins/build/skills/build-skill/references/as-tool-scaffolding.md
+    ```
+    Returns no output.
+
+20. **No regression on other 41 SKILL.md files.** `python3 plugins/wiki/scripts/lint.py --root . --no-urls` shows zero new fail-level findings on non-hook/non-shell SKILL.md files attributable to checks 23-31.
+
+21. **Ruff clean.**
+    ```
+    ruff check plugins/build
+    ```
+    Returns 0 warnings.
+
+22. **Tests pass.**
+    ```
+    python3 -m pytest plugins/build/tests/ -v
+    ```
+    All tests pass.
+
+23. **Dummy plugin still works.** `/dummy:greet --as-tool name=bob time-of-day=morning` returns `{type: "Success", value: {text: "Good morning, bob!", ...}}` — no regression from shared-contract or scaffolding changes (neither should have happened).
+
+24. **PR is open.** `gh pr view` returns a PR URL; CI green.
+
+## Notes
+
+- **Superseded plan.** `.plans/2026-04-19-hook-shell-structured-invocation.plan.md` (branch `explore/327-structured-invocation-thinking`) is pre-refinement exploration. Do not use it as implementation basis. This plan is the authoritative one for #327.
+- **Renumbering vs preserving check IDs in `check-hook`.** Task 6 Step 3 leaves this as an execution-time judgment call. Document the choice here once made.
+- **Inner-skill `Refusal` propagation.** When `/build:build-shell --as-tool` returns a `Refusal` (e.g., FX.1 scope gate fires for an inner call), `build-hook --as-tool` must wrap it as its own `Refusal` with `category: "inner-refusal"` and `reason` citing the inner refusal. Document the wrapping behavior explicitly in `build-hook`'s contract section (Task 4 Step 5).

--- a/.plans/2026-04-20-hook-shell-as-tool-delegation.plan.md
+++ b/.plans/2026-04-20-hook-shell-as-tool-delegation.plan.md
@@ -230,10 +230,12 @@ No files created. No files deleted. No Python source changes.
 
 **Depends on:** Task 9
 
-- [ ] **Step 1:** Push branch `feat/327-hook-shell-as-tool-delegation` with `-u origin`.
-- [ ] **Step 2:** Open PR against `main`. Title: `feat(build): hook/shell --as-tool delegation (build-0.6.0)`. Body: Summary (4 skills opt in; hook pair delegates to shell pair; check-shell S11; no migration of other skills; version bump). Test plan bullets: Chunk 1 self-audits, Chunk 2/3 invocation smoke, regression check, human-mode regression spot-check. Link #327 (closes) and the design doc.
-- [ ] **Step 3:** Verify: `gh pr view` returns a PR URL; CI (ruff + pytest) green.
-- [ ] **Step 4:** No commit (PR creation is not a commit).
+- [x] Task 10 complete <!-- pr:#336 — CI green on 3.9 and 3.12 -->
+
+- [x] **Step 1:** Push branch `feat/327-hook-shell-as-tool-delegation` with `-u origin`.
+- [x] **Step 2:** Open PR against `main`. Title: `feat(build): hook/shell --as-tool delegation (build-0.6.0)`. Body: Summary (4 skills opt in; hook pair delegates to shell pair; check-shell S11; no migration of other skills; version bump). Test plan bullets: Chunk 1 self-audits, Chunk 2/3 invocation smoke, regression check, human-mode regression spot-check. Link #327 (closes) and the design doc.
+- [x] **Step 3:** Verify: `gh pr view` returns a PR URL; CI (ruff + pytest) green.
+- [x] **Step 4:** No commit (PR creation is not a commit).
 
 ## Validation
 

--- a/plugins/build/.claude-plugin/plugin.json
+++ b/plugins/build/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "build",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Skills for creating and refining Claude Code skills, rules, hooks, and subagents.",
   "author": {
     "name": "Brandon Beidel"

--- a/plugins/build/pyproject.toml
+++ b/plugins/build/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "check"
-version = "0.5.0"
+version = "0.6.0"
 description = "Claude Code plugin for auditing Claude Code skills and rules for quality issues."
 requires-python = ">=3.9"
 dependencies = []

--- a/plugins/build/skills/build-hook/SKILL.md
+++ b/plugins/build/skills/build-hook/SKILL.md
@@ -8,14 +8,29 @@ description: >
   after tool use", or "block dangerous operations automatically".
 argument-hint: "[hook event] [enforcement goal]"
 user-invocable: true
+skill-invocable: true
 references:
   - ../../_shared/references/primitive-routing.md
+  - ../../_shared/references/as-tool-contract.md
 ---
 
 # Build Hook
 
 Scaffold a Claude Code hook: an event-driven script that enforces quality
 gates deterministically, bypassing LLM interpretation.
+
+Two invocation modes:
+
+- **Human** — prompts for `hook-event`, `handler-type`, and
+  `enforcement-goal`, generates the scaffold by calling
+  `/build:build-shell` internally, layers hook-specific content, presents
+  both artifacts for approval, writes the script, shows the settings
+  snippet.
+- **`--as-tool`** — skill-caller mode. Structured MULTI-ARTIFACT emission
+  per [`as-tool-contract.md`](../../_shared/references/as-tool-contract.md):
+  a JSON envelope declaring `artifact_types: ["text/x-shellscript", "application/json"]`
+  followed by two fenced blocks (hook script, then settings entry). No
+  prompts, no approval, no file writes.
 
 **Workflow sequence:** 1. Route → 2. Elicit → 3. Draft → 4. Safety Check → (5. Stop Hook Guard if Stop/SubagentStop) → 6. Rule Overlap → 7. Review Gate → 8. Save → 9. Test
 
@@ -68,7 +83,42 @@ detect? Confirm the goal before drafting.
 
 Produce two artifacts.
 
-**Artifact 1: Hook script** (for `command` type — adapt for other types)
+**Base scaffold via `/build:build-shell --as-tool`.** Instead of
+hand-rolling the shell scaffold, delegate to `/build:build-shell`:
+
+    /build:build-shell --as-tool \
+      target-shell=bash-3.2-portable \
+      purpose="<one-line summary derived from enforcement-goal>" \
+      invocation-style=glue \
+      setuid=no \
+      deps=jq
+
+`target-shell` is pinned to `bash-3.2-portable` for hook scripts —
+Apple still ships bash 3.2, and hooks run on every developer's box.
+`deps=jq` is the default (hooks parse the stdin JSON payload);
+add more deps when the enforcement logic calls other tools.
+
+The inner call returns an ARTIFACT envelope + one fenced ```bash
+block carrying a strict-mode scaffold (shebang, header, `set -Eeuo
+pipefail`, `IFS=$'\n\t'`, `REQUIRED_CMDS`, preflight, `main`,
+self-sourcing guard). Layer hook-specific content onto that base —
+see the checklist below.
+
+If the inner call returns `NeedsMoreInfo` or `Refusal`, propagate it:
+wrap the inner envelope as this skill's own return (category
+`inner-refusal` for Refusal) under `--as-tool`; halt interactively
+under human mode.
+
+**Artifact 1: Hook script** (for `command` type — adapt for other types).
+Layer these hook-specific elements onto the base scaffold:
+
+- `INPUT=$(cat)` near the top of `main` to consume the stdin JSON payload.
+- `jq -r '.tool_input.<field>'` extractions per the tool-specific table
+  below.
+- Enforcement logic (the reason this hook exists).
+- `exit 2` for blocking paths (PreToolUse) / `exit 0` for pass.
+
+Reference scaffold after layering:
 
 ```bash
 #!/usr/bin/env bash
@@ -389,6 +439,8 @@ decides.
 
 ## 7. Review Gate
 
+### 7a. Human mode
+
 Present both artifacts — the complete hook script and the settings.json
 snippet — and wait for explicit user approval before writing any file to
 disk. Write only after this gate passes.
@@ -397,7 +449,13 @@ If the user requests changes, revise and re-present. Continue this loop
 until the user explicitly approves the artifacts or cancels. Proceed to
 Save only on explicit approval.
 
+### 7b. `--as-tool` mode
+
+Skipped. The caller owns approval; proceed directly to §8b.
+
 ## 8. Save
+
+### 8a. Human mode
 
 Write the approved hook to `.claude/hooks/<name>.sh` (or a path the user
 specifies). Make it executable:
@@ -414,7 +472,48 @@ should not be overwritten.
 > entry shown above to `.claude/settings.json` (or settings.local.json
 > for local-only enforcement) to activate it."
 
+### 8b. `--as-tool` mode
+
+Skipped — no file is written. Emit the structured return per the
+shared contract: a MULTI-ARTIFACT Success envelope followed by exactly
+two fenced blocks in declared order (hook script first, settings entry
+second).
+
+**Success:**
+
+    {"type": "Success", "artifact_types": ["text/x-shellscript", "application/json"], "metadata": {"hook_event": "PreToolUse", "matcher": "Bash", "handler_type": "command"}}
+    ```bash
+    #!/usr/bin/env bash
+    # ... hook script (base scaffold + hook-specific content) ...
+    ```
+    ```json
+    {"hooks": {"PreToolUse": [{"matcher": "Bash", "hooks": [{"type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/<name>.sh", "timeout": 60}]}]}}
+    ```
+
+`metadata` carries exactly three keys: `hook_event`, `matcher`,
+`handler_type`. Anything else the caller needs (command path,
+timeout, async flag, matcher regex) is already in the settings.json
+fenced block.
+
+**NeedsMoreInfo** (any of the four required fields missing; JSON only,
+no fenced blocks):
+
+    {"type": "NeedsMoreInfo", "missing": ["matcher"], "hint": "pass hook-event, handler-type, enforcement-goal, matcher under --as-tool (use matcher=\"*\" for non-tool events)"}
+
+**Refusal** (Route step rejected the primitive, or the inner
+`/build:build-shell --as-tool` returned a Refusal; JSON only, no
+fenced blocks):
+
+    {"type": "Refusal", "reason": "goal fits permissions.deny — no hook logic needed", "category": "wrong-primitive"}
+
+Categories: `wrong-primitive` (Route suggested `permissions.deny`,
+CLAUDE.md, a skill, or a rule instead), `inner-refusal` (inner
+`build-shell` scope-gate or invalid-combo fired; `reason` echoes the
+inner envelope's reason).
+
 ## 9. Test
+
+### 9a. Human mode
 
 Read `references/hook-testing.md` and follow the three-layer verification
 procedure (configuration, logic isolation, execution trace) before activating
@@ -424,6 +523,48 @@ After testing, offer:
 
 > "Run `/build:check-hook` to audit the configuration for coverage gaps,
 > misconfigurations, and safety issues?"
+
+### 9b. `--as-tool` mode
+
+Skipped. The caller decides whether to chain to `/build:check-hook`.
+
+## --as-tool contract
+
+**Required fields:**
+
+- `hook-event` — Claude Code lifecycle event (`PreToolUse`,
+  `PostToolUse`, `Stop`, `SessionStart`, etc.).
+- `handler-type` — one of `command`, `http`, `prompt`, `agent`.
+- `enforcement-goal` — one-sentence description of what the hook
+  enforces or detects.
+- `matcher` — tool-name pattern for tool-scoped events (`Bash`,
+  `Write|Edit|MultiEdit`, `mcp__memory__.*`, or `*`). Pass `"*"` for
+  non-tool events (`SessionStart`, `Stop`, etc.) — required regardless
+  to keep the schema flat.
+
+**Return shape:** ARTIFACT.
+
+**Artifact types:** `text/x-shellscript, application/json`.
+
+**Success** — JSON envelope declaring `artifact_types: ["text/x-shellscript", "application/json"]`
+and `metadata: {hook_event, matcher, handler_type}`, followed by exactly
+two fenced blocks in declared order: ```bash (the hook script) then
+```json (the settings.json entry).
+
+**NeedsMoreInfo** — JSON only: `missing: [...]` lists absent required
+fields; `hint` reminds callers that all four fields are required.
+
+**Refusal** — JSON only: `reason:` one-sentence explanation;
+`category:` one of `wrong-primitive` (Route step rejected the hook
+primitive; reason cites the suggested alternative) or `inner-refusal`
+(inner `/build:build-shell --as-tool` call returned a Refusal; reason
+echoes the inner envelope).
+
+**Side effects:** invokes `/build:build-shell --as-tool` once per call,
+with pinned `target-shell=bash-3.2-portable`. No filesystem writes, no
+`chmod`, no network.
+
+**Parallel-safe:** yes.
 
 ## Anti-Pattern Guards
 
@@ -435,6 +576,16 @@ After testing, offer:
 
 ## Key Instructions
 
+- Under `--as-tool`: emit per the contract — a JSON envelope declaring
+  `artifact_types: ["text/x-shellscript", "application/json"]` followed
+  by exactly two fenced blocks in declared order (```bash hook script,
+  then ```json settings entry). No prose, no preamble, no approval.
+- Under `--as-tool`: hard-fail with `NeedsMoreInfo` (JSON only) when
+  any of the four required fields is missing. Do not prompt — the
+  caller will retry with the missing field filled in.
+- `NeedsMoreInfo` and `Refusal` emit JSON only, never followed by
+  fenced blocks. Inner `/build:build-shell --as-tool` Refusals
+  propagate as outer Refusals with `category: "inner-refusal"`.
 - Do not write any file to disk before the Review Gate passes — present both artifacts first, wait for explicit user approval
 - Do not auto-patch `settings.json`; always show the snippet for the user to apply manually
 - Won't build a hook when `permissions.deny` covers the goal — unconditional permanent blocks don't need logic or a script

--- a/plugins/build/skills/build-shell/SKILL.md
+++ b/plugins/build/skills/build-shell/SKILL.md
@@ -9,8 +9,10 @@ description: >
   script". Not for Claude Code hooks — route to `/build:build-hook`.
 argument-hint: "[target-shell] [purpose]"
 user-invocable: true
+skill-invocable: true
 references:
   - references/scope-gate.md
+  - ../../_shared/references/as-tool-contract.md
 ---
 
 # Build Shell
@@ -19,6 +21,15 @@ Scaffold a general-purpose shell script: a deterministic automation unit
 with a consistent structural shape (strict mode, structured header,
 dependency preflight, `main` + self-sourcing guard) scoped to a declared
 target shell.
+
+Two invocation modes:
+
+- **Human** — prompts for missing info, shows the scaffolded script, asks
+  for approval, writes the file, offers the audit.
+- **`--as-tool`** — skill-caller mode. Structured emission per
+  [`as-tool-contract.md`](../../_shared/references/as-tool-contract.md):
+  JSON envelope plus one fenced `bash` block carrying the scaffold. No
+  prompts, no approval, no file writes.
 
 This skill is not for Claude Code hooks — `/build:build-hook` owns that
 lifecycle. Route there when the script has an event trigger and
@@ -69,6 +80,11 @@ Probe for any of:
 If any signal fires, state the signal, quote the recommendation, and
 stop. Do not proceed to Elicit. The skill's value is in refusing cleanly
 as much as in scaffolding cleanly.
+
+Under `--as-tool`, a tripped signal does **not** halt interactively.
+Return a structured `Refusal` envelope instead (`category:
+"scope-gate"`, `reason:` citing the signal and its recommendation). See
+§7b below and the shared contract's envelope rules.
 
 ## 3. Elicit
 
@@ -227,6 +243,8 @@ alternative.
 
 ## 6. Review Gate
 
+### 6a. Human mode
+
 Present both artifacts and wait for explicit user approval before
 writing any file to disk. Write only after this gate passes.
 
@@ -234,7 +252,13 @@ If the user requests changes, revise and re-present. Continue until
 the user explicitly approves the artifacts or cancels. Proceed to Save
 only on explicit approval.
 
+### 6b. `--as-tool` mode
+
+Skipped. The caller owns approval; proceed directly to §7b.
+
 ## 7. Save
+
+### 7a. Human mode
 
 Write the approved script to the user-supplied path from Elicit. Make
 it executable:
@@ -246,12 +270,79 @@ chmod +x <path>
 Show the suggested invocation line for the user to wire into their
 Makefile, CI config, or README.
 
+### 7b. `--as-tool` mode
+
+Skipped — no file is written. Emit the structured return per the
+shared contract: a single JSON envelope followed by exactly one fenced
+`bash` block carrying the scaffold.
+
+**Success:**
+
+    {"type": "Success", "artifact_types": ["text/x-shellscript"], "metadata": {"target_shell": "<picked>", "invocation_style": "<picked>"}}
+    ```bash
+    #!/usr/bin/env bash
+    # ... full scaffold ...
+    ```
+
+**NeedsMoreInfo** (any of the five required fields missing; JSON only,
+no fenced block):
+
+    {"type": "NeedsMoreInfo", "missing": ["target-shell"], "hint": "pass target-shell, purpose, invocation-style, setuid, deps under --as-tool"}
+
+**Refusal** (FX.1 scope-gate signal fired, or input combination is
+unsatisfiable; JSON only, no fenced block):
+
+    {"type": "Refusal", "reason": "scope-gate: concurrency need — recommend Python concurrent.futures", "category": "scope-gate"}
+
 ## 8. Test
+
+### 8a. Human mode
 
 Offer the audit:
 
 > "Run `/build:check-shell <path>` to audit the scaffolded script
 > against the 14 lints plus `shellcheck` / `shfmt` (when installed)?"
+
+### 8b. `--as-tool` mode
+
+Skipped. The caller decides whether to chain to `check-shell`.
+
+## --as-tool contract
+
+**Required fields:**
+
+- `target-shell` — one of `bash-3.2-portable`, `bash-4+`, `bash-5+`, `posix-sh`.
+- `purpose` — one-sentence description of what the script does.
+- `invocation-style` — one of `cli`, `glue`, `library`.
+- `setuid` — `yes` or `no`. Controls shebang form.
+- `deps` — comma-separated list of runtime commands (or empty string for none). Populates `REQUIRED_CMDS`.
+
+`save-path` is **not** required under `--as-tool` — the caller owns the
+Save step and writes the file itself.
+
+**Return shape:** ARTIFACT.
+
+**Artifact types:** `text/x-shellscript`.
+
+**Success** — JSON envelope with `artifact_types: ["text/x-shellscript"]`
+and `metadata` carrying at minimum `target_shell` and `invocation_style`,
+followed by exactly one fenced ```bash block with the full scaffold.
+
+**NeedsMoreInfo** — JSON only (no fenced block): `missing: [...]` with
+the field names that were absent from `--as-tool` args; `hint:` a
+one-sentence reminder that `target-shell`, `purpose`, `invocation-style`,
+`setuid`, and `deps` are all required.
+
+**Refusal** — JSON only (no fenced block): `reason:` one-sentence
+explanation; `category:` one of `scope-gate` (FX.1 signal fired;
+`reason` cites the signal and its alternative recommendation),
+`invalid-combo` (inputs are internally inconsistent, e.g., setuid +
+posix-sh when setuid handling requires bash).
+
+**Side effects:** reads intake fields. No file writes, no `chmod`, no
+network, no external commands executed under `--as-tool`.
+
+**Parallel-safe:** yes.
 
 ## Anti-Pattern Guards
 
@@ -271,6 +362,16 @@ Offer the audit:
 
 ## Key Instructions
 
+- Under `--as-tool`: emit per the contract — a JSON envelope with
+  `artifact_types: ["text/x-shellscript"]` followed by one fenced
+  ```bash block carrying the scaffold. No prose, no preamble, no
+  approval step.
+- Under `--as-tool`: hard-fail with `NeedsMoreInfo` (JSON only) when
+  any of the five required fields is missing. Do not prompt — the
+  caller will retry with the missing field filled in.
+- `NeedsMoreInfo` and `Refusal` emit JSON only, never followed by a
+  fenced block. The failure envelope is identical across DATA and
+  ARTIFACT shapes — callers rely on this uniformity.
 - Refuse cleanly on FX.1 signals. Scaffolding a script when shell is
   the wrong tool actively harms the codebase — apologizing in comments
   afterward does not recover the harm.

--- a/plugins/build/skills/build-shell/SKILL.md
+++ b/plugins/build/skills/build-shell/SKILL.md
@@ -219,7 +219,7 @@ Present both artifacts to the user before any safety checks.
 
 ## 5. Safety Check
 
-Review the draft against the 14 lints `/build:check-shell` enforces,
+Review the draft against the 15 lints `/build:check-shell` enforces,
 grouped:
 
 **Portability.** Target-shell features match declaration. `mktemp`
@@ -301,7 +301,7 @@ unsatisfiable; JSON only, no fenced block):
 Offer the audit:
 
 > "Run `/build:check-shell <path>` to audit the scaffolded script
-> against the 14 lints plus `shellcheck` / `shfmt` (when installed)?"
+> against the 15 lints plus `shellcheck` / `shfmt` (when installed)?"
 
 ### 8b. `--as-tool` mode
 
@@ -398,4 +398,4 @@ invocation style, setuid intent, runtime dependencies, save path).
 **Produces:** an executable shell script at the user-supplied path
 plus a suggested invocation line.
 **Chainable to:** `/build:check-shell` (audit the scaffold against
-the 14 lints and available external tools).
+the 15 lints and available external tools).

--- a/plugins/build/skills/check-hook/SKILL.md
+++ b/plugins/build/skills/check-hook/SKILL.md
@@ -8,8 +8,10 @@ description: >
   "are my hooks safe".
 argument-hint: "[settings.json path]"
 user-invocable: true
+skill-invocable: true
 references:
   - references/platform-limitations.md
+  - ../../_shared/references/as-tool-contract.md
 ---
 
 # Check Hook
@@ -17,6 +19,17 @@ references:
 Inspect a project's Claude Code hooks configuration for coverage gaps,
 misconfigurations, unsafe patterns, and redundancy. Read-only — reports
 findings but does not modify any files.
+
+Two invocation modes:
+
+- **Human** — prompts for a path if none supplied, runs hook-specific
+  checks, invokes `/build:check-shell` per command-hook script for
+  shell-hygiene coverage, renders a merged findings table.
+- **`--as-tool`** — skill-caller mode. Structured DATA emission per
+  [`as-tool-contract.md`](../../_shared/references/as-tool-contract.md):
+  a single JSON envelope with `findings` merged from `check-hook` and
+  `check-shell` sources. Every finding carries `source:` so callers can
+  trace ownership.
 
 ## 1. Input
 
@@ -52,7 +65,35 @@ These checks target Claude Code (`settings.json` / `settings.local.json`). If th
 
 ## 4. Checks
 
-Run sixteen checks. For each configured hook, apply all relevant checks.
+Run thirteen hook-specific checks, plus delegate shell-hygiene coverage
+to `/build:check-shell` for every `"type": "command"` hook script.
+
+**Delegation to `check-shell`.** For each hook whose entry has
+`"type": "command"` and resolves to a script on disk, invoke:
+
+    /build:check-shell --as-tool path=<resolved hook-script path>
+
+Collect the returned `findings` and `external_tools` from each inner
+call. Merge the findings into the outer report under `source:
+"check-shell"`; retain the outer skill's findings under `source:
+"check-hook"`. The external-tool Missing Tools preamble from
+`check-shell` bubbles up unchanged — no hook-side tool detection
+needed.
+
+**Checks owned by `check-shell` (removed from this skill):**
+
+- Script safety preamble (`set -Eeuo pipefail`, `|| true` guards) —
+  covered by `check-shell` S11 + existing safety lints.
+- ShellCheck / shfmt integration — covered by `check-shell`'s external-tool
+  probe.
+- Script style conventions (stderr vs stdout, `[[` vs `[`, `set -x`,
+  shebang form) — covered by `check-shell`'s safety and style lints.
+- Unquoted variable expansion on payload-derived values — covered by
+  `check-shell` S1.
+
+The thirteen retained checks below focus on *hook-specific* semantics:
+tool_input payload handling, event-lifecycle correctness, blocking-intent
+discipline, and Claude Code configuration attack-surface concerns.
 
 ### 1. No hooks / PreToolUse gap
 
@@ -160,49 +201,54 @@ Flag as `warn` per pattern found.
 
 For each synchronous hook (no `async: true`), check whether the command calls an LLM, makes a network request, or runs a slow external process (e.g., `curl`, `claude`, a Python script that imports large models). Synchronous hooks block Claude while they run; slow hooks create session sluggishness that accumulates across a session and generates pressure to bypass hooks entirely. Flag as `warn` for any hook whose command string suggests a network call or LLM invocation in the hot path.
 
-### 11. Script safety preamble
+### 11. Injection safety (hook-payload specific)
 
-For each readable hook script (command type), check whether it begins with `set -Eeuo pipefail`. This preamble converts silent failures — commands exiting non-zero without aborting the script — into explicit exits. Flag as `warn` if absent. Also flag as `warn` any detection command (`grep`, `diff`, `test`, `[`) that appears outside an `if` condition without a `|| true` guard; these commands' legitimate non-zero exits trip `-e` and abort the hook prematurely, producing false-positive blocks on normal operations.
+For each hook script, flag as `fail` if the script passes a payload-derived variable to `eval` (e.g., `eval "$command"` where `command` is extracted from `tool_input`). Hook payloads are user-influenced — `tool_input.command` in Bash hooks reflects what the user asked Claude to run — and `eval` on user-controlled data is a shell injection vector with no safe sanitization path.
 
-### 12. Injection safety
+Evidence suggests bare command names (`jq`, `grep`) are susceptible to PATH override in adversarial environments — flag as `warn` for hooks defined in project-level `settings.json` (where any collaborator with commit access can influence the environment) or hooks with evidence of CI usage (e.g., a `.github/` directory exists), where PATH may be injected by the build environment (MODERATE confidence from a single T5 source).
 
-For each hook script, flag as `fail` if the script passes a payload-derived variable to `eval` (e.g., `eval "$command"` where `command` is extracted from `tool_input`). Hook payloads are user-influenced — `tool_input.command` in Bash hooks reflects what the user asked Claude to run — and `eval` on user-controlled data is a shell injection vector with no safe sanitization path. Also flag as `warn` for unquoted variable expansions on payload-derived values (`$var` instead of `"${var}"`); unquoted variables undergo word-splitting and globbing that payload content can exploit. Evidence suggests bare command names (`jq`, `grep`) are susceptible to PATH override in adversarial environments — flag as `warn` for hooks defined in project-level `settings.json` (where any collaborator with commit access can influence the environment) or hooks with evidence of CI usage (e.g., a `.github/` directory exists), where PATH may be injected by the build environment (MODERATE confidence from a single T5 source).
+*(Generic unquoted-variable findings are delegated to `check-shell` S1
+and surface under `source: "check-shell"` in the merged report.)*
 
-### 13. jq availability and field path correctness
+### 12. jq availability and field path correctness
 
 For each hook script that calls `jq`, check whether `jq` availability is verified before use (e.g., `command -v jq &>/dev/null`). Claude Code runs hooks with a restricted PATH; `jq` is not guaranteed on all systems. A missing `jq` causes the hook to fail in an uncontrolled way — silently passing (exit 0) or blocking everything (exit 2) — depending on script structure. Flag as `warn` if no availability check is present. Also check that jq field paths match the target tool's `tool_input` schema: `jq -r '.tool_input.command'` is correct for Bash hooks but returns `null` silently for Write hooks (`.tool_input.file_path`). Flag as `warn` for scripts whose matcher targets a tool whose `tool_input` structure differs from what the jq path assumes.
 
 If the hook may run on Copilot, flag as `fail`: Copilot serializes tool arguments as `toolArgs` (a JSON string), not as `tool_input` (an object). Hooks using `jq '.tool_input.*'` fail silently on Copilot — cross-platform hooks require a platform detection branch or separate configurations.
 
-### 14. ShellCheck static analysis
+*(ShellCheck and shfmt integration — previously checks 14 — are now
+delegated to `check-shell`'s external-tool probe; findings surface
+under `source: "check-shell"`. Generic script-style findings —
+previously check 15: stderr vs stdout, `[[` vs `[`, `set -x`, shebang
+form — are also delegated to `check-shell`.)*
 
-For each hook script (command type), check whether there is evidence it has been run through ShellCheck (e.g., a CI step, a pre-commit hook, or a comment). ShellCheck is the de facto static analysis standard for bash — it catches quoting issues, deprecated backtick syntax, incorrect conditionals, and command misuse. Flag as `warn` if no ShellCheck integration is apparent. Note: ShellCheck passing is a floor, not a ceiling — wrong exit code intent and incorrect jq field paths are logic errors invisible to static analysis.
-
-Also flag as `warn` if ShellCheck appears to be disabled wholesale (e.g., `# shellcheck disable` with no rule number, or ShellCheck absent from CI). Hook scripts commonly trigger false positives on jq-assigned variables (SC2034) and intentionally single-quoted JSON strings (SC2016) — these should be suppressed inline or via `.shellcheckrc`, not by disabling ShellCheck entirely.
-
-Also flag as `warn` if `shfmt` is absent from the project's formatting or CI pipeline alongside ShellCheck. ShellCheck catches bugs; `shfmt` enforces consistent formatting — both together constitute complete static analysis coverage for bash hook scripts.
-
-### 15. Script style conventions
-
-Evidence suggests several MODERATE-confidence style conventions reduce silent failures in hook scripts. Flag as `warn` if: (a) error or blocking messages go to stdout rather than stderr (`>&2`) — stdout is for structured JSON output on exit 0; stderr is what Claude reads on blocking exits and what appears in the transcript; (b) conditionals use `[` instead of `[[` in bash scripts — `[[` does not word-split unquoted variables and supports `=~` for regex matching; (c) `set -x` appears in a committed hook script — in production it floods stderr with trace output and can leak sensitive payload values; (d) the shebang is `#!/bin/bash` rather than `#!/usr/bin/env bash` — the `env` form locates whichever `bash` is active in `$PATH` and is more portable across NixOS, Homebrew-managed bash, and other non-standard installations where bash is not at `/bin/bash`.
-
-### 16. settings.json as attack surface
+### 13. settings.json as attack surface
 
 Check whether hooks are defined in project-level `.claude/settings.json` (checked into the repo) versus `.claude/settings.local.json` (gitignored, personal only). Project-level hook entries execute automatically on any developer who opens the repo — a collaborator with commit access can inject arbitrary commands (CVE-2025-59536). Flag as `warn` for any hook in project `settings.json` that has not been treated with the same code-review scrutiny as executable source files. Flag as `warn` if security-sensitive hooks (credentials protection, command blocking) live in `settings.json` where they are also visible and modifiable by the full team — suggest moving personal-only enforcement to `settings.local.json`.
 
 ## 5. Report
 
-Present findings as a table with a summary count at the top:
+### 5a. Human mode
+
+Present findings as a table with a summary count at the top. Include a
+`source` column so hook-specific findings (from `check-hook`) and
+shell-hygiene findings (delegated to `check-shell`) are distinguishable
+at a glance:
 
 ```
 N issues across M hooks (X fail, Y warn)
 
-event          | hook command          | check             | finding
----------------+-----------------------+-------------------+---------------------------
-PostToolUse    | .claude/hooks/gate.sh | Event coverage    | PostToolUse cannot block; use PreToolUse for enforcement
-Stop           | .claude/hooks/stop.sh | Stop hook loop    | No stop_hook_active guard — infinite loop risk
-PostToolUse    | lint-after-write.sh   | Async + blocking  | async:true with exit 2 — hook will never block
+source       | event          | hook command          | check             | finding
+-------------+----------------+-----------------------+-------------------+---------------------------
+check-hook   | PostToolUse    | .claude/hooks/gate.sh | Event coverage    | PostToolUse cannot block; use PreToolUse for enforcement
+check-hook   | Stop           | .claude/hooks/stop.sh | Stop hook loop    | No stop_hook_active guard — infinite loop risk
+check-shell  | -              | .claude/hooks/gate.sh | S1                | Unquoted ${TOOL_NAME} expansion (line 12)
+check-hook   | PostToolUse    | lint-after-write.sh   | Async + blocking  | async:true with exit 2 — hook will never block
 ```
+
+The `external_tools` Missing Tools preamble from `check-shell` surfaces
+unchanged at the top of the report when any of `shellcheck` / `shfmt` /
+`checkbashisms` is absent.
 
 If cross-platform gaps were identified in Platform Scope, append a separate section to the report:
 ```
@@ -212,6 +258,78 @@ If cross-platform gaps were identified in Platform Scope, append a separate sect
 If no issues are found, confirm:
 > "Hooks look well-configured."
 
+### 5b. `--as-tool` mode
+
+Emit a single JSON envelope — no fenced blocks, no prose. Schema:
+
+    {"type": "Success", "value": {
+      "settings_path": ".claude/settings.json",
+      "summary": {"fail": 1, "warn": 4, "total": 5},
+      "findings": [
+        {"source": "check-hook", "check": "4", "severity": "fail", "event": "Stop", "hook": ".claude/hooks/stop.sh", "line": null, "message": "No stop_hook_active guard — infinite loop risk"},
+        {"source": "check-shell", "lint": "S1", "severity": "fail", "event": null, "hook": ".claude/hooks/gate.sh", "line": 12, "message": "Unquoted ${TOOL_NAME} expansion"}
+      ],
+      "external_tools": {
+        "shellcheck": {"present": true, "output": "..."},
+        "shfmt":      {"present": false, "install_hint": "..."}
+      }
+    }}
+
+Rules:
+
+- `source` ∈ `{"check-hook", "check-shell"}` on every finding — callers
+  rely on it to attribute the finding to the owning skill.
+- `check-hook` findings carry a `check` field (numeric, as a string);
+  `check-shell` findings carry a `lint` field (e.g., `"S1"`, `"S11"`).
+- `event` is set on `check-hook` findings when the finding is
+  event-specific; `null` otherwise. `check-shell` findings always
+  carry `event: null`.
+- `line` is `null` for findings that are not line-scoped (most
+  `check-hook` findings; some `check-shell` file-level findings).
+- `external_tools` bubbles up the merged set from each inner
+  `check-shell` call. When the same tool is absent across all inner
+  calls, emit it once with a single `install_hint`.
+- `findings` are ordered by severity (fail first), then by source
+  (check-hook before check-shell for the same severity), then by hook
+  path and line.
+
+Zero-findings case: same envelope with `summary: {"fail": 0, "warn": 0, "total": 0}`
+and `findings: []`.
+
+## --as-tool contract
+
+**Required fields:**
+
+- `settings-path` — path to `.claude/settings.json` (or
+  `.claude/settings.local.json`, or an explicit user-supplied settings
+  file). No default under `--as-tool`; human mode retains the
+  dual-path default behavior.
+
+**Return shape:** DATA.
+
+**Success** — JSON envelope with `value` carrying `settings_path`,
+`summary`, `findings` (merged from `check-hook` and `check-shell`
+sources; every entry carries `source`), and `external_tools` (bubbled
+up from inner `check-shell` calls). See §5b for the full schema.
+
+**NeedsMoreInfo** — JSON only: `missing: ["settings-path"]`, `hint:`
+reminder that `settings-path` is the sole required field.
+
+**Refusal** — JSON only: `reason:` one-sentence explanation;
+`category:` one of `file-not-found` (settings path absent or
+unreadable), `no-hooks` (file loaded but contains no `hooks:` key),
+`parse-error` (settings JSON is malformed).
+
+**Side effects:** reads the file at `settings-path`; scans `CLAUDE.md`
+(if present) for rule-overlap detection; invokes
+`/build:check-shell --as-tool path=<hook-script>` once per `"type":
+"command"` hook script referenced by the settings file. Read-only on
+the filesystem.
+
+**Parallel-safe:** yes. Inner `check-shell` calls are parallel-safe;
+concurrent outer calls on the same `settings-path` are redundant but
+correct.
+
 ## Anti-Pattern Guards
 
 1. **Treating rule overlap as always wrong** — hook + CLAUDE.md duplication can be intentional belt-and-suspenders; flag for user decision, don't recommend removal
@@ -220,6 +338,17 @@ If no issues are found, confirm:
 
 ## Key Instructions
 
+- Under `--as-tool`: emit per the contract — a single JSON envelope
+  with a `value` object carrying merged `findings` (each with a
+  `source` field) and `external_tools`. No fenced blocks, no prose,
+  no preamble.
+- Under `--as-tool`: hard-fail with `NeedsMoreInfo` (JSON only) when
+  `settings-path` is missing. Do not prompt — the caller will retry.
+- `NeedsMoreInfo` and `Refusal` emit JSON only, never followed by
+  fenced blocks.
+- Every finding carries a `source` field — `"check-hook"` or
+  `"check-shell"` — so callers can trace ownership across the
+  delegation boundary.
 - Read-only — do not modify any files; report findings only
 - Always run Primitive Routing before numbered checks, even when no hooks are configured
 - Stop hook loop risk (check 4) is a fail, not a warn — an unguarded blocking Stop hook creates an infinite loop that requires a session kill to recover

--- a/plugins/build/skills/check-shell/SKILL.md
+++ b/plugins/build/skills/check-shell/SKILL.md
@@ -236,7 +236,7 @@ state. Severity: **warn**. Fix: `<<'EOF'` for literal help text.
 
 `echo "Error: ..."` without `>&2`. Errors on stdout poison pipelines
 that consume the script's output. Severity: **warn**. Fix: `echo "..." >&2`
-or `printf '...\n' >&2`.
+or `printf 'message\n' >&2`.
 
 ## 5. Report
 

--- a/plugins/build/skills/check-shell/SKILL.md
+++ b/plugins/build/skills/check-shell/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: check-shell
 description: >
-  Audits a general-purpose shell script against 14 curated lints grouped
+  Audits a general-purpose shell script against 15 curated lints grouped
   into Portability / Safety / Documentation, detects and merges findings
   from shellcheck / shfmt / checkbashisms when present, and surfaces a
   Missing Tools preamble with install hints when any are absent. Use
@@ -10,16 +10,28 @@ description: >
   script safe". Not for hook scripts — route to `/build:check-hook`.
 argument-hint: "[script path]"
 user-invocable: true
+skill-invocable: true
 references:
   - references/external-tools.md
+  - ../../_shared/references/as-tool-contract.md
 ---
 
 # Check Shell
 
 Inspect a general-purpose shell script for portability, safety, and
-documentation problems. Run 14 curated lints plus output from
+documentation problems. Run 15 curated lints plus output from
 `shellcheck` / `shfmt` / `checkbashisms` when they are installed.
 Read-only — reports findings but does not modify the script.
+
+Two invocation modes:
+
+- **Human** — prompts for a path if none supplied, runs the lints and
+  external tools, renders a findings table with the Missing Tools
+  preamble.
+- **`--as-tool`** — skill-caller mode. Structured DATA emission per
+  [`as-tool-contract.md`](../../_shared/references/as-tool-contract.md):
+  a single JSON envelope carrying `findings` and `external_tools`. No
+  prompts, no rendering.
 
 This skill is not for Claude Code hooks — `/build:check-hook` owns that
 lifecycle. Route there when the script is wired to a hook event.
@@ -87,7 +99,7 @@ the visibility of the preamble at the top of the report.
 
 ## 4. Checks
 
-Run 14 lints scoped to the detected target shell, plus output from
+Run 15 lints scoped to the detected target shell, plus output from
 whichever external tools are available. Each lint entry below names
 the pattern, why it is wrong, severity, and fix guidance.
 
@@ -179,6 +191,16 @@ Variables assigned inside a function leak to global scope when
 `local` is omitted. Severity: **warn**. Fix: declare with `local`
 (bash) or use a subshell `( ... )` (POSIX sh).
 
+#### S11. Missing strict-mode preamble
+
+Script does not begin (after the shebang and header) with
+`set -Eeuo pipefail` (bash targets) or `set -eu` (`posix-sh` target).
+Without strict mode, commands that exit non-zero proceed silently and
+unset-variable dereferences expand to empty strings, producing actions
+on wrong inputs. Severity: **warn**. Fix: add the appropriate
+strict-mode line near the top of the script; bash targets should also
+carry `IFS=$'\n\t'` when the script handles whitespace-heavy input.
+
 ### Documentation
 
 #### D1. Missing top-of-file header
@@ -218,6 +240,8 @@ or `printf '...\n' >&2`.
 
 ## 5. Report
 
+### 5a. Human mode
+
 Present findings as a table, preceded by the Missing Tools preamble
 when applicable. Summary count at the top:
 
@@ -235,12 +259,46 @@ Documentation | D1   | Missing top-of-file header                  | -
 ```
 
 When `shellcheck`, `shfmt`, or `checkbashisms` were run, append their
-output as a separate section below the 14-lint table (one section per
+output as a separate section below the 15-lint table (one section per
 tool), preserving the tool's native output format so the user can
 correlate with upstream documentation.
 
-If zero findings: "Script looks clean (against the 14 lints and the
+If zero findings: "Script looks clean (against the 15 lints and the
 available external tools)."
+
+### 5b. `--as-tool` mode
+
+Emit a single JSON envelope — no fenced blocks, no prose. Schema:
+
+    {"type": "Success", "value": {
+      "path": "scripts/foo.sh",
+      "target_shell": "bash-3.2-portable",
+      "summary": {"fail": 2, "warn": 3, "total": 5},
+      "findings": [
+        {"group": "Safety", "lint": "S1", "severity": "fail", "line": 57, "message": "Unquoted $INPUT expansion"},
+        {"group": "Documentation", "lint": "D1", "severity": "warn", "line": null, "message": "Missing top-of-file header"}
+      ],
+      "external_tools": {
+        "shellcheck":    {"present": true,  "output": "..."},
+        "shfmt":         {"present": false, "install_hint": "brew install shfmt | apt install shfmt"},
+        "checkbashisms": {"present": false, "install_hint": "apt install devscripts"}
+      }
+    }}
+
+Rules:
+
+- `severity` ∈ `{fail, warn}`; identical to the human-mode catalog.
+- `line` is `null` for file-level findings (e.g., missing header).
+- `external_tools` carries one entry per tool probed (`shellcheck`,
+  `shfmt`, `checkbashisms`). When present, `output` carries the tool's
+  raw stdout as a string so the caller can surface it verbatim. When
+  absent, `install_hint` carries the platform-specific install command
+  from the human-mode Missing Tools preamble.
+- `findings` are ordered by severity (fail first) then by line number
+  ascending.
+
+Zero-findings case: same envelope with `summary: {"fail": 0, "warn": 0, "total": 0}`
+and `findings: []`.
 
 ## 6. Handoff
 
@@ -253,11 +311,38 @@ Only suggest this when the severity mix is heavy on `fail`-level
 structural issues; for a handful of `warn` findings, the user should
 fix in place.
 
+## --as-tool contract
+
+**Required fields:**
+
+- `path` — filesystem path to the shell script to audit.
+
+**Return shape:** DATA.
+
+**Success** — JSON envelope with a `value` object carrying `path`,
+`target_shell` (detected or `"ambiguous"` if inference failed),
+`summary` (counts by severity), `findings` (flat array per the schema
+in §5b), and `external_tools` (per-tool availability + raw output or
+install hint).
+
+**NeedsMoreInfo** — JSON only (no fenced block): `missing: ["path"]`,
+`hint:` a reminder that `path` is the sole required field.
+
+**Refusal** — JSON only: `reason:` one-sentence explanation; `category:`
+one of `file-not-found` (path doesn't exist or isn't readable),
+`not-a-shell-script` (shebang absent or non-shell; e.g., `#!/usr/bin/env python3`).
+
+**Side effects:** reads the file at `path`; probes `PATH` for
+`shellcheck`, `shfmt`, `checkbashisms`; executes whichever are present
+against the script. Read-only on the filesystem — no writes, no `chmod`.
+
+**Parallel-safe:** yes.
+
 ## Anti-Pattern Guards
 
 1. **Hard-failing on a missing external tool** — a missing
    `shellcheck` should produce a Missing Tools block, not an error
-   exit. The 14 FX lints run independently of tool availability.
+   exit. The 15 FX lints run independently of tool availability.
 2. **Silent coverage-gap reporting** — the Missing Tools block must be
    prominent (top of report, named tools, install commands, coverage
    gap description). A one-liner note at the end fails the fail-fast
@@ -270,9 +355,17 @@ fix in place.
 
 ## Key Instructions
 
+- Under `--as-tool`: emit per the contract — a single JSON envelope with
+  a `value` object carrying `findings` and `external_tools`. No fenced
+  blocks, no prose, no preamble. Failure envelopes are JSON-only too.
+- Under `--as-tool`: hard-fail with `NeedsMoreInfo` (JSON only) when
+  `path` is missing. Do not prompt.
+- `NeedsMoreInfo` and `Refusal` emit JSON only. Never emit a fenced
+  block on a failure path — the envelope is uniform across DATA and
+  ARTIFACT shapes.
 - Read-only: report findings only; do not write, edit, or reformat
   the script under audit.
-- Always run all 14 FX lints, even when every external tool is
+- Always run all 15 FX lints, even when every external tool is
   available — the FX lints catch things shellcheck does not (filename
   drift, undocumented exits, `mktemp`-before-`trap`, bare TODO).
 - The Missing Tools preamble is part of the contract. If a relevant


### PR DESCRIPTION
## Summary

- Opts four skills into `skill-invocable: true`: `build-shell` (ARTIFACT, `text/x-shellscript`), `check-shell` (DATA), `build-hook` (MULTI-ARTIFACT, `text/x-shellscript + application/json`), `check-hook` (DATA).
- Hook pair delegates shell concerns to the shell pair via the settled `--as-tool` contract:
  - `build-hook` Draft step calls `/build:build-shell --as-tool` (pinned `target-shell=bash-3.2-portable`), then layers hook-specific content (`INPUT=$(cat)`, `jq tool_input` extraction, `updatedInput` JSON contract).
  - `check-hook` Checks step calls `/build:check-shell --as-tool` per `"type": "command"` hook script; findings merged under `source: "check-hook"` / `source: "check-shell"` labels.
- `check-shell` gains lint **S11: missing strict-mode preamble (warn)** — closes the delegation gap when `check-hook` drops its preamble audit.
- `check-hook` renumbered: retains 13 hook-specific checks; removes old 11, 14, 15 fully and old 12's unquoted-variable portion (all delegated to `check-shell`). Notes in the plan document the old → new mapping.
- Build plugin bumped 0.5.0 → 0.6.0. No breaking change to human-mode invocation surface.
- Pre-existing D6 false-positive on `check-shell` line 217 (`..\n` in `printf '...\n'` matched `_check_body_paths`'s Windows-path regex) fixed opportunistically.

Design: `.designs/2026-04-20-hook-shell-as-tool-delegation.design.md`
Plan: `.plans/2026-04-20-hook-shell-as-tool-delegation.plan.md`

Closes #327.

## Test plan

- [x] `/build:check-skill` self-audit passes on all four modified SKILL.md files (0 fail)
- [x] Repo-wide SKILL.md audit: 0 fails across all skills
- [x] Python tests: 140 passing (`pytest plugins/build/tests/`)
- [ ] CI green (ruff + pytest)
- [ ] Smoke — `build-shell --as-tool`: valid ARTIFACT envelope + one ```bash fenced block
- [ ] Smoke — `check-shell --as-tool`: valid DATA envelope with `findings` including S11 on a preamble-less fixture
- [ ] Smoke — `build-hook --as-tool`: valid MULTI-ARTIFACT envelope + two fenced blocks (`bash`, then `json`), `metadata` with exactly `{hook_event, matcher, handler_type}`
- [ ] Smoke — `check-hook --as-tool`: valid DATA envelope with `findings` carrying `source` labels from both skills
- [ ] Human-mode regression spot-check on each of the four skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)