### PR TITLE
feat(build): slug-based topic resolver for shared references

### DIFF
--- a/plugins/build/_shared/references/primitive-routing.md
+++ b/plugins/build/_shared/references/primitive-routing.md
@@ -1,6 +1,8 @@
 ---
 name: Primitive Routing Guide
 description: Decision framework for choosing the right Claude Code primitive — rules, skills, hooks, subagents, CLAUDE.md, or permissions.deny. Referenced by all build-* skills as a shared routing gate.
+topic: primitive-routing
+applies-to: [build-hook, build-skill, build-rule, build-subagent]
 ---
 
 # Primitive Routing Guide

--- a/plugins/build/skills/build-hook/SKILL.md
+++ b/plugins/build/skills/build-hook/SKILL.md
@@ -8,8 +8,8 @@ description: >
   after tool use", or "block dangerous operations automatically".
 argument-hint: "[hook event] [enforcement goal]"
 user-invocable: true
-references:
-  - ../../_shared/references/primitive-routing.md
+needs:
+  - primitive-routing
 ---
 
 # Build Hook

--- a/plugins/build/skills/build-rule/SKILL.md
+++ b/plugins/build/skills/build-rule/SKILL.md
@@ -5,7 +5,8 @@ argument-hint: A topic name or description of the convention to capture
 user-invocable: true
 references:
   - references/rule-format-guide.md
-  - ../../_shared/references/primitive-routing.md
+needs:
+  - primitive-routing
 ---
 
 # /build:build-rule

--- a/plugins/build/skills/build-skill/SKILL.md
+++ b/plugins/build/skills/build-skill/SKILL.md
@@ -12,7 +12,8 @@ tested_with: [sonnet]
 references:
   - references/platform-notes.md
   - references/skill-writing-guide.md
-  - ../../_shared/references/primitive-routing.md
+needs:
+  - primitive-routing
 ---
 
 # Skill Creator

--- a/plugins/build/skills/build-subagent/SKILL.md
+++ b/plugins/build/skills/build-subagent/SKILL.md
@@ -9,8 +9,8 @@ description: >
   or "make a custom agent".
 argument-hint: "[subagent name or description]"
 user-invocable: true
-references:
-  - ../../_shared/references/primitive-routing.md
+needs:
+  - primitive-routing
 ---
 
 # Build Subagent


### PR DESCRIPTION
## Summary

Demonstration PR for the **information-resolver pattern** described in `.research/2026-04-21-resolvers.research.md`. Replaces hardcoded relative paths with topic-slug addressing for `primitive-routing`, the first shared reference in the repo.

**Before.** Each consumer carried the producer's path:

```yaml
# plugins/build/skills/build-hook/SKILL.md
references:
  - ../../_shared/references/primitive-routing.md
```

A rename or move of `primitive-routing.md` touched all four consumer `SKILL.md` files.

**After.** Consumers declare *what they need* by slug, not *where it lives*:

```yaml
# plugins/build/skills/build-hook/SKILL.md
needs:
  - primitive-routing
```

The producer is now self-describing:

```yaml
# plugins/build/_shared/references/primitive-routing.md
---
name: Primitive Routing Guide
description: ...
topic: primitive-routing
applies-to: [build-hook, build-skill, build-rule, build-subagent]
---
```

Resolution is convention-based (mechanism `a` in the research doc): slug `X` resolves to `plugins/<plugin>/_shared/references/X.md`. A rename now touches the producer's filename + its `topic:` field; consumers stay unchanged.

## Files touched (5)

- `plugins/build/_shared/references/primitive-routing.md` — added `topic:` and `applies-to:`
- `plugins/build/skills/build-hook/SKILL.md` — `references:` → `needs:`
- `plugins/build/skills/build-skill/SKILL.md` — removed shared ref from `references:`; added `needs:`; kept per-skill `references:` entries
- `plugins/build/skills/build-rule/SKILL.md` — same as `build-skill`
- `plugins/build/skills/build-subagent/SKILL.md` — same as `build-hook`

Per-skill local `references/` paths (e.g. `references/platform-notes.md` in `build-skill`) are intentionally unchanged — the migration is scoped to cross-cutting shared references.

## Out of scope (follow-ups)

- `/build-resolver` — skill that authors a canonical doc at the convention path, adds the slug to each consumer's `needs:`, and runs `/check-resolver` on completion.
- `/check-resolver` — deterministic skill-graph linter (slug resolution, orphan producers, duplicate topics, mixed-mode `references:` + `needs:` flag, plugin-scope isolation). Prior art: `mlc`, `markdown-link-check`.
- No tooling currently reads `needs:` — this PR establishes the convention in files. Until `/check-resolver` lands, the `needs:` field is declarative only.

## Test plan

- [ ] Visual diff review — confirm every removed `references:` line had exactly `../../_shared/references/primitive-routing.md` (no behavior change expected from Claude Code today since `needs:` isn't yet consumed by any tool).
- [ ] `grep -r "primitive-routing" plugins/build/` to confirm no stale paths remain.
- [ ] Decide whether `needs:` is the right frontmatter key, or if it should be `consumes:` / `requires:` / something else before the convention spreads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)