### PR TITLE
Add build-python-script / check-python-script skill pair (build-0.7.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,27 +3,15 @@
 <!-- wiki:begin -->
 ## Context Navigation
 
-- `.context/` -- Project context documents covering domain knowledge, patterns, and conventions.
-- `.plans/` -- Implementation plans for toolkit features.
-- `.prompts/` -- Saved and refined prompts for skill development and maintenance tasks.
-- `.research/` -- Research investigations using the SIFT framework.
+Each directory has an `_index.md` listing all files with descriptions.
+- `.context/_index.md` -- Project context documents covering domain knowledge, patterns, and conventions.
+- `.plans/_index.md` -- Implementation plans for toolkit features.
+- `.prompts/_index.md` -- Saved and refined prompts for skill development and maintenance tasks.
+- `.research/_index.md` -- Research investigations using the SIFT framework.
 
 Each `.md` file starts with YAML metadata (between `---` lines).
 Read the `description` field before reading the full file.
 Documents put key insights first and last; supplemental detail in the middle.
-
-### Plugin Structure
-
-| Plugin | Path | Skills |
-|--------|------|--------|
-| `build` | `plugins/build/` | `build-skill`, `build-rule`, `build-hook`, `build-subagent`, `build-shell`, `refine-prompt`, `check-skill`, `check-rule`, `check-hook`, `check-subagent`, `check-shell`, `check-skill-chain` |
-| `wiki` | `plugins/wiki/` | `setup`, `research`, `ingest`, `lint` |
-| `work` | `plugins/work/` | `scope-work`, `plan-work`, `start-work`, `verify-work`, `finish-work` |
-| `consider` | `plugins/consider/` | 16 mental models + meta |
-
-Each plugin's skills live at `plugins/<plugin>/skills/<name>/SKILL.md`.
-Python package: `plugins/wiki/src/wiki/` (editable install).
-Shared scripts: `plugins/wiki/scripts/`.
 
 ### Areas
 | Area | Path |
@@ -53,12 +41,26 @@ LLMs lose attention mid-document — first and last sections are what agents ret
 - Context files target 200-800 words. Over 800, consider splitting.
 - One concept per file. Multiple distinct topics should be separate files.
 - Link bidirectionally — if A references B in `related`, B should reference A.
+<!-- wiki:end -->
 
-### Preferences
+## Plugin Structure
+
+| Plugin | Path | Skills |
+|--------|------|--------|
+| `build` | `plugins/build/` | `build-skill`, `build-rule`, `build-hook`, `build-subagent`, `build-shell`, `build-python-script`, `refine-prompt`, `check-skill`, `check-rule`, `check-hook`, `check-subagent`, `check-shell`, `check-python-script`, `check-skill-chain` |
+| `wiki` | `plugins/wiki/` | `setup`, `research`, `ingest`, `lint` |
+| `work` | `plugins/work/` | `scope-work`, `plan-work`, `start-work`, `verify-work`, `finish-work` |
+| `consider` | `plugins/consider/` | 16 mental models + meta |
+
+Each plugin's skills live at `plugins/<plugin>/skills/<name>/SKILL.md`.
+Python package: `plugins/wiki/src/wiki/` (editable install).
+Shared scripts: `plugins/wiki/scripts/`.
+
+## Preferences
+
 - **Directness:** Be direct. State problems and disagreements plainly without hedging or softening.
 - **Verbosity:** Keep responses concise. Skip preamble and unnecessary elaboration.
 - **Depth:** Explain the reasoning and principles behind recommendations. Help me learn, not just execute.
-<!-- wiki:end -->
 
 ## Working Agreements
 

--- a/plugins/build/.claude-plugin/plugin.json
+++ b/plugins/build/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "build",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Skills for creating and refining Claude Code skills, rules, hooks, and subagents.",
   "author": {
     "name": "Brandon Beidel"

--- a/plugins/build/_shared/references/primitive-routing.md
+++ b/plugins/build/_shared/references/primitive-routing.md
@@ -73,3 +73,30 @@ Wrong-primitive failures don't announce themselves as configuration errors. They
 ---
 
 **Diagnostic for existing failures:** Paste the failing rule as the first message (outside CLAUDE.md). If Claude follows it there but not in CLAUDE.md — the issue is primitive delivery, change the primitive. If Claude still doesn't follow it — the issue is the rule itself, rewrite it. This isolates whether you have a delivery problem or a quality problem.
+
+## Language Selection — when the answer is "a script"
+
+When the routing test lands on "a script" (glue code, a CLI tool, a hook body), one more decision follows: shell or Python? Both are scripts; they fail in different directions.
+
+**Pick shell when:**
+- The task is *glue* — stitching CLI tools (`git`, `curl`, `jq`, `find`, `xargs`) through pipelines
+- The task is genuinely one-shot and will not acquire business logic
+- The work operates on text streams, not structured records
+- The execution environment cannot be relied on to ship Python (bare containers, minimal CI images)
+
+**Pick Python when:**
+- The task manipulates structured data — arrays of typed records, nested JSON, schema-validated payloads
+- Projected logic exceeds ~100 LOC of business code (not counting help or boilerplate)
+- The script needs testable seams — `pytest` against `main()`
+- Real error recovery is required — typed exceptions, retry with backoff, context managers
+- Cross-platform correctness matters — Windows compatibility, path normalization
+- The work needs concurrency, or calls HTTP APIs with JSON and retry semantics
+- The argument surface has subcommands or interdependent flags
+
+**Cost axes.** Shell scripts are genuinely painful to unit-test; if the script lives past a quarter, Python's testing story pays back. Pure-POSIX shell runs anywhere; a Python script with third-party deps needs a virtualenv, a PEP 723 runner, or `pipx`. Shell fails silently (unquoted variables, `set -e` surprises, broken pipes ignored); Python fails loudly (`ImportError`, typed exceptions). Pick based on which failure mode your environment catches better.
+
+**Tiebreaker.** When the decision is genuinely balanced — 20–100 LOC of mixed glue and light logic, no strong environment constraint — **pick Python**. Interpretability wins: `subprocess.run([...], check=True)` reads more clearly than `cmd1 | while IFS= read -r line; do ...`, and the next maintainer will thank you.
+
+**Escalation — start as a script, graduate to a package.** Either language: when the script grows a second entry point, acquires shared state across invocations, runs as a long-lived service, or its test coverage exceeds its code, convert to a proper package. Both Scope Gates flag these signals explicitly.
+
+Route: `/build:build-shell` for shell; `/build:build-python-script` for Python.

--- a/plugins/build/_shared/references/python-scripts-best-practices.md
+++ b/plugins/build/_shared/references/python-scripts-best-practices.md
@@ -1,0 +1,119 @@
+---
+name: Python Scripts Best Practices
+description: Authoring guide for standalone Python 3 scripts — what makes a script load-bearing in production, how to shape the file, the positive patterns that work, and the safety and maintenance posture. Referenced by build-python-script and check-python-script.
+---
+
+# Python Scripts Best Practices
+
+## What a Good Python Script Does
+
+A Python script is a single-file program that runs from the shell, does one clear thing, and returns a useful exit code. It reads its inputs explicitly, writes primary data to stdout and diagnostics to stderr, and stays composable in pipelines and automation. The value proposition is narrow: a script earns its place when the work is too small for a package, too repeatable for a one-off notebook, and needs to be honest about success and failure to its caller.
+
+Primitive selection — shell script vs. Python script vs. a proper package — is adjacent to this document. This guide assumes a single-file Python script is the right tool and focuses on making it a *good* one.
+
+## Anatomy
+
+```python
+#!/usr/bin/env python3
+"""One-line synopsis. Example: ./fetch_rates.py --source usd --out rates.csv"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="…")
+    parser.add_argument("--out", type=Path, required=True, help="Output path.")
+    args = parser.parse_args(argv)
+    try:
+        with args.out.open("w", encoding="utf-8") as out:
+            ...
+        return 0
+    except KeyboardInterrupt:
+        return 130
+    except (FileNotFoundError, ValueError) as err:
+        print(f"error: {err}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+Load-bearing pieces: the shebang and executable bit, the module docstring, the imports at module scope, the `main()` that returns an exit code, and the `__main__` guard that delegates via `sys.exit(main())`. Third-party dependencies are declared in a colocated `requirements.txt` or a PEP 723 `# /// script` block — scripts are expected to be reproducible on a fresh machine.
+
+## Authoring Principles
+
+**Make the entry point explicit.** Start with `#!/usr/bin/env python3`, set the executable bit, and wrap execution in a `main()` function returning an `int`, invoked via `if __name__ == "__main__": sys.exit(main())`. The guard keeps the script importable for testing; the `sys.exit(main())` wiring makes the exit contract honest. A shebang without `chmod +x` is a lie a reader will catch later than they should.
+
+**Document intent at the top.** The first statement is a module docstring that names the script's purpose and shows one example invocation. It is often the only documentation the next reader has. Inside functions, comments explain *why* a non-obvious choice was made; comments that restate what the code does rot alongside the code.
+
+**Parse arguments with `argparse` from the standard library.** Every argument carries a non-empty `help=` string; validation lives in `type=` and `choices=` where applicable. Manual `sys.argv` slicing loses `--help`, usage errors, and typed conversions for no gain. Reach for `click` or `typer` only when subcommands, rich help, or shell completion genuinely require them.
+
+**Treat I/O as a contract.** Primary output goes to stdout; logs, errors, and prompts go to stderr. Specify `encoding="utf-8"` on every text-mode `open()` call — the platform default has produced silent corruption on every production system long enough to have one. Use `pathlib.Path` for filesystem paths and context managers (`with`) for any resource that needs cleanup.
+
+**Fail loud, fail early, return meaningful codes.** Return 0 on success and non-zero on failure. Validate inputs before performing destructive work. Catch specific exceptions where you can recover and let the rest surface with a concise stderr message; reserve full tracebacks for a `--debug` flag. Handle `KeyboardInterrupt` at the top level and exit without a traceback — a script that dumps Python internals on Ctrl+C is user-hostile.
+
+**Prefer the standard library.** `argparse`, `pathlib`, `json`, `csv`, `subprocess`, `logging`, `tempfile`, and `http.client` cover most scripting needs and ship on every Python install. When a third-party dependency earns its place, declare it explicitly — PEP 723 inline metadata or a colocated `requirements.txt` — so the script stays reproducible. Unused imports come out.
+
+**Keep the module scope disciplined.** Imports, constants, class and function definitions, and the `__main__` guard are what belong at the top level. Configuration is passed as arguments, not assigned to module globals. A script that mutates module state at import time resists both testing and reuse.
+
+**Name intent into the code.** Functions and variables state what they represent; numeric and string literals that carry meaning get named constants (`TIMEOUT_SECONDS`, `MAX_RETRIES`, `DEFAULT_PAGE_SIZE`). Single-letter names belong to loop counters and well-established math conventions, not to module scope. Readers spend more time interpreting names than the author spends writing them.
+
+**Keep functions small and single-purpose.** A function does one coherent thing at one level of abstraction. Helper functions make `main()` scannable — the entry point reads as a list of named operations, not a flat wall of logic. When a function sprouts conjunctions in its name (`parse_and_validate_and_write`), it is two functions pretending to be one.
+
+**Eliminate duplication.** Two similar lines is not a problem; three near-identical blocks is. Extract a function and give it a name. Duplication is the easiest bug multiplier to fix at authoring time and the most expensive one to fix after the copies drift.
+
+**Hold the safety posture.** Never pass `shell=True` to subprocess calls, especially with interpolated input. Never use `eval` or `exec` on external input. Use `tempfile` for temporary paths — `/tmp/foo_{pid}` constructions invite races and symlink attacks. Keep paths, credentials, and hostnames out of the script body; read them from arguments or the environment.
+
+**Dress the style.** Format with an automated formatter (`ruff format` or `black`) and leave the line-length debate there. Add type hints to function signatures — they are documentation that doesn't drift and they enable static analysis downstream. Prefer f-strings for formatting; avoid wildcard imports.
+
+## Patterns That Work
+
+These are the positive shapes a durable script tends to take. Each one corresponds to a failure mode the audit rubric catches.
+
+**Stdlib-first dependencies over "grab whatever."** Small surface area is its own feature.
+
+**Explicit exit codes over "it probably worked."** Callers in cron, CI, and Make depend on the contract.
+
+**Stdout for data, stderr for chatter.** One decision that makes scripts composable for years.
+
+**Pathlib over `os.path` strings.** Object-oriented paths remove a class of bugs.
+
+**Context managers over manual close.** Cleanup on exceptions, guaranteed.
+
+**Named constants over magic literals.** A value named `HTTP_TIMEOUT_SECONDS` teaches the reader what it means.
+
+**Small functions over long ones.** Short functions with specific names read as their own commentary.
+
+**Arguments over module globals.** Testable, explicit, and portable across invocations.
+
+**F-strings over `%` or `.format()`.** Clearer to read, faster to execute, harder to mis-quote.
+
+**Specific exceptions over `Exception`.** Catch what you can recover from; surface what you can't.
+
+**PEP 723 or `requirements.txt` over undocumented deps.** The next person to run this is not you.
+
+## Safety
+
+Scripts run with the invoker's privileges and reach the filesystem, the network, and subprocesses. The safety rules are non-negotiable.
+
+- **No `shell=True` on interpolated input.** Pass argument lists; shell injection is trivial and real.
+- **No `eval` or `exec` on external input.** Remote-code-execution from a helpful one-liner.
+- **Validate inputs before destructive work.** A `--dry-run` flag for anything that deletes or overwrites is cheap insurance.
+- **`tempfile` for temporary paths.** Race conditions and symlink attacks are real and easily avoided.
+- **No hardcoded credentials, hostnames, or absolute paths.** Arguments or environment variables carry those.
+- **Safe parsers for untrusted structured input.** `yaml.safe_load`, not `yaml.load`; JSON over pickle from any untrusted source.
+
+Shell-injection, `eval`/`exec`, and literal `/tmp/` path construction are audited deterministically. The remaining rules rely on author judgment — deterministic detection of "is this input validated enough before the delete?" is infeasible — and live in the authoring rubric and code review.
+
+## Review and Decay
+
+Scripts rot. The platform `python3` moves, third-party APIs change, the shell environment the script assumed goes away. Retire a script when it stops being invoked, when its functionality migrates into a package or service, or when its exit contract can no longer be trusted. Convert to a package when the single file acquires shared state, multiple entry points, or test coverage heavier than the code itself — single-file discipline breaks down past a threshold, and fighting it produces a worse package than starting one would. A neglected script is worse than a missing one — callers trust the exit code they have stopped checking.
+
+---
+
+**Diagnostic when a script misbehaves.** First check the shape: shebang, executable bit, `main()` returning an int, `__main__` guard delegating to it. Then check the contract: does it write data to stdout and diagnostics to stderr? Does it exit non-zero on every failure path? If shape and contract are right, check the scope: is the logic split into small, named functions, or is one function carrying the whole script? Most pathologies live in one of those three places.

--- a/plugins/build/pyproject.toml
+++ b/plugins/build/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "check"
-version = "0.6.0"
+version = "0.7.0"
 description = "Claude Code plugin for auditing Claude Code skills and rules for quality issues."
 requires-python = ">=3.9"
 dependencies = []

--- a/plugins/build/skills/build-python-script/SKILL.md
+++ b/plugins/build/skills/build-python-script/SKILL.md
@@ -1,0 +1,365 @@
+---
+name: build-python-script
+description: >
+  Scaffolds a standalone Python 3 script — a single-file CLI tool,
+  automation helper, or data-wrangling utility — with shebang, module
+  docstring, `main(argv) -> int`, `__main__` guard via `sys.exit(main())`,
+  argparse parser, KeyboardInterrupt handling, and declared dependencies.
+  Use when the user wants to "create a python script", "scaffold a
+  python script", "write a CLI script in python", "new python script",
+  or "build an automation script in python". Not for long-running
+  services, packages with multiple modules, or Claude Code hooks — route
+  to the appropriate primitive instead.
+argument-hint: "[purpose]"
+user-invocable: true
+references:
+  - ../../_shared/references/python-scripts-best-practices.md
+  - ../../_shared/references/primitive-routing.md
+---
+
+# Build Python Script
+
+Scaffold a standalone Python 3 script: a single-file program that runs
+from the shell, does one clear thing, and returns a useful exit code.
+The authoring rubric — what makes a script load-bearing, the anatomy
+template, patterns that work — lives in
+[python-scripts-best-practices.md](../../_shared/references/python-scripts-best-practices.md).
+This skill is the workflow; the principles doc is the rubric.
+
+This skill is not for Claude Code hooks (`/build:build-hook` owns that
+lifecycle), not for shell one-liners (`/build:build-shell`), and not for
+multi-module Python packages (scripting discipline breaks down past a
+threshold; start a proper package instead).
+
+**Workflow sequence:** 1. Route → 2. Scope Gate → 3. Elicit →
+4. Draft → 5. Safety Check → 6. Review Gate → 7. Save → 8. Test
+
+## 1. Route
+
+Confirm a standalone Python script is the right primitive *and* that
+Python is the right language before asking scaffold-specific questions.
+
+**Wrong primitive:**
+
+- **Event-triggered quality enforcement** (PreToolUse, SessionStart,
+  Stop, etc.) → `/build:build-hook`. Hooks have a `settings.json`
+  registration, a `tool_input` payload contract, and lifecycle
+  semantics a standalone script doesn't express.
+- **A Claude Code skill definition** → `/build:build-skill`.
+- **A semantic judgment captured as an LLM-evaluated rule** →
+  `/build:build-rule`.
+
+**Wrong language — should be shell instead:**
+
+- Task is pure glue — stitching `git` / `curl` / `jq` / `find` /
+  `xargs` through a pipeline, no structured data
+- Task is genuinely one-shot and will not grow business logic
+- Execution environment cannot be relied on to ship Python (bare
+  containers, minimal CI images)
+
+The full language-selection decision lives in the *Language Selection*
+section of
+[primitive-routing.md](../../_shared/references/primitive-routing.md) —
+consult it when the choice is not obvious. **Tiebreaker rule from that
+doc:** when the decision is genuinely balanced, Python wins on
+interpretability.
+
+**Right primitive and right language** (CLI tool, data-wrangling helper,
+automation utility, one-shot job with structured data or >100 LOC of
+business logic, work that benefits from `pytest` against `main()`) →
+proceed to Scope Gate.
+
+## 2. Scope Gate
+
+Refuse to scaffold — and recommend an alternative — when the request
+signals Python-script is the wrong tool. Probe for any of:
+
+1. **Multiple entry points or long-running service** — a daemon, a web
+   server, or anything with more than one callable surface is a
+   package, not a script. Recommend starting `pyproject.toml` +
+   `src/<pkg>/` layout.
+2. **Test coverage heavier than the code** — if the author is planning
+   to write more test code than script code, the workflow wants a
+   package with proper module boundaries. Single-file scripts trade
+   testability for portability; if testability is the priority, pay
+   the package cost.
+3. **Shared state across invocations** — databases, long-lived
+   connections, on-disk caches the script owns. Scripts are stateless
+   units; persistent state belongs in a service or package.
+4. **Hot path / performance-critical** — a script invoked thousands of
+   times per second loses to the import-time overhead. Recommend a
+   daemon + IPC or a compiled tool.
+5. **Cross-platform GUI or system-tray integration** — Python scripts
+   don't handle GUI packaging cleanly. Recommend the user pick a
+   platform-native toolkit.
+
+If any signal fires, state the signal, name the recommended
+alternative, and stop. Do not proceed to Elicit.
+
+## 3. Elicit
+
+If `$ARGUMENTS` is non-empty, parse it as `[purpose]` and pre-fill the
+purpose field. Otherwise ask, one question at a time:
+
+**1. Purpose** — one sentence: what does this script do? Preferably
+verb-phrased ("fetch daily exchange rates and write them to a CSV").
+
+**2. Invocation style** — pick one:
+- `cli` — accepts flags and positional args via `argparse`; has
+  `--help` output. Default for anything a human invokes.
+- `glue` — fixed positional args, called from a Makefile or another
+  script. Minimal argparse surface.
+- `library` — importable for testing (`from <script> import main`) but
+  also runnable directly via the `__main__` guard. The default
+  structure already supports this; pick when the user will write
+  `pytest` against `main()`.
+
+**3. Input shape** — where does the script read from?
+- `args` — filenames or values passed as positional arguments.
+- `stdin` — reads from stdin, supports `-` as stdin sentinel.
+- `none` — no input beyond flags.
+
+**4. Output destination** — where does primary output go?
+- `stdout` — default; data to stdout, logs to stderr. Composable in
+  pipelines.
+- `file` — writes to a path provided via `--out`. Pair with
+  `encoding="utf-8"`.
+- `none` — the script is called for its side effects (e.g., network
+  calls).
+
+**5. Destructive operations?** — does the script delete, overwrite,
+move files, or make irreversible network calls? If yes, the scaffold
+adds a `--dry-run` flag (default true) and a `--yes` confirmation
+flag. If no, those are omitted.
+
+**6. Third-party dependencies** — any non-stdlib imports? If yes,
+collect the list and pick the declaration mechanism:
+- `pep723` — inline `# /// script` block at the top of the file. Best
+  for portable single-file scripts run via `uv run` or `pipx run`.
+- `requirements` — a colocated `requirements.txt`. Best when the
+  script ships with a README or test fixtures.
+- `comment` — a top-of-file comment block. Accept as a fallback.
+- `none` — stdlib-only (prefer this when feasible; most scripting
+  needs are met by `argparse`, `pathlib`, `json`, `csv`,
+  `subprocess`, `logging`, `http.client`, `tempfile`).
+
+**7. Save path** — where should the script land? No default; common
+homes: `scripts/`, `bin/`, `plugins/<name>/scripts/`,
+`.github/scripts/`. Ask explicitly.
+
+## 4. Draft
+
+Produce two artifacts.
+
+**Artifact 1: The script.**
+
+One conditionalized template. Sections marked *(if destructive)* or
+*(if pep723)* are omitted when the intake rules them out.
+
+```python
+#!/usr/bin/env python3
+"""<one-line synopsis>.
+
+Example:
+    ./<progname> <typical args>
+"""
+
+# /// script                                     # (if pep723)
+# requires-python = ">=3.10"
+# dependencies = [
+#   "<dep>==<version>",
+# ]
+# ///
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+LOG = logging.getLogger(__name__)
+EXIT_USAGE = 2
+EXIT_INTERRUPTED = 130
+
+
+def get_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="<one-line purpose>",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--input", type=Path, required=True, help="Input path.")
+    parser.add_argument("--out", type=Path, required=True, help="Output path.")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print planned actions; take none.")       # (if destructive)
+    parser.add_argument("-v", "--verbose", action="count", default=0,
+                        help="Increase log verbosity (repeatable).")
+    return parser
+
+
+def run(args: argparse.Namespace) -> int:
+    # <body — split into small functions as the script grows>
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = get_parser().parse_args(argv)
+    logging.basicConfig(
+        level=logging.WARNING - 10 * min(args.verbose, 2),
+        stream=sys.stderr,
+        format="%(levelname)s %(message)s",
+    )
+    try:
+        return run(args)
+    except KeyboardInterrupt:
+        return EXIT_INTERRUPTED
+    except (FileNotFoundError, ValueError) as err:
+        print(f"error: {err}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+*(if pep723)* Include the `# /// script` block between the docstring
+and the imports. Omit the colocated `requirements.txt` reference —
+PEP 723 is self-contained.
+
+*(if not destructive)* Omit the `--dry-run` argument. The rest stays.
+
+*(library invocation style)* No scaffold changes — the default
+structure (`main(argv)` parameterized, module-scope side-effect-free,
+`__main__` guard) already supports `from <script> import main` for
+testing.
+
+**Artifact 2: A suggested invocation line** — how the user or a
+Makefile would call the script, ready to paste. Include the
+`chmod +x` step so the shebang + executable-bit contract holds.
+
+Present both artifacts to the user before any safety checks.
+
+## 5. Safety Check
+
+Review the draft against the rubric in
+[python-scripts-best-practices.md](../../_shared/references/python-scripts-best-practices.md)
+before presenting. Group the checks:
+
+**Structure.** Shebang is exactly `#!/usr/bin/env python3`. Module
+docstring is the first statement and shows at least one example
+invocation. `main()` signature returns an `int`. The `__main__` guard
+delegates via `sys.exit(main())`. `except KeyboardInterrupt` is present
+at the top level.
+
+**I/O contract.** Primary output goes to stdout; errors and logs go to
+stderr. Text-mode `open()` calls carry `encoding="utf-8"`. Filesystem
+paths use `pathlib.Path`, not `os.path` strings. Context managers
+(`with`) wrap any resource needing cleanup.
+
+**Arguments.** `argparse` is imported (not manual `sys.argv` slicing).
+Every `add_argument` carries a non-empty `help=` string. Validation
+lives in `type=` and `choices=` where applicable.
+
+**Safety.** No `shell=True` in subprocess calls. No `eval` / `exec`.
+No hardcoded `/tmp/` or `/var/tmp/` path literals (use `tempfile`
+instead). No hardcoded credentials, hostnames, or absolute paths —
+those come from arguments or `os.environ.get()`.
+
+**Dependencies.** If any non-stdlib import is present, dependencies
+are declared (PEP 723 block, colocated `requirements.txt`, or
+top-of-file comment). No wildcard imports. No unused imports.
+
+If any check fails, revise the draft before presenting. The Review
+Gate is for user approval, not correctness recovery — safety issues
+get fixed in the draft, not at the gate.
+
+## 6. Review Gate
+
+Present both artifacts (script + invocation line) and wait for
+explicit user approval before writing any file to disk. Write only
+after this gate passes.
+
+If the user requests changes, revise and re-present. Continue until
+the user explicitly approves or cancels. Proceed to Save only on
+explicit approval.
+
+## 7. Save
+
+Write the approved script to the path elicited in Step 3.6. Mark it
+executable:
+
+```bash
+chmod +x <path>
+```
+
+A shebang without `+x` is a lie — the executable bit is part of the
+contract the principles doc names. Show the suggested invocation line
+for the user to wire into a Makefile, CI config, or README.
+
+If PEP 723 was picked, no extra files are needed. If `requirements`
+was picked, scaffold `<parent>/requirements.txt` next to the script
+(create if absent, append if not).
+
+## 8. Test
+
+Offer the audit:
+
+> "Run `/build:check-python-script <path>` to audit the scaffolded
+> script against the deterministic checks and the judgment dimensions?"
+
+The audit is the canonical follow-on; running it once after scaffold
+catches anything the Safety Check missed and gives the user a
+baseline-clean starting point.
+
+## Anti-Pattern Guards
+
+1. **Skipping the Scope Gate** — always probe the five signals before
+   Elicit. Scaffolding a single-file script when the workflow wants a
+   package pushes technical debt into the repo that will be expensive
+   to pay down later.
+2. **Leaving dependencies undeclared** — scripts that import
+   third-party packages without a PEP 723 block, `requirements.txt`,
+   or top-of-file comment block are not reproducible. The intake
+   explicitly elicits the declaration mechanism; populate it.
+3. **Omitting the KeyboardInterrupt handler** — a script that dumps a
+   traceback on Ctrl+C is user-hostile, and this is a detail authors
+   routinely forget. The scaffold includes it by default; do not
+   strip it for brevity.
+4. **Hand-waving `--dry-run`** — if Intake step 3.5 flagged destructive
+   operations, the draft must wire `args.dry_run` into the actual
+   destructive code path, not just accept the flag and ignore it.
+   Show the `if args.dry_run: ...` branch in the `run()` body.
+5. **Skipping the Review Gate** — write to disk only after explicit
+   user approval. Present both artifacts first.
+
+## Key Instructions
+
+- Refuse cleanly on Scope Gate signals. Scaffolding a script when a
+  package is the right tool creates a conversion cost someone has to
+  pay later.
+- Write files to disk only after the Review Gate passes.
+- Elicit the save path from the user. Do not invent one.
+- The `--dry-run` flag is only scaffolded when Intake step 3.5 flagged
+  destructive operations. Do not add it unconditionally — it clutters
+  read-only scripts.
+- When Intake picks `pep723`, use only the PEP 723 block — a second
+  declaration (colocated `requirements.txt`) creates two sources of
+  truth.
+- Won't scaffold scripts for Claude Code hook events — route to
+  `/build:build-hook`.
+- Won't scaffold when any Scope Gate signal fires — recommend the
+  appropriate alternative instead.
+- Recovery if a script is written in error: `rm <path>` removes it
+  cleanly. The scaffold is self-contained (no settings.json entry, no
+  shared-module registration), so removal leaves no dangling state.
+
+## Handoff
+
+**Receives:** user intent for a Python script (purpose, invocation
+style, input shape, output destination, destructive-op flag,
+third-party dependencies + declaration mechanism, save path).
+**Produces:** an executable Python script at the user-supplied path
+plus a suggested invocation line; optionally a `requirements.txt`
+when that declaration mechanism was picked.
+**Chainable to:** `/build:check-python-script` (audit the scaffolded
+script against the deterministic checks and judgment dimensions).

--- a/plugins/build/skills/build-shell/SKILL.md
+++ b/plugins/build/skills/build-shell/SKILL.md
@@ -11,6 +11,7 @@ argument-hint: "[target-shell] [purpose]"
 user-invocable: true
 references:
   - references/scope-gate.md
+  - ../../_shared/references/primitive-routing.md
 ---
 
 # Build Shell
@@ -29,20 +30,40 @@ lifecycle. Route there when the script has an event trigger and
 
 ## 1. Route
 
-Determine whether a general-purpose shell script is the right primitive
-before asking scaffold-specific questions.
+Confirm a general-purpose shell script is the right primitive *and*
+that shell is the right language before asking scaffold-specific
+questions.
 
-- **Goal is event-triggered quality enforcement** (PreToolUse, SessionStart,
-  Stop, etc.) → suggest `/build:build-hook` instead. Hooks have a
-  `settings.json` registration, a `tool_input` payload contract, and
-  lifecycle semantics this skill does not handle.
-- **Goal is a Claude Code skill definition** (markdown with frontmatter,
-  invoked by slash command) → suggest `/build:build-skill` instead.
-- **Goal is a semantic judgment captured as an LLM-evaluated rule** →
-  suggest `/build:build-rule` instead.
-- **Goal is a general-purpose automation or CLI script** (glue, setup,
-  CI step, utility called by humans or Makefiles) → proceed to Scope
-  Gate.
+**Wrong primitive:**
+
+- **Event-triggered quality enforcement** (PreToolUse, SessionStart,
+  Stop, etc.) → `/build:build-hook`. Hooks have a `settings.json`
+  registration, a `tool_input` payload contract, and lifecycle
+  semantics a shell script doesn't express.
+- **A Claude Code skill definition** (markdown with frontmatter,
+  invoked by slash command) → `/build:build-skill`.
+- **A semantic judgment captured as an LLM-evaluated rule** →
+  `/build:build-rule`.
+
+**Wrong language — should be Python instead:**
+
+- Task manipulates structured data — arrays of typed records, nested
+  JSON, schema-validated payloads
+- Projected logic exceeds ~100 LOC of business code
+- Task needs testable seams (`pytest` against `main()`)
+- Task needs concurrency, HTTP with retry / JSON, or cross-platform
+  correctness (Windows)
+
+The full language-selection decision lives in the *Language Selection*
+section of
+[primitive-routing.md](../../_shared/references/primitive-routing.md) —
+consult it when the choice is not obvious. **Tiebreaker rule from that
+doc:** when the decision is genuinely balanced, Python wins on
+interpretability.
+
+**Right primitive and right language** (glue, setup, CI step, utility
+called by humans or Makefiles; POSIX-tool pipelines; one-shot
+automation) → proceed to Scope Gate.
 
 ## 2. FX.1 Scope Gate
 

--- a/plugins/build/skills/check-python-script/SKILL.md
+++ b/plugins/build/skills/check-python-script/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: check-python-script
+description: >
+  Audits a standalone Python 3 script against 22 deterministic checks
+  (shebang, `__main__` guard, argparse shape, declared dependencies,
+  ruff-backed AST lints, line count, secret patterns) plus nine
+  judgment dimensions (output discipline, input validation, dependency
+  posture, performance intent, naming, function design, module-scope
+  discipline, literal intent, commenting intent). Use when the user
+  wants to "audit a python script", "check my python script",
+  "review this script", "lint a python script", "is this script
+  safe", "what's wrong with my script", or "why is my script
+  failing". Not for general-purpose shell scripts — route to
+  `/build:check-shell`.
+argument-hint: "[path]"
+user-invocable: true
+references:
+  - ../../_shared/references/python-scripts-best-practices.md
+  - references/audit-dimensions.md
+  - references/repair-playbook.md
+---
+
+# Check Python Script
+
+Audit a standalone Python 3 script for structural soundness, safety,
+and adherence to the project's Python-script conventions. The rubric
+— what makes a script load-bearing, the anatomy template, patterns
+that work — lives in
+[python-scripts-best-practices.md](../../_shared/references/python-scripts-best-practices.md).
+This skill is the audit workflow; the principles doc is what it
+audits against.
+
+The audit runs in three tiers. **Tier-1** is deterministic — six shell
+scripts run per target and emit fixed-format findings. **Tier-2** is a
+single locked-rubric LLM call per target evaluating all nine
+[audit dimensions](references/audit-dimensions.md) at once; dimensions
+that don't apply return PASS silently, so every target gets the full
+pass. **Tier-3** is cross-entity collision detection — when the scope
+holds multiple scripts in the same directory, check for duplicated
+logic the maintainer could consolidate.
+
+## Workflow
+
+1. Scope → 2. Tier-1 Deterministic Checks → 3. Tier-2 Judgment
+Checks → 4. Tier-3 Cross-Entity Collision → 5. Report → 6. Opt-In
+Repair Loop.
+
+### 1. Scope
+
+Read `$ARGUMENTS`:
+
+- **Single path to a `.py` file** — audit that file.
+- **Directory path** — walk the directory, audit every `.py` at the
+  top level; do not recurse into sub-packages (scripts are flat by
+  definition).
+- **Empty** — refuse and explain: this skill operates on a target,
+  not a configuration.
+
+Confirm the scope aloud before proceeding (one line: "Auditing
+<path> (N scripts found)"). Miscounted scope is one of the most
+common report-confusion signals.
+
+### 2. Tier-1 Deterministic Checks
+
+Run six scripts in sequence against each target. Each exits `0`
+on clean / WARN / INFO and `1` on one or more FAIL; do not stop on
+any script's FAIL exit — all six contribute findings to the merge.
+
+```bash
+SCRIPTS="${SKILL_DIR}/scripts"   # resolved by Claude at invocation
+TARGETS="$ARGUMENTS"
+
+bash "$SCRIPTS/check_secrets.sh"   $TARGETS   # FAIL: any secret pattern — excludes file from Tier-2
+bash "$SCRIPTS/check_structure.sh" $TARGETS   # FAIL: shebang / guard-missing / guard-shape; WARN: main-returns, KeyboardInterrupt; INFO: exec bit
+bash "$SCRIPTS/check_argparse.sh"  $TARGETS   # WARN: argparse-when-argv, add-argument help=, subprocess check=True
+bash "$SCRIPTS/check_deps.sh"      $TARGETS   # WARN: non-stdlib import without declared-deps mechanism
+bash "$SCRIPTS/check_ruff.sh"      $TARGETS   # FAIL: E722/F403/S108/S307/S602; WARN: others; INFO if ruff absent
+bash "$SCRIPTS/check_size.sh"      $TARGETS   # WARN: line count over 500
+```
+
+The scripts and their helper `_ast_checks.py` live next to `SKILL.md`
+under `scripts/` and are executable. Claude resolves `${SKILL_DIR}`
+from the skill's own directory at invocation time — hooks use
+`$CLAUDE_PLUGIN_ROOT`, but skills do not.
+
+**Script-to-check map** (what each script covers, from
+Section 5 of the ensemble synthesis):
+
+| Script | Checks |
+|---|---|
+| `check_secrets.sh` | API keys, tokens, private URLs (toolkit convention) |
+| `check_structure.sh` | shebang, `__main__` guard invokes `sys.exit(main())`, `main()` returns int, `except KeyboardInterrupt`, exec bit |
+| `check_argparse.sh` | `argparse` imported when `sys.argv` used past `[0]`, every `add_argument` has non-empty `help=`, `subprocess.run(..., check=True)` or result inspected |
+| `check_deps.sh` | declared dependencies (requirements.txt, PEP 723 block, or top-of-file comment) when non-stdlib import present |
+| `check_ruff.sh` | wraps `ruff check` for D100, E722, SIM115, PLW1514, PTH, S602/S604, S307, F401, ANN, UP031/UP032, F403, S108, plus `ruff format --check`; emits INFO + exits 0 if ruff absent |
+| `check_size.sh` | script length ≤ 500 non-blank lines |
+
+**Exit-code contract every script honors:** `0` on clean / WARN /
+INFO / HINT-only; `1` on one or more FAIL; `64` on argument error;
+`69` on missing required dependency (not ruff — ruff is optional).
+
+**FAIL findings that exclude the file from Tier-2** (evaluation is
+not useful until these are resolved):
+
+- Any finding from `check_secrets.sh` (secrets present)
+- Python `SyntaxError` surfaced by any AST-parsing script
+- `check_ruff.sh` FAILs on `S307` (eval/exec), `S602` (shell=True),
+  `S108` (`/tmp/` literal), `E722` (bare except), `F403` (wildcard
+  import)
+
+**FAIL findings that do NOT exclude from Tier-2:** shebang malformed,
+`__main__` guard missing or mis-shaped. These leave a parseable
+script that Tier-2 can still evaluate productively.
+
+**WARN / INFO / HINT findings never exclude.** They surface in the
+report alongside Tier-2 findings. HINT lines (if a pre-filter is ever
+added — Phase 9 of the synthesis-to-skill-pair workflow) feed into
+the Tier-2 prompt as pre-evaluation context so the judge does not
+rediscover the same signal; they are not themselves repair targets.
+
+### 3. Tier-2 Judgment Checks
+
+For each file that passed the Tier-2-exclusion filter, make a single
+LLM call against the audit rubric in
+[audit-dimensions.md](references/audit-dimensions.md). All nine
+dimensions run together — no trigger gating. A dimension that doesn't
+apply (e.g., Performance intent on a script that never reads a file)
+returns PASS silently.
+
+The nine dimensions:
+
+| Dimension | What it judges |
+|---|---|
+| D1 Output Discipline | Does data go to stdout and chatter to stderr; do error paths actually exit non-zero; is `logging` used for operational messages? |
+| D2 Input Validation | Are inputs validated before destructive work; do deletes/overwrites gate on `--dry-run` or confirmation; are credentials externalized? |
+| D3 Dependency Posture | When a third-party dep is imported, is it justified, or would stdlib suffice? |
+| D4 Performance Intent | Does the script `.read()` a whole file it only iterates, or materialize lists it only iterates? |
+| D5 Naming | Do names state intent; are single-letter names confined to loop counters and math? |
+| D6 Function Design | Does each function do one thing at one level of abstraction; are near-identical blocks extracted to helpers? |
+| D7 Module-Scope Discipline | Does module scope hold only imports, constants, defs, and the guard — no side-effecting calls or mutable state? |
+| D8 Literal Intent | Do numeric/string literals carrying meaning have named-constant homes? |
+| D9 Commenting Intent | Do comments explain why rather than restate what; are TODOs owned? |
+
+Feed the file contents plus any Tier-1 HINT lines (if added later as
+pre-filters) into the prompt. Parse the model's response into the
+fixed lint format (one finding per dimension at most; dimensions that
+PASS produce no finding).
+
+### 4. Tier-3 Cross-Entity Collision
+
+When the scope holds multiple scripts (directory walk, step 1), check
+for structural duplication the maintainer could consolidate:
+
+- Two or more scripts sharing the same module docstring or example
+  invocation line (likely copy-paste drift)
+- Identical or near-identical `get_parser()` functions across scripts
+  (candidate for a shared helper module)
+- Identical or near-identical error-handling patterns that should live
+  in a shared `utils.py`
+
+Report collisions as INFO findings — they are maintainer guidance,
+not failures. Single-script scope skips this tier.
+
+### 5. Report
+
+Emit a unified findings table sorted by severity (FAIL > WARN > INFO
+> HINT), then by file path. Deduplicate exact-match findings at merge
+time — a Python `SyntaxError` surfaces from every AST-parsing script
+(structure, argparse, deps), which is expected but noisy unless
+reduced to one row.
+
+```
+SEVERITY  <path> — <check>: <detail>
+  Recommendation: <specific change>
+```
+
+Summary line at top and bottom: `N fail, N warn, N info across N
+scripts`. If any file was excluded from Tier-2, name it and the
+exclusion-trigger finding.
+
+### 6. Opt-In Repair Loop
+
+After presenting findings, ask:
+
+> "Apply fixes? Enter `y` (all), `n` (skip), or comma-separated
+> finding numbers."
+
+For each selected finding, follow the recipe in
+[repair-playbook.md](references/repair-playbook.md):
+
+1. Read the relevant section of the target file.
+2. Propose a minimal specific edit — fix the finding without
+   restructuring surrounding code.
+3. Show the diff.
+4. Write the change only on explicit user confirmation.
+5. Re-run the Tier-1 script that produced the finding; confirm it
+   passes.
+
+Per-change confirmation is non-negotiable. Bulk application removes
+the user's ability to review individual edits.
+
+## Anti-Pattern Guards
+
+1. **Running Tier-2 before Tier-1** — deterministic checks are cheap
+   and authoritative; running them first avoids spending LLM calls on
+   files that should have been excluded.
+2. **Trigger-gating Tier-2 dimensions** — all nine dimensions run on
+   every file. A dimension that doesn't apply returns PASS silently.
+   Conditional dimensions produce inconsistent rubrics across runs
+   and make findings non-comparable.
+3. **Applying all repair fixes in one batch** — per-finding
+   confirmation is required. The user loses the ability to review
+   individual edits in a bulk apply.
+4. **Auditing a directory recursively** — scripts are single-file by
+   definition; recursing into sub-packages pulls in library code that
+   the script rubric doesn't model. Top-level `.py` only.
+5. **Skipping the re-run after a fix** — Step 5 of the repair loop
+   re-runs the script that produced the finding. A fix that produces
+   a new finding elsewhere is more common than it sounds.
+
+## Key Instructions
+
+- Tier-1 scripts run first and always. Tier-2 runs only on files that
+  passed the Tier-2-exclusion filter.
+- All nine Tier-2 dimensions are evaluated on every non-excluded file.
+  A dimension that does not apply returns PASS silently.
+- Repairs require per-finding confirmation — each change writes
+  individually and waits for explicit approval before the next.
+- When a Tier-1 script reports missing dependencies (exit 69), surface
+  the dependency name and install hint to the user; do not silently
+  skip.
+- When `ruff` is absent, `check_ruff.sh` emits an INFO line naming the
+  reduced coverage and exits 0. Continue with the other scripts.
+- Won't modify files without per-change confirmation — the audit is
+  read-only by default; repair fixes opt in one at a time.
+- Won't audit paths outside `$ARGUMENTS` — the scope the user named is
+  the only scope.
+- Recovery if a repair edit produces a worse state: the edit is a
+  single file change; revert with `git checkout -- <path>` or the
+  editor's undo.
+
+## Handoff
+
+**Receives:** Path to a single `.py` file or a directory holding `.py`
+scripts at the top level.
+**Produces:** Structured findings table in the lint format
+(`SEVERITY  <path> — <check>: <detail>` with a `Recommendation:`
+follow-up line); optionally, targeted edits applied to the audited
+script(s) after per-finding confirmation.
+**Chainable to:** `/build:build-python-script` (rebuild from scratch
+after flagged repairs if the repair loop surfaces structural issues
+bigger than point fixes).

--- a/plugins/build/skills/check-python-script/references/audit-dimensions.md
+++ b/plugins/build/skills/check-python-script/references/audit-dimensions.md
@@ -1,0 +1,253 @@
+---
+name: Audit Dimensions — Python Scripts
+description: The complete check inventory for check-python-script — Tier-1 deterministic check table (22 checks grouped across 6 scripts) and Tier-2 judgment dimension specifications (9 dimensions, each citing its source principle). Referenced by the check-python-script workflow.
+---
+
+# Audit Dimensions
+
+The check-python-script audit runs in three tiers. This document is
+the inventory: every deterministic check Tier-1 emits, every
+judgment dimension Tier-2 evaluates. Every dimension cites the source
+principle it audits from
+[python-scripts-best-practices.md](../../../_shared/references/python-scripts-best-practices.md).
+
+## Tier-1 — Deterministic Checks
+
+Six scripts, 22 checks. Each script emits findings in the fixed lint
+format (`SEVERITY  <path> — <check>: <detail>` + `Recommendation:`).
+Exit codes: `0` clean / WARN / INFO / HINT-only; `1` on FAIL; `64`
+arg error; `69` missing dependency.
+
+| Script | Check ID | What | Severity | Source principle |
+|---|---|---|---|---|
+| `check_secrets.sh` | `secret` | API keys, tokens, private URLs via regex pattern list | FAIL | Safety — "No secrets" (toolkit convention) |
+| `check_structure.sh` | `shebang` | First line is exactly `#!/usr/bin/env python3` | FAIL | Make the entry point explicit |
+| `check_structure.sh` | `guard-missing` | `if __name__ == "__main__":` guard exists at module top level | FAIL | Make the entry point explicit |
+| `check_structure.sh` | `guard-shape` | guard body invokes `sys.exit(main())` (not just `main()`) | FAIL | Make the entry point explicit |
+| `check_structure.sh` | `syntax` | file parses as Python (emitted by the AST helper when `ast.parse` raises) | FAIL | Fail loud, fail early, return meaningful codes |
+| `check_structure.sh` | `main-returns` | `main()` signature returns an `int` | WARN | Make the entry point explicit |
+| `check_structure.sh` | `keyboard-interrupt` | `except KeyboardInterrupt` handler at top level of `main()` | WARN | Fail loud, fail early, return meaningful codes |
+| `check_structure.sh` | `exec-bit` | Executable bit set when shebang is present | INFO | Make the entry point explicit |
+| `check_argparse.sh` | `argparse-when-argv` | `argparse` imported when `sys.argv` accessed past `[0]` | WARN | Parse arguments with argparse |
+| `check_argparse.sh` | `add-argument-help` | Every `add_argument()` call carries a non-empty `help=` | WARN | Parse arguments with argparse |
+| `check_argparse.sh` | `subprocess-check` | `subprocess.run()` includes `check=True` or inspects the return | WARN | Hold the safety posture |
+| `check_deps.sh` | `declared-deps` | 3rd-party imports are declared (PEP 723 block, colocated `requirements.txt`, or top-of-file comment) | WARN | Prefer the standard library |
+| `check_ruff.sh` | `ruff-D100` | Module docstring present | WARN | Document intent at the top |
+| `check_ruff.sh` | `ruff-E722` | No bare `except:` | FAIL | Fail loud, fail early, return meaningful codes |
+| `check_ruff.sh` | `ruff-SIM115` | Context manager wraps `open()` calls | WARN | Treat I/O as a contract |
+| `check_ruff.sh` | `ruff-PLW1514` | `encoding="utf-8"` on text-mode `open()` | WARN | Treat I/O as a contract |
+| `check_ruff.sh` | `ruff-PTH` | `pathlib.Path` over `os.path` string manipulation | WARN | Treat I/O as a contract |
+| `check_ruff.sh` | `ruff-S602` / `ruff-S604` | No `shell=True` in subprocess calls (both rule codes cover the same pattern) | FAIL | Hold the safety posture |
+| `check_ruff.sh` | `ruff-S307` | No `eval` / `exec` | FAIL | Hold the safety posture |
+| `check_ruff.sh` | `ruff-F401` | No unused imports | WARN | Prefer the standard library |
+| `check_ruff.sh` | `ruff-ANN` | Type hints on function signatures | WARN | Dress the style |
+| `check_ruff.sh` | `ruff-format` | `ruff format --check` passes | WARN | Dress the style |
+| `check_ruff.sh` | `ruff-UP031-UP032` | f-strings over `%` / `.format()` | WARN | Dress the style |
+| `check_ruff.sh` | `ruff-F403` | No wildcard imports | FAIL | Dress the style |
+| `check_ruff.sh` | `ruff-S108` | No hardcoded `/tmp/` or `/var/tmp/` path literals | FAIL | Hold the safety posture |
+| `check_size.sh` | `size` | Script length ≤ 500 non-blank lines | WARN | Keep functions small and single-purpose (script-level) |
+
+**FAIL exclusions from Tier-2.** Any `secret`, `syntax` (Python
+`SyntaxError`), `ruff-S307`, `ruff-S602` / `ruff-S604`, `ruff-S108`,
+`ruff-E722`, or `ruff-F403` finding excludes the file from Tier-2.
+Other FAILs (`shebang`, `guard-missing`, `guard-shape`) leave a
+parseable script that judgment can still evaluate productively.
+
+## Tier-2 — Judgment Dimensions
+
+One LLM call per file. All nine dimensions run every time; a dimension
+that doesn't apply returns PASS silently. Findings carry WARN severity
+unless a dimension explicitly marks otherwise — judgment-level drift
+is coaching, not blocking.
+
+### D1 Output Discipline
+
+**Source principles:** *Treat I/O as a contract*; *Fail loud, fail
+early, return meaningful codes.*
+
+**Judges:** Does data output go to stdout and chatter (logs, errors,
+prompts) go to stderr? Does every error path actually produce a
+non-zero exit code, or is there an error path that logs-and-returns-0?
+When operational messages are emitted, is `logging` used (configured to
+stderr) rather than `print` for them?
+
+**PASS conditions:** No `print()` of error/log content to stdout. Every
+documented or implied failure mode results in `return N` where `N > 0`
+or `raise`. Operational messages route through `logging` when the
+script carries verbosity flags or runs in automation.
+
+**Common fail signal:** `print(f"error: {err}")` without `file=sys.stderr`;
+error branches that log and then `return 0`; `print()` used as a mix of
+data output and status narration.
+
+### D2 Input Validation
+
+**Source principles:** *Fail loud, fail early, return meaningful codes*;
+*Hold the safety posture.*
+
+**Scope:** Input validation and destructive-operation safety — these are
+two sides of the same discipline: don't damage state on input you haven't
+inspected.
+
+**Judges:** Are inputs validated before any destructive or expensive
+work begins? For deletes, overwrites, or irreversible network calls, is
+there a `--dry-run` flag (or equivalent confirmation gate), and does
+the destructive branch actually read it? Are credentials, hostnames,
+and paths sourced from arguments or the environment rather than
+hardcoded?
+
+**PASS conditions:** Validation of required inputs is the first work
+`main()` does after argparse. Destructive branches check a dry-run or
+confirmation flag. No credentials or absolute paths appear as string
+literals.
+
+**Common fail signal:** A `shutil.rmtree()` call that runs before the
+input path is checked to exist; a `--dry-run` flag that's declared but
+never consulted in the destructive branch; a hostname embedded in a
+string literal.
+
+### D3 Dependency Posture
+
+**Source principles:** *Prefer the standard library.*
+
+**Judges:** When a third-party dependency is imported, is the
+complexity it brings justified — or would `argparse`, `pathlib`, `json`,
+`csv`, `subprocess`, `logging`, `tempfile`, or `http.client` suffice?
+
+**PASS conditions:** Every non-stdlib import has a clear reason the
+stdlib equivalent cannot meet (e.g., `requests` for streaming + retry,
+`pydantic` for schema validation). Stdlib-solvable problems use the
+stdlib.
+
+**Common fail signal:** `requests.get(url).json()` where
+`urllib.request.urlopen(url).read()` + `json.loads()` would do;
+`pandas.read_csv()` for a 200-row CSV that `csv.DictReader` handles.
+
+### D4 Performance Intent
+
+**Source principles:** *Treat I/O as a contract* (streaming subset);
+the performance subsection of the principles doc.
+
+**Judges:** Does the script read whole files into memory when it only
+iterates over them? Does it materialize lists or sets from generators
+without needing random access or repeated traversal?
+
+**PASS conditions:** Line-by-line iteration for text files consumed
+once; generator chains for transformations; explicit `list()` only
+where materialization is needed.
+
+**Common fail signal:** `content = open(path).read()` followed by
+`for line in content.splitlines()`; `list(map(f, xs))` where the result
+is iterated once; loading a large CSV into memory before filtering.
+
+### D5 Naming
+
+**Source principles:** *Name intent into the code* (plus external
+sources: Clean Code ch. 2 Meaningful Names).
+
+**Judges:** Do function and variable names state their intent
+specifically enough that a reader can predict behavior without diving
+into the body? Are single-letter names confined to loop counters, math
+conventions, and comprehensions? Are builtins shadowed (`list`, `id`,
+`file`, `type`)?
+
+**PASS conditions:** Names at module scope are descriptive.
+Single-letter names appear only in `for i in range(...)` or similar
+local-scope conventions. No builtin is shadowed.
+
+**Common fail signal:** `def process(data):`, `tmp = ...`, `d = ...`,
+`list = []`, module-level `x = config()` with no meaningful name.
+
+### D6 Function Design
+
+**Source principles:** *Keep functions small and single-purpose*;
+*Eliminate duplication* (plus external sources: Clean Code ch. 3
+Functions; *The Pragmatic Programmer* §15 DRY).
+
+**Judges:** Does each function do one coherent thing at one level of
+abstraction? Are three or more near-identical blocks extracted into a
+shared helper? Do function names stay clean, or do they sprout
+conjunctions (`parse_and_validate_and_write`)?
+
+**PASS conditions:** `main()` reads as a sequence of named operations.
+Helper functions each have a single verb-phrased name. Repeated blocks
+become helpers.
+
+**Common fail signal:** A 200-line `main()` that inlines fetch,
+transform, validate, and write; the same 6-line try/except block
+copy-pasted three times with different filenames.
+
+### D7 Module-Scope Discipline
+
+**Source principles:** *Keep the module scope disciplined* (plus
+external sources: Clean Code ch. 17 G13; *Effective Python* Item 16).
+
+**Judges:** Does the module top level hold only imports, constants,
+class/function definitions, and the `__main__` guard? Are there
+module-level function calls, global mutable state, or side-effecting
+initialization that would fire at import time?
+
+**PASS conditions:** No module-level assignments beyond constants
+(CONSTANT_CASE) and typed aliases. No function calls outside the
+`__main__` guard. No mutable globals referenced from within functions
+(use arguments instead).
+
+**Common fail signal:** `client = HTTPClient()` at module scope;
+`CONFIG = json.load(open("cfg.json"))` at module scope; a `setup()` call
+outside the guard.
+
+### D8 Literal Intent
+
+**Source principles:** *Name intent into the code* (literal-constant
+subset; plus Clean Code ch. 17 G25 magic numbers).
+
+**Judges:** Do numeric and string literals that carry meaning have
+named-constant homes? `0`, `1`, `-1`, and empty strings are exempt; a
+`30` that represents a timeout, or a `10` that represents page size, is
+not.
+
+**PASS conditions:** Meaningful literals live at the top of the module
+as `UPPER_SNAKE_CASE` constants. Exemptions apply for trivial values
+(`0`, `1`, `-1`, `""`, `None` equivalents) and for values that would
+not improve with a name (array indexing, single-use values tied to the
+literal in-place).
+
+**Common fail signal:** `requests.get(url, timeout=30)` with no
+`REQUEST_TIMEOUT_SECONDS = 30` constant; a page-size `100` repeated
+across three call sites.
+
+### D9 Commenting Intent
+
+**Source principles:** *Document intent at the top* (inline-comment
+subset; plus Clean Code ch. 4).
+
+**Judges:** Do comments explain *why* a non-obvious choice was made —
+constraint, trade-off, workaround — or do they restate what the code
+already says? Do TODOs carry an owner or a ticket?
+
+**PASS conditions:** Comments name hidden constraints or subtle
+invariants. TODOs are tagged (`TODO(bbeidel)` or `TODO(WIKI-123)`).
+Code that needs extensive what-comments is refactored to read on its
+own.
+
+**Common fail signal:** `# increment counter` above `counter += 1`;
+bare `# TODO: fix this` with no owner; a paragraph comment explaining
+logic that a helper function would name.
+
+## Cross-Dimension Notes
+
+**All dimensions run always.** A dimension that doesn't apply (D4
+Performance intent on a script with no file I/O; D2 Input validation on
+a read-only query tool) returns PASS silently. Conditional evaluation
+produces inconsistent rubrics across runs and makes findings
+non-comparable.
+
+**One finding per dimension maximum.** If D6 Function design identifies
+four problematic functions, surface the highest-signal one with
+concrete detail (line numbers, what to extract). Bulk findings train
+the user to disregard the audit.
+
+**Severity defaults to WARN.** Tier-2 findings are judgment-level
+coaching, not blocking. A dimension that surfaces a safety concern the
+Tier-1 scripts missed can be escalated to FAIL by the judge, but the
+default is WARN — Tier-1 is where blocking lives.

--- a/plugins/build/skills/check-python-script/references/repair-playbook.md
+++ b/plugins/build/skills/check-python-script/references/repair-playbook.md
@@ -1,0 +1,722 @@
+---
+name: Repair Playbook — Python Scripts
+description: One repair recipe per Tier-1 finding type plus one per Tier-2 dimension plus one per Tier-3 collision. Each recipe is Signal → CHANGE → FROM → TO → REASON. Applied during the check-python-script opt-in repair loop with per-finding confirmation.
+---
+
+# Repair Playbook
+
+Per-finding repair recipes for check-python-script. Every Tier-1
+finding type and every Tier-2 dimension has a recipe here. Apply
+one at a time, with explicit user confirmation, re-running the
+producing check after each fix.
+
+**HINT-severity findings are feed-forward context, not repair
+targets.** They inform the Tier-2 prompt; they do not belong in the
+repair queue.
+
+## Table of Contents
+
+- [Format](#format)
+- Tier-1 recipes
+  - [`check_secrets.sh`](#tier-1--check_secretssh)
+  - [AST parse failure (syntax)](#tier-1--ast-parse-failure)
+  - [`check_structure.sh`](#tier-1--check_structuresh)
+  - [`check_argparse.sh`](#tier-1--check_argparsesh)
+  - [`check_deps.sh`](#tier-1--check_depssh)
+  - [`check_ruff.sh`](#tier-1--check_ruffsh)
+  - [`check_size.sh`](#tier-1--check_sizesh)
+- [Tier-2 — Judgment Dimension Recipes](#tier-2--judgment-dimension-recipes)
+  - D1 Output Discipline · D2 Input Validation · D3 Dependency Posture · D4 Performance Intent · D5 Naming · D6 Function Design · D7 Module-Scope Discipline · D8 Literal Intent · D9 Commenting Intent
+- [Tier-3 — Cross-Entity Collision](#tier-3--cross-entity-collision)
+- [Notes](#notes)
+
+## Format
+
+Each recipe carries five fields:
+
+- **Signal** — the finding string or dimension name that triggers
+  the recipe
+- **CHANGE** — what to modify, in one sentence
+- **FROM** — a concrete example of the non-compliant pattern
+- **TO** — the compliant replacement
+- **REASON** — why the change matters, tied to the source principle
+
+---
+
+## Tier-1 — `check_secrets.sh`
+
+### Signal: `secret — API key / token / private URL detected`
+
+**CHANGE** Remove the secret from source. Replace with an
+`os.environ.get("<VAR_NAME>")` read and document the env var in the
+module docstring.
+
+**FROM**
+```python
+API_KEY = "sk-proj-abc123def456..."
+```
+
+**TO**
+```python
+import os
+API_KEY = os.environ.get("OPENAI_API_KEY")
+if not API_KEY:
+    sys.exit("OPENAI_API_KEY not set")
+```
+
+**REASON** Secrets in committed source leak through git history,
+logs, and backups. Externalizing to the environment is the minimum
+bar; a secret manager is better where available.
+
+---
+
+## Tier-1 — AST parse failure
+
+### Signal: `syntax — SyntaxError at line N: <msg>`
+
+**CHANGE** Fix the Python syntax error named in the finding. The file
+cannot be evaluated further — no other Tier-1 check runs on an
+unparseable file, and Tier-2 judgment is skipped.
+
+**FROM** *(unparseable — for example, an unclosed parenthesis or a
+misaligned indent block)*
+
+**TO** *(syntactically valid Python, verified by `python3 -c "import
+ast; ast.parse(open('<path>').read())"`)*
+
+**REASON** The AST helper cannot run any downstream check on a file
+that doesn't parse. Fixing the syntax error is a strict prerequisite
+to the rest of the audit; nothing else runs until this clears.
+
+---
+
+## Tier-1 — `check_structure.sh`
+
+### Signal: `shebang — first line is not \`#!/usr/bin/env python3\``
+
+**CHANGE** Replace the first line with `#!/usr/bin/env python3`. No
+other first-line form is accepted; hardcoded paths (`/usr/bin/python`)
+break virtualenvs and `/opt/homebrew/bin/python3` is not portable.
+
+**FROM** `#!/usr/bin/python3`
+**TO** `#!/usr/bin/env python3`
+
+**REASON** `env` resolves the active Python from `PATH`, including
+virtualenv-activated shells. Hardcoded paths are fragile across
+environments.
+
+### Signal: `guard-missing — no \`if __name__ == "__main__":\` guard at top level`
+
+**CHANGE** Add a `__main__` guard at the module bottom that invokes
+`sys.exit(main())`.
+
+**FROM** *(script has no guard; `main()` is called at module scope or
+never)*
+
+**TO**
+```python
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+**REASON** Without the guard, importing the script runs its body as a
+side effect — breaking testability and turning `import myscript` into
+an execution event. The guard also gives `sys.exit` a return value
+from `main()` to translate into an exit code.
+
+### Signal: `guard-shape — \`if __name__ == "__main__":\` does not invoke \`sys.exit(main())\``
+
+**CHANGE** Replace the guard body with `sys.exit(main())`.
+
+**FROM**
+```python
+if __name__ == "__main__":
+    main()
+```
+
+**TO**
+```python
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+**REASON** `main()` returns an int by the conventions in the
+principles doc; without `sys.exit`, the return value is dropped and
+the exit code is always 0 regardless of error paths.
+
+### Signal: `main-returns — main() does not return an int`
+
+**CHANGE** Annotate the `main()` signature as `-> int` and ensure
+every code path returns a concrete int.
+
+**FROM**
+```python
+def main(argv=None):
+    args = get_parser().parse_args(argv)
+    run(args)
+```
+
+**TO**
+```python
+def main(argv: list[str] | None = None) -> int:
+    args = get_parser().parse_args(argv)
+    return run(args)
+```
+
+**REASON** The `sys.exit(main())` contract only works when `main()`
+actually returns an exit code.
+
+### Signal: `keyboard-interrupt — no except KeyboardInterrupt at top level of main()`
+
+**CHANGE** Wrap the body of `main()` in a `try` that catches
+`KeyboardInterrupt` and returns `130`.
+
+**FROM**
+```python
+def main(argv=None) -> int:
+    args = get_parser().parse_args(argv)
+    return run(args)
+```
+
+**TO**
+```python
+def main(argv: list[str] | None = None) -> int:
+    args = get_parser().parse_args(argv)
+    try:
+        return run(args)
+    except KeyboardInterrupt:
+        return 130
+```
+
+**REASON** A script that dumps a traceback on Ctrl+C is
+user-hostile. Exit code 130 is the shell convention for
+SIGINT-terminated processes.
+
+### Signal: `exec-bit — shebang present but executable bit not set`
+
+**CHANGE** Run `chmod +x <path>` against the file.
+
+**FROM** (filesystem) `-rw-r--r-- 1 user user 2048 Apr 22 14:30 script.py`
+**TO** (filesystem) `-rwxr-xr-x 1 user user 2048 Apr 22 14:30 script.py`
+
+**REASON** A shebang without `+x` is a lie — `./script.py` still
+errors. The scaffold depends on the invocation contract.
+
+---
+
+## Tier-1 — `check_argparse.sh`
+
+### Signal: `argparse-when-argv — sys.argv used past [0] but argparse not imported`
+
+**CHANGE** Replace manual `sys.argv` slicing with an `argparse`-based
+parser inside a `get_parser()` function.
+
+**FROM**
+```python
+input_path = sys.argv[1]
+output_path = sys.argv[2]
+```
+
+**TO**
+```python
+parser = argparse.ArgumentParser()
+parser.add_argument("input", type=Path, help="Input file.")
+parser.add_argument("output", type=Path, help="Output file.")
+args = parser.parse_args()
+```
+
+**REASON** `argparse` provides `--help`, type coercion, and usage
+errors that manual slicing can never match. Users who run the script
+wrong deserve a useful error, not an `IndexError` traceback.
+
+### Signal: `add-argument-help — add_argument() missing non-empty help=`
+
+**CHANGE** Add a `help=` string to every `add_argument` call that
+lacks one.
+
+**FROM** `parser.add_argument("--out", type=Path)`
+**TO** `parser.add_argument("--out", type=Path, help="Output path.")`
+
+**REASON** The `help=` string is what the user sees when they run
+`--help`. No string means no documentation.
+
+### Signal: `subprocess-check — subprocess.run() missing check=True (or result not inspected)`
+
+**CHANGE** Add `check=True` to the `subprocess.run()` call, or inspect
+`result.returncode` explicitly.
+
+**FROM** `subprocess.run(["git", "pull"])`
+**TO** `subprocess.run(["git", "pull"], check=True)`
+
+**REASON** Without `check=True`, a non-zero exit from the child
+process is silently ignored and the script continues as if nothing
+went wrong. That failure mode is exactly what a script should surface.
+
+---
+
+## Tier-1 — `check_deps.sh`
+
+### Signal: `declared-deps — 3rd-party import without declared dependencies`
+
+**CHANGE** Either add a PEP 723 `# /// script` block at the top of
+the file, or colocate a `requirements.txt` next to the script.
+
+**FROM** (script imports `requests` with no declaration present)
+
+**TO** (PEP 723, self-contained)
+```python
+#!/usr/bin/env python3
+"""Fetch exchange rates."""
+
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["requests>=2.32"]
+# ///
+
+import requests
+```
+
+Or (colocated `requirements.txt`):
+```
+# requirements.txt next to the script
+requests>=2.32
+```
+
+**REASON** Scripts are expected to be reproducible on a fresh
+machine. Undeclared dependencies mean the next maintainer debugs an
+`ImportError` before they can debug the actual problem.
+
+---
+
+## Tier-1 — `check_ruff.sh`
+
+`check_ruff.sh` wraps `ruff`; the recipes below cover the emitted rule
+codes.
+
+### Signal: `ruff-D100 — module docstring missing`
+
+**CHANGE** Add a module docstring as the first statement, naming the
+script's purpose and one example invocation.
+
+**FROM**
+```python
+#!/usr/bin/env python3
+import argparse
+```
+
+**TO**
+```python
+#!/usr/bin/env python3
+"""Fetch exchange rates and write them to a CSV.
+
+Example:
+    ./fetch_rates.py --source usd --target eur --out rates.csv
+"""
+
+import argparse
+```
+
+**REASON** The docstring is the first thing a reader sees and often
+the only documentation a one-off script has.
+
+### Signal: `ruff-E722 — bare except:` *(FAIL)*
+
+**CHANGE** Replace `except:` with a specific exception type, or with
+`except Exception as err:` at the top-level `main()` if a catch-all is
+intended.
+
+**FROM**
+```python
+try:
+    run(args)
+except:
+    print("failed")
+```
+
+**TO**
+```python
+try:
+    run(args)
+except (FileNotFoundError, ValueError) as err:
+    print(f"error: {err}", file=sys.stderr)
+    return 1
+```
+
+**REASON** Bare `except:` swallows `KeyboardInterrupt` and
+`SystemExit` and hides real bugs. It is the highest-frequency cause
+of "my script is ignoring Ctrl+C" reports.
+
+### Signal: `ruff-SIM115 — open() call not wrapped in a with statement`
+
+**CHANGE** Wrap the `open()` call in a `with` block so cleanup runs on
+exceptions.
+
+**FROM**
+```python
+f = open(path)
+data = f.read()
+f.close()
+```
+
+**TO**
+```python
+with open(path, encoding="utf-8") as f:
+    data = f.read()
+```
+
+**REASON** An exception between `open` and `close` leaves the file
+handle dangling. The context manager guarantees cleanup.
+
+### Signal: `ruff-PLW1514 — text-mode open() without encoding=`
+
+**CHANGE** Add `encoding="utf-8"` to the `open()` call.
+
+**FROM** `with open(path) as f:`
+**TO** `with open(path, encoding="utf-8") as f:`
+
+**REASON** The default encoding is platform-dependent. On a Windows
+CI runner, a file that works locally on macOS silently corrupts
+non-ASCII characters.
+
+### Signal: `ruff-PTH — os.path.* used where pathlib.Path would work`
+
+**CHANGE** Rewrite the `os.path` operation using `pathlib.Path`.
+
+**FROM**
+```python
+if os.path.exists(os.path.join(dirname, filename)):
+    ...
+```
+
+**TO**
+```python
+if (Path(dirname) / filename).exists():
+    ...
+```
+
+**REASON** `pathlib.Path` removes a class of string-manipulation bugs
+and reads more clearly. On Windows, the normalization is handled by
+the library rather than by the author.
+
+### Signal: `ruff-S602` / `ruff-S604 — shell=True in subprocess call` *(FAIL)*
+
+**CHANGE** Replace `shell=True` with a list of arguments. Both S602
+and S604 flag the same pattern; the ruff wrapper reports whichever ruff
+version-specific code fires.
+
+**FROM** `subprocess.run(f"grep {pattern} {file}", shell=True)`
+**TO** `subprocess.run(["grep", pattern, file])`
+
+**REASON** Shell injection is trivial when interpolated input reaches
+`shell=True`. Argument lists pass through `execvp`, not a shell
+parser, and are injection-safe.
+
+### Signal: `ruff-S307 — eval or exec call` *(FAIL)*
+
+**CHANGE** Replace `eval` / `exec` with a targeted parser — `json.loads`,
+`ast.literal_eval`, or an explicit dispatch table.
+
+**FROM** `result = eval(user_input)`
+**TO** `result = ast.literal_eval(user_input)` *(for literal values)*
+
+Or, for dispatch:
+```python
+ACTIONS = {"start": start, "stop": stop}
+ACTIONS[action_name](args)
+```
+
+**REASON** `eval` / `exec` on external input is an RCE vector. The
+targeted replacements cover every legitimate use case without the
+vulnerability surface.
+
+### Signal: `ruff-F401 — unused import`
+
+**CHANGE** Remove the import.
+
+**FROM** `import json  # not used anywhere`
+**TO** *(line deleted)*
+
+**REASON** Unused imports confuse readers and slow startup. If the
+import exists for a side effect, add an explicit comment naming the
+side effect.
+
+### Signal: `ruff-ANN — function signature missing type hints`
+
+**CHANGE** Add type annotations to parameters and return type. Start
+with `main()` and script-boundary functions; interior helpers are
+optional but encouraged.
+
+**FROM** `def run(args):`
+**TO** `def run(args: argparse.Namespace) -> int:`
+
+**REASON** Type hints are documentation that doesn't drift and enable
+static analysis (mypy, pyright) that catches a class of bugs before
+runtime.
+
+### Signal: `ruff-format — ruff format --check drift`
+
+**CHANGE** Run `ruff format <path>` against the file.
+
+**FROM** *(formatting drift)*
+**TO** *(formatted)*
+
+**REASON** Formatter compliance eliminates style bikeshedding and
+keeps diffs legible. Drift from the formatter's output is a mechanical
+signal, not a judgment call.
+
+### Signal: `ruff-UP031 / ruff-UP032 — %-format or .format() where f-string applies`
+
+**CHANGE** Rewrite as an f-string.
+
+**FROM** `"hello, %s" % name` or `"hello, {}".format(name)`
+**TO** `f"hello, {name}"`
+
+**REASON** f-strings are clearer, faster at runtime, and harder to
+mis-quote.
+
+### Signal: `ruff-F403 — wildcard import` *(FAIL)*
+
+**CHANGE** Replace the wildcard with explicit named imports.
+
+**FROM** `from utils import *`
+**TO** `from utils import load_config, write_report`
+
+**REASON** Wildcard imports pollute the namespace and impede static
+analysis — the tools can't tell which names the module exports.
+
+### Signal: `ruff-S108 — hardcoded /tmp/ or /var/tmp/ path literal` *(FAIL)*
+
+**CHANGE** Replace with a `tempfile` call.
+
+**FROM** `tmp = f"/tmp/work_{os.getpid()}"`
+**TO**
+```python
+import tempfile
+with tempfile.TemporaryDirectory() as tmp:
+    ...
+```
+
+**REASON** Hand-constructed `/tmp/` paths race against other processes
+creating the same name and expose symlink-attack surface. `tempfile`
+handles both.
+
+---
+
+## Tier-1 — `check_size.sh`
+
+### Signal: `size — script length over 500 non-blank lines`
+
+**CHANGE** Extract cohesive sections into helper functions (or
+modules, if the refactor is large enough to justify a `utils.py`
+alongside the script). Past ~500 lines, convert to a package:
+`pyproject.toml` + `src/<pkg>/`.
+
+**FROM** *(a 750-line single-file script with four logical sections
+inlined in `main()`)*
+**TO** *(a 300-line script that imports helpers from a colocated
+`<script>_helpers.py`, or a `pyproject.toml`-managed package)*
+
+**REASON** Single-file discipline breaks down past a threshold. A
+750-line script fails testability, readability, and partial-import
+signals that a package handles cleanly.
+
+---
+
+## Tier-2 — Judgment Dimension Recipes
+
+Tier-2 findings carry WARN severity; they're coaching, not blocking.
+Each recipe is a repair pattern the user can apply after the judge
+names a specific violation.
+
+### D1 Output Discipline
+
+**CHANGE** Move non-data output to stderr. Switch status narration to
+`logging`. Ensure every error branch returns non-zero.
+
+**FROM** `print(f"error: {err}")` in an error path that returns `0`
+**TO** `print(f"error: {err}", file=sys.stderr); return 1`
+
+**REASON** Unix pipelines depend on the stdout-for-data /
+stderr-for-chatter convention. Callers in cron, CI, and Make depend on
+the exit-code contract.
+
+### D2 Input Validation
+
+**CHANGE** Add early input validation before destructive work. Wire
+`args.dry_run` into the destructive code path.
+
+**FROM**
+```python
+for path in args.inputs:
+    shutil.rmtree(path)
+```
+
+**TO**
+```python
+for path in args.inputs:
+    if not path.exists():
+        print(f"skip: {path} does not exist", file=sys.stderr)
+        continue
+    if args.dry_run:
+        print(f"would remove: {path}")
+        continue
+    shutil.rmtree(path)
+```
+
+**REASON** "Fail before damage" is cheap to implement and expensive
+to skip. A dry-run flag that isn't consulted is worse than no flag —
+it implies safety that isn't there.
+
+### D3 Dependency Posture
+
+**CHANGE** Replace the third-party dependency with a stdlib
+equivalent, when feasible.
+
+**FROM** `import requests; resp = requests.get(url).json()`
+**TO**
+```python
+import json, urllib.request
+with urllib.request.urlopen(url, timeout=30) as resp:
+    data = json.load(resp)
+```
+
+**REASON** Each third-party dependency is a deployment surface and a
+potential security-update obligation. Scripts that use stdlib
+equivalents run anywhere Python runs.
+
+### D4 Performance Intent
+
+**CHANGE** Replace `.read()` followed by iteration with line-by-line
+iteration.
+
+**FROM**
+```python
+content = open(path).read()
+for line in content.splitlines():
+    process(line)
+```
+
+**TO**
+```python
+with open(path, encoding="utf-8") as f:
+    for line in f:
+        process(line)
+```
+
+**REASON** Scripts get run on files larger than the author imagined.
+OOM on a 2 GB input is not a bug the user should have to work around.
+
+### D5 Naming
+
+**CHANGE** Rename the function or variable to state its intent. Move
+away from `tmp`, `data`, `process`, `handle_it`.
+
+**FROM** `def process(data):` with a body that parses CSV rows
+**TO** `def parse_csv_rows(rows: Iterable[str]) -> list[Row]:`
+
+**REASON** Code is read far more often than it's written. A name
+that predicts behavior saves the reader one or more scans of the
+body.
+
+### D6 Function Design
+
+**CHANGE** Extract cohesive sections of a long function into
+helpers. Fold three copies of the same block into a single helper
+call.
+
+**FROM** *(a 150-line main() with fetch, transform, validate, write
+inlined)*
+
+**TO**
+```python
+def main(argv=None) -> int:
+    args = get_parser().parse_args(argv)
+    raw = fetch(args.source)
+    records = transform(raw)
+    validate(records)
+    write(records, args.out)
+    return 0
+```
+
+**REASON** Short named functions read as their own commentary. Duplicated
+blocks drift — fix one copy, forget the others, ship a partial bug.
+
+### D7 Module-Scope Discipline
+
+**CHANGE** Move module-level side-effecting calls into a function or
+behind the `__main__` guard. Replace module-level mutable state with
+argument-passed parameters.
+
+**FROM** `client = HTTPClient()` at module scope
+**TO** Instantiate `client` inside the function that needs it, or
+pass it as a parameter from `main()`.
+
+**REASON** Module-level side effects fire on `import`, which breaks
+testability and surfaces subtle dependency-order bugs.
+
+### D8 Literal Intent
+
+**CHANGE** Promote the meaningful literal to a named constant at the
+top of the module.
+
+**FROM** `response = requests.get(url, timeout=30)`
+**TO**
+```python
+HTTP_TIMEOUT_SECONDS = 30
+...
+response = requests.get(url, timeout=HTTP_TIMEOUT_SECONDS)
+```
+
+**REASON** A named constant teaches the reader what the value means
+and centralizes its adjustment point.
+
+### D9 Commenting Intent
+
+**CHANGE** Replace what-comments with why-comments (or delete them if
+the code speaks for itself). Tag owner-less TODOs.
+
+**FROM** `# increment counter` above `counter += 1`
+**TO** *(delete the comment)*
+
+Or
+**FROM** `# TODO: fix this`
+**TO** `# TODO(bbeidel): normalize Unicode before comparison — currently miscounts combining characters`
+
+**REASON** Comments that restate the code rot alongside it. Comments
+that explain *why* stay useful as the code evolves.
+
+---
+
+## Tier-3 — Cross-Entity Collision
+
+### Signal: `collision — near-identical get_parser() / error-handler / docstring across scripts`
+
+**CHANGE** Extract the shared block into a helper module sitting
+alongside the scripts (`<dir>/_helpers.py`) and import from it. If the
+scripts are truly independent, accept the duplication — DRY applies
+to scripts that will co-evolve, not scripts that happen to look alike.
+
+**FROM** `get_parser()` copied across three scripts with
+script-specific tweaks to each
+
+**TO** `_helpers.py` exposes `make_base_parser()`; each script
+imports it and adds its own arguments.
+
+**REASON** Shared parsing logic drifts when maintained in triplicate.
+A single source of truth keeps the arguments coherent and documents
+the shared conventions in one place.
+
+---
+
+## Notes
+
+- **HINT-severity findings** are pre-filter pre-evaluations, not
+  repair targets. They inform the Tier-2 prompt and do not enter the
+  repair queue.
+- **Per-finding confirmation** is non-negotiable. Bulk application
+  removes the user's ability to review individual changes and is a
+  documented anti-pattern in the check-python-script SKILL.md.
+- **Re-run after each fix.** A repair can introduce a new finding
+  elsewhere (e.g., adding `sys.exit(main())` may require fixing the
+  `main()` return type). The Tier-1 script that produced the original
+  finding re-runs before moving to the next repair.

--- a/plugins/build/skills/check-python-script/scripts/_ast_checks.py
+++ b/plugins/build/skills/check-python-script/scripts/_ast_checks.py
@@ -1,0 +1,567 @@
+#!/usr/bin/env python3
+"""AST-backed deterministic checks for Python scripts.
+
+Invoked by check_structure.sh / check_argparse.sh / check_deps.sh
+to perform per-check AST analysis that POSIX awk cannot express.
+Each subcommand emits findings in the fixed Tier-1 lint format and
+exits per the shared contract (0 clean / 1 FAIL / 64 arg error).
+
+Usage:
+    _ast_checks.py <check> <file>
+
+Subcommands:
+    structure   shebang / main guard shape / main return type /
+                KeyboardInterrupt handler / exec bit
+    argparse    argparse-when-sys.argv / add_argument help= /
+                subprocess check=True
+    deps        non-stdlib imports without a declared-deps mechanism
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import stat
+import sys
+from pathlib import Path
+from typing import Iterator
+
+EXIT_CLEAN = 0
+EXIT_FAIL = 1
+EXIT_USAGE = 64
+
+# Stdlib module names available from Python 3.10 onward via sys.stdlib_module_names.
+# Fall back to a baked-in set for 3.9 compatibility.
+try:
+    STDLIB_MODULES = set(sys.stdlib_module_names)  # type: ignore[attr-defined]
+except AttributeError:
+    # Minimal stdlib set sufficient for most scripting use — extend as needed.
+    STDLIB_MODULES = {
+        "abc",
+        "argparse",
+        "ast",
+        "asyncio",
+        "base64",
+        "collections",
+        "concurrent",
+        "contextlib",
+        "copy",
+        "csv",
+        "dataclasses",
+        "datetime",
+        "enum",
+        "functools",
+        "glob",
+        "hashlib",
+        "http",
+        "importlib",
+        "io",
+        "itertools",
+        "json",
+        "logging",
+        "math",
+        "multiprocessing",
+        "os",
+        "pathlib",
+        "pickle",
+        "platform",
+        "queue",
+        "random",
+        "re",
+        "shutil",
+        "socket",
+        "sqlite3",
+        "stat",
+        "string",
+        "subprocess",
+        "sys",
+        "tempfile",
+        "textwrap",
+        "threading",
+        "time",
+        "traceback",
+        "typing",
+        "unittest",
+        "urllib",
+        "uuid",
+        "warnings",
+        "weakref",
+        "xml",
+        "zipfile",
+    }
+
+
+def emit(severity: str, path: Path, check: str, detail: str, rec: str) -> None:
+    """Write one finding in the canonical Tier-1 lint format."""
+    print(f"{severity}  {path} — {check}: {detail}")
+    print(f"  Recommendation: {rec}")
+
+
+def parse_or_fail(path: Path) -> ast.Module | None:
+    """Parse the file; emit a FAIL finding and return None on SyntaxError."""
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            return ast.parse(fh.read(), filename=str(path))
+    except SyntaxError as err:
+        emit(
+            "FAIL",
+            path,
+            "syntax",
+            f"SyntaxError at line {err.lineno}: {err.msg}",
+            "Fix the syntax error — the file cannot be evaluated until it parses.",
+        )
+        return None
+    except OSError as err:
+        print(f"_ast_checks.py: cannot read {path}: {err}", file=sys.stderr)
+        return None
+
+
+# ---- structure ------------------------------------------------------------
+
+
+def check_shebang(path: Path, source: str) -> bool:
+    """First line must be exactly `#!/usr/bin/env python3`."""
+    first = source.splitlines()[0] if source else ""
+    if first != "#!/usr/bin/env python3":
+        emit(
+            "FAIL",
+            path,
+            "shebang",
+            f"first line is {first!r}, expected '#!/usr/bin/env python3'",
+            "Replace the first line with '#!/usr/bin/env python3'.",
+        )
+        return False
+    return True
+
+
+def check_exec_bit(path: Path, has_shebang: bool) -> None:
+    """Executable bit should be set when a shebang is present."""
+    if not has_shebang:
+        return
+    mode = path.stat().st_mode
+    if not mode & stat.S_IXUSR:
+        emit(
+            "INFO",
+            path,
+            "exec-bit",
+            "shebang present but executable bit not set",
+            f"Run: chmod +x {path}",
+        )
+
+
+def find_main_def(tree: ast.Module) -> ast.FunctionDef | None:
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "main":
+            return node
+    return None
+
+
+def find_main_guard(tree: ast.Module) -> ast.If | None:
+    for node in tree.body:
+        if not isinstance(node, ast.If):
+            continue
+        test = node.test
+        # Match `__name__ == "__main__"` in either order.
+        if (
+            isinstance(test, ast.Compare)
+            and len(test.ops) == 1
+            and isinstance(test.ops[0], ast.Eq)
+        ):
+            left_name = isinstance(test.left, ast.Name) and test.left.id == "__name__"
+            right_const = (
+                isinstance(test.comparators[0], ast.Constant)
+                and test.comparators[0].value == "__main__"
+            )
+            if left_name and right_const:
+                return node
+    return None
+
+
+def guard_invokes_sys_exit_main(guard: ast.If) -> bool:
+    """Return True iff the guard body contains `sys.exit(main(...))`."""
+    for stmt in guard.body:
+        if not isinstance(stmt, ast.Expr):
+            continue
+        call = stmt.value
+        if not isinstance(call, ast.Call):
+            continue
+        # sys.exit(...)
+        if not (
+            isinstance(call.func, ast.Attribute)
+            and call.func.attr == "exit"
+            and isinstance(call.func.value, ast.Name)
+            and call.func.value.id == "sys"
+        ):
+            continue
+        # argument is a call to main(...)
+        if call.args and isinstance(call.args[0], ast.Call):
+            inner = call.args[0].func
+            if isinstance(inner, ast.Name) and inner.id == "main":
+                return True
+    return False
+
+
+def main_returns_int(main_fn: ast.FunctionDef) -> bool:
+    """Best-effort: annotated return type is `int` (as Name or Subscript)."""
+    ret = main_fn.returns
+    if isinstance(ret, ast.Name) and ret.id == "int":
+        return True
+    return False
+
+
+def has_keyboard_interrupt_handler(main_fn: ast.FunctionDef) -> bool:
+    """Does main() contain a top-level `except KeyboardInterrupt`?"""
+    for node in ast.walk(main_fn):
+        if isinstance(node, ast.ExceptHandler):
+            exc = node.type
+            if isinstance(exc, ast.Name) and exc.id == "KeyboardInterrupt":
+                return True
+            if isinstance(exc, ast.Tuple):
+                for elt in exc.elts:
+                    if isinstance(elt, ast.Name) and elt.id == "KeyboardInterrupt":
+                        return True
+    return False
+
+
+def check_structure(path: Path) -> int:
+    """Run all structure checks. Returns 1 if any FAIL was emitted."""
+    try:
+        source = path.read_text(encoding="utf-8")
+    except OSError as err:
+        print(f"_ast_checks.py: cannot read {path}: {err}", file=sys.stderr)
+        return EXIT_FAIL
+
+    fail = False
+    has_shebang = check_shebang(path, source)
+    if not has_shebang:
+        fail = True
+
+    check_exec_bit(path, has_shebang)
+
+    tree = parse_or_fail(path)
+    if tree is None:
+        return EXIT_FAIL
+
+    main_fn = find_main_def(tree)
+    guard = find_main_guard(tree)
+
+    if guard is None:
+        emit(
+            "FAIL",
+            path,
+            "guard-missing",
+            "no 'if __name__ == \"__main__\":' guard at top level",
+            "Add 'if __name__ == \"__main__\": sys.exit(main())' at the module bottom.",
+        )
+        fail = True
+    elif not guard_invokes_sys_exit_main(guard):
+        emit(
+            "FAIL",
+            path,
+            "guard-shape",
+            "__main__ guard does not invoke sys.exit(main())",
+            "Change the guard body to 'sys.exit(main())'.",
+        )
+        fail = True
+
+    if main_fn is not None:
+        if not main_returns_int(main_fn):
+            emit(
+                "WARN",
+                path,
+                "main-returns",
+                "main() signature does not declare '-> int' return type",
+                "Annotate main() as '-> int' and ensure every path returns an int.",
+            )
+        if not has_keyboard_interrupt_handler(main_fn):
+            emit(
+                "WARN",
+                path,
+                "keyboard-interrupt",
+                "main() has no 'except KeyboardInterrupt' handler",
+                "Wrap main()'s body in try/except KeyboardInterrupt: return 130.",
+            )
+
+    return EXIT_FAIL if fail else EXIT_CLEAN
+
+
+# ---- argparse -------------------------------------------------------------
+
+
+def walks_sys_argv_past_zero(tree: ast.Module) -> bool:
+    """Detect any sys.argv[N] where N != 0, or any slice of sys.argv."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Subscript):
+            continue
+        value = node.value
+        if not (
+            isinstance(value, ast.Attribute)
+            and value.attr == "argv"
+            and isinstance(value.value, ast.Name)
+            and value.value.id == "sys"
+        ):
+            continue
+        slice_node = node.slice
+        # sys.argv[N] with N != 0
+        if isinstance(slice_node, ast.Constant):
+            if slice_node.value != 0:
+                return True
+        else:
+            # sys.argv[1:], sys.argv[i], len(sys.argv), etc.
+            return True
+    return False
+
+
+def imports_argparse(tree: ast.Module) -> bool:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "argparse":
+                    return True
+        elif isinstance(node, ast.ImportFrom) and node.module == "argparse":
+            return True
+    return False
+
+
+def walk_add_argument_calls(tree: ast.Module) -> Iterator[ast.Call]:
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Attribute) and func.attr == "add_argument":
+            yield node
+
+
+def walk_subprocess_run_calls(tree: ast.Module) -> Iterator[ast.Call]:
+    """Yield calls that match subprocess.run / .call / .check_output / Popen."""
+    targets = {"run", "call", "check_output", "Popen", "check_call"}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if (
+            isinstance(func, ast.Attribute)
+            and func.attr in targets
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "subprocess"
+        ):
+            yield node
+
+
+def kwarg_value(call: ast.Call, name: str) -> ast.expr | None:
+    for kw in call.keywords:
+        if kw.arg == name:
+            return kw.value
+    return None
+
+
+def result_is_assigned(call: ast.Call, tree: ast.Module) -> bool:
+    """Is this subprocess.run(...) call's return value bound to a name?
+
+    We approximate: walk the tree and find the Assign/AnnAssign whose value
+    is this Call node. ast doesn't give us parent links; do a targeted walk.
+    """
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, (ast.Assign, ast.AnnAssign, ast.NamedExpr))
+            and node.value is call
+        ):
+            return True
+    return False
+
+
+def check_argparse(path: Path) -> int:
+    tree = parse_or_fail(path)
+    if tree is None:
+        return EXIT_FAIL
+
+    # argparse-when-sys.argv
+    if walks_sys_argv_past_zero(tree) and not imports_argparse(tree):
+        emit(
+            "WARN",
+            path,
+            "argparse-when-argv",
+            "sys.argv indexed past [0] but argparse is not imported",
+            "Replace manual sys.argv parsing with argparse.",
+        )
+
+    # add-argument help=
+    for call in walk_add_argument_calls(tree):
+        help_val = kwarg_value(call, "help")
+        empty = help_val is None or (
+            isinstance(help_val, ast.Constant) and help_val.value in ("", None)
+        )
+        if empty:
+            emit(
+                "WARN",
+                path,
+                "add-argument-help",
+                f"add_argument() at line {call.lineno} missing non-empty help=",
+                "Add a help='...' string; it is what the user sees on --help.",
+            )
+
+    # subprocess check=True or result inspected
+    for call in walk_subprocess_run_calls(tree):
+        if isinstance(call.func, ast.Attribute) and call.func.attr in {
+            "Popen",
+            "check_output",
+            "check_call",
+        }:
+            # Popen constructs; check_output/check_call already raise.
+            continue
+        check_kw = kwarg_value(call, "check")
+        is_check_true = isinstance(check_kw, ast.Constant) and check_kw.value is True
+        if not is_check_true and not result_is_assigned(call, tree):
+            emit(
+                "WARN",
+                path,
+                "subprocess-check",
+                (
+                    f"subprocess.{call.func.attr}() at line {call.lineno} "
+                    "neither sets check=True nor inspects the return"
+                ),
+                "Add check=True, or assign the result and inspect returncode.",
+            )
+
+    return EXIT_CLEAN
+
+
+# ---- deps -----------------------------------------------------------------
+
+
+def top_level_imports(tree: ast.Module) -> set[str]:
+    """Return the set of top-level module names imported (first dotted part)."""
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom):
+            # node.module is None for `from . import foo` (relative)
+            if node.level == 0 and node.module:
+                names.add(node.module.split(".")[0])
+    return names
+
+
+def has_pep723_block(source: str) -> bool:
+    """Look for the `# /// script` PEP 723 block anywhere in the first 50 lines."""
+    for line in source.splitlines()[:50]:
+        if line.strip() == "# /// script":
+            return True
+    return False
+
+
+def has_top_of_file_deps_comment(source: str) -> bool:
+    """Heuristic — a top-of-file comment block mentioning 'dependencies'/'requires'."""
+    header_lines = []
+    for line in source.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if (
+            stripped.startswith("#")
+            or stripped.startswith('"""')
+            or stripped.startswith("'''")
+        ):
+            header_lines.append(stripped.lower())
+            if len(header_lines) >= 30:
+                break
+        else:
+            break
+    joined = " ".join(header_lines)
+    return (
+        "requires" in joined or "dependencies" in joined or "requirements" in joined
+    ) and (
+        "pip" in joined
+        or "install" in joined
+        or "requires-python" in joined
+        or "==" in joined
+    )
+
+
+def colocated_requirements_txt(path: Path) -> bool:
+    return (path.parent / "requirements.txt").is_file()
+
+
+def check_deps(path: Path) -> int:
+    try:
+        source = path.read_text(encoding="utf-8")
+    except OSError as err:
+        print(f"_ast_checks.py: cannot read {path}: {err}", file=sys.stderr)
+        return EXIT_FAIL
+
+    tree = parse_or_fail(path)
+    if tree is None:
+        return EXIT_FAIL
+
+    imports = top_level_imports(tree)
+    non_stdlib = {
+        n for n in imports if n not in STDLIB_MODULES and not n.startswith("_")
+    }
+    if not non_stdlib:
+        return EXIT_CLEAN
+
+    if has_pep723_block(source):
+        return EXIT_CLEAN
+    if colocated_requirements_txt(path):
+        return EXIT_CLEAN
+    if has_top_of_file_deps_comment(source):
+        return EXIT_CLEAN
+
+    emit(
+        "WARN",
+        path,
+        "declared-deps",
+        (
+            "non-stdlib imports with no declared-deps mechanism: "
+            f"{', '.join(sorted(non_stdlib))}"
+        ),
+        (
+            "Add a PEP 723 '# /// script' block, a colocated "
+            "requirements.txt, or a top-of-file deps comment."
+        ),
+    )
+    return EXIT_CLEAN
+
+
+# ---- dispatch -------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="AST-backed deterministic checks for Python scripts.",
+    )
+    parser.add_argument(
+        "check",
+        choices=("structure", "argparse", "deps"),
+        help="Which check family to run.",
+    )
+    parser.add_argument(
+        "file",
+        type=Path,
+        help="Path to a single .py file.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if not args.file.is_file():
+        print(f"_ast_checks.py: not a file: {args.file}", file=sys.stderr)
+        return EXIT_USAGE
+
+    try:
+        if args.check == "structure":
+            return check_structure(args.file)
+        if args.check == "argparse":
+            return check_argparse(args.file)
+        if args.check == "deps":
+            return check_deps(args.file)
+    except KeyboardInterrupt:
+        return 130
+
+    return EXIT_USAGE
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/build/skills/check-python-script/scripts/check_argparse.sh
+++ b/plugins/build/skills/check-python-script/scripts/check_argparse.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+#
+# check_argparse.sh — Deterministic Tier-1 argparse / subprocess checks
+# for Python scripts: argparse-when-sys.argv, add_argument help=,
+# subprocess.run check=True / return-inspected.
+#
+# Thin wrapper around _ast_checks.py argparse <file>.
+#
+# Usage:
+#   check_argparse.sh <path> [<path> ...]
+#
+# Exit codes:
+#   0   no FAIL findings (all emitted findings are WARN — exits 0)
+#   1   one or more FAIL findings
+#   64  usage error
+#   69  missing dependency
+#
+# Dependencies:
+#   python3, find, basename
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+PROGNAME="$(basename "${0}")"
+SCRIPT_DIR="$(cd "$(dirname "${0}")" && pwd)"
+HELPER="${SCRIPT_DIR}/_ast_checks.py"
+
+REQUIRED_CMDS=(python3 find basename)
+
+usage() {
+  cat <<'EOF'
+check_argparse.sh — argparse / subprocess checks for Python scripts.
+
+Usage:
+  check_argparse.sh <path> [<path> ...]
+
+Checks:
+  argparse-when-argv  argparse imported when sys.argv accessed past [0]
+  add-argument-help   every add_argument() carries a non-empty help=
+  subprocess-check    subprocess.run() sets check=True or inspects result
+
+Options:
+  -h, --help   Show this help and exit.
+
+Exit codes:
+  0   no FAIL findings
+  1   one or more FAIL findings
+  64  usage error
+  69  missing dependency
+EOF
+}
+
+install_hint() {
+  case "${1}" in
+    python3)       printf 'brew install python  |  apt install python3  |  dnf install python3' ;;
+    find|basename) printf 'should be preinstalled on any POSIX system' ;;
+    *)             printf 'see your package manager' ;;
+  esac
+}
+
+preflight() {
+  local missing=()
+  local cmd
+  for cmd in "${REQUIRED_CMDS[@]}"; do
+    if ! command -v "${cmd}" >/dev/null 2>&1; then
+      missing+=("${cmd}")
+    fi
+  done
+  if [ "${#missing[@]}" -gt 0 ]; then
+    for cmd in "${missing[@]}"; do
+      printf '%s: missing required command %q. Install: %s\n' \
+        "${PROGNAME}" "${cmd}" "$(install_hint "${cmd}")" >&2
+    done
+    exit 69
+  fi
+  if [ ! -f "${HELPER}" ]; then
+    printf '%s: helper not found: %s\n' "${PROGNAME}" "${HELPER}" >&2
+    exit 69
+  fi
+}
+
+check_file() {
+  python3 "${HELPER}" argparse "$1" || return "$?"
+}
+
+check_path() {
+  local target="$1"
+  local any=0
+  local file
+
+  if [ -f "${target}" ]; then
+    case "${target}" in
+      *.py) check_file "${target}" || any=1 ;;
+    esac
+  elif [ -d "${target}" ]; then
+    while IFS= read -r file; do
+      check_file "${file}" || any=1
+    done < <(find "${target}" -maxdepth 1 -type f -name '*.py' 2>/dev/null)
+  else
+    printf '%s: path not found: %s\n' "${PROGNAME}" "${target}" >&2
+    return 64
+  fi
+  return "${any}"
+}
+
+main() {
+  if [ "$#" -eq 0 ]; then
+    usage >&2
+    exit 64
+  fi
+
+  case "${1:-}" in
+    -h|--help) usage; exit 0 ;;
+  esac
+
+  preflight
+
+  local any=0
+  local target
+  for target in "$@"; do
+    check_path "${target}" || any=1
+  done
+
+  exit "${any}"
+}
+
+if [ "${0}" = "${BASH_SOURCE[0]:-$0}" ]; then
+  main "$@"
+fi

--- a/plugins/build/skills/check-python-script/scripts/check_deps.sh
+++ b/plugins/build/skills/check-python-script/scripts/check_deps.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+#
+# check_deps.sh — Deterministic Tier-1 dependency-declaration check for
+# Python scripts: when a non-stdlib module is imported, the file must
+# declare its dependencies (PEP 723 '# /// script' block, colocated
+# requirements.txt, or a top-of-file deps comment).
+#
+# Thin wrapper around _ast_checks.py deps <file>.
+#
+# Usage:
+#   check_deps.sh <path> [<path> ...]
+#
+# Exit codes:
+#   0   no FAIL findings
+#   1   one or more FAIL findings
+#   64  usage error
+#   69  missing dependency
+#
+# Dependencies:
+#   python3, find, basename
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+PROGNAME="$(basename "${0}")"
+SCRIPT_DIR="$(cd "$(dirname "${0}")" && pwd)"
+HELPER="${SCRIPT_DIR}/_ast_checks.py"
+
+REQUIRED_CMDS=(python3 find basename)
+
+usage() {
+  cat <<'EOF'
+check_deps.sh — Dependency-declaration check for Python scripts.
+
+Usage:
+  check_deps.sh <path> [<path> ...]
+
+Check:
+  declared-deps  non-stdlib imports must pair with a PEP 723 block,
+                 colocated requirements.txt, or top-of-file deps comment.
+
+Options:
+  -h, --help   Show this help and exit.
+
+Exit codes:
+  0   no FAIL findings
+  1   one or more FAIL findings
+  64  usage error
+  69  missing dependency
+EOF
+}
+
+install_hint() {
+  case "${1}" in
+    python3)       printf 'brew install python  |  apt install python3  |  dnf install python3' ;;
+    find|basename) printf 'should be preinstalled on any POSIX system' ;;
+    *)             printf 'see your package manager' ;;
+  esac
+}
+
+preflight() {
+  local missing=()
+  local cmd
+  for cmd in "${REQUIRED_CMDS[@]}"; do
+    if ! command -v "${cmd}" >/dev/null 2>&1; then
+      missing+=("${cmd}")
+    fi
+  done
+  if [ "${#missing[@]}" -gt 0 ]; then
+    for cmd in "${missing[@]}"; do
+      printf '%s: missing required command %q. Install: %s\n' \
+        "${PROGNAME}" "${cmd}" "$(install_hint "${cmd}")" >&2
+    done
+    exit 69
+  fi
+  if [ ! -f "${HELPER}" ]; then
+    printf '%s: helper not found: %s\n' "${PROGNAME}" "${HELPER}" >&2
+    exit 69
+  fi
+}
+
+check_file() {
+  python3 "${HELPER}" deps "$1" || return "$?"
+}
+
+check_path() {
+  local target="$1"
+  local any=0
+  local file
+
+  if [ -f "${target}" ]; then
+    case "${target}" in
+      *.py) check_file "${target}" || any=1 ;;
+    esac
+  elif [ -d "${target}" ]; then
+    while IFS= read -r file; do
+      check_file "${file}" || any=1
+    done < <(find "${target}" -maxdepth 1 -type f -name '*.py' 2>/dev/null)
+  else
+    printf '%s: path not found: %s\n' "${PROGNAME}" "${target}" >&2
+    return 64
+  fi
+  return "${any}"
+}
+
+main() {
+  if [ "$#" -eq 0 ]; then
+    usage >&2
+    exit 64
+  fi
+
+  case "${1:-}" in
+    -h|--help) usage; exit 0 ;;
+  esac
+
+  preflight
+
+  local any=0
+  local target
+  for target in "$@"; do
+    check_path "${target}" || any=1
+  done
+
+  exit "${any}"
+}
+
+if [ "${0}" = "${BASH_SOURCE[0]:-$0}" ]; then
+  main "$@"
+fi

--- a/plugins/build/skills/check-python-script/scripts/check_ruff.sh
+++ b/plugins/build/skills/check-python-script/scripts/check_ruff.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+#
+# check_ruff.sh — Deterministic Tier-1 lint / format check for Python
+# scripts, wrapping the external `ruff` tool and reshaping its output
+# to the fixed lint format.
+#
+# Ruff is optional — when absent, this script emits a single INFO line
+# naming the reduced coverage and exits 0, matching the peer
+# check-shell's Missing Tools preamble pattern. Other Tier-1 scripts
+# continue running.
+#
+# Covers:
+#   D100      module docstring missing                     WARN
+#   E722      bare except:                                 FAIL
+#   SIM115    open() not wrapped in with                   WARN
+#   PLW1514   text-mode open() missing encoding=           WARN
+#   PTH       os.path.* where pathlib.Path fits            WARN
+#   S602/604  shell=True in subprocess                     FAIL
+#   S307      eval / exec                                  FAIL
+#   F401      unused imports                               WARN
+#   ANN       missing type annotations (ANN001/201/204)    WARN
+#   F403      wildcard imports                             FAIL
+#   S108      hardcoded /tmp/ path literals                FAIL
+#   UP031     %-format where f-string fits                 WARN
+#   UP032     .format() where f-string fits                WARN
+#   format    `ruff format --check` drift                  WARN
+#
+# Usage:
+#   check_ruff.sh <path> [<path> ...]
+#
+# Exit codes:
+#   0   no FAIL findings (including when ruff is absent)
+#   1   one or more FAIL findings
+#   64  usage error
+#   69  missing dependency (python3 / awk — not ruff)
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+PROGNAME="$(basename "${0}")"
+
+REQUIRED_CMDS=(awk find basename)
+
+# Rule codes that escalate to FAIL; all other ruff findings are WARN.
+# S604 is included with S602 (subprocess shell=True variants).
+FAIL_CODES="E722 F403 S108 S307 S602 S604"
+
+# The explicit selector set we pass to ruff. Kept in lockstep with the
+# severity map in emit_finding() so drift is visible at review time.
+RUFF_SELECT="D100,E722,SIM115,PLW1514,PTH,S602,S604,S307,F401,ANN,F403,S108,UP031,UP032"
+
+usage() {
+  cat <<'EOF'
+check_ruff.sh — Ruff-backed lint and format check for Python scripts.
+
+Usage:
+  check_ruff.sh <path> [<path> ...]
+
+Ruff is optional. When absent, one INFO line is emitted naming the
+reduced coverage and the script exits 0.
+
+Options:
+  -h, --help   Show this help and exit.
+
+Exit codes:
+  0   no FAIL findings
+  1   one or more FAIL findings
+  64  usage error
+  69  missing required dependency (not ruff)
+EOF
+}
+
+install_hint() {
+  case "${1}" in
+    awk|find|basename) printf 'should be preinstalled on any POSIX system' ;;
+    python3)           printf 'brew install python  |  apt install python3  |  dnf install python3' ;;
+    *)                 printf 'see your package manager' ;;
+  esac
+}
+
+preflight() {
+  local missing=()
+  local cmd
+  for cmd in "${REQUIRED_CMDS[@]}"; do
+    if ! command -v "${cmd}" >/dev/null 2>&1; then
+      missing+=("${cmd}")
+    fi
+  done
+  if [ "${#missing[@]}" -gt 0 ]; then
+    for cmd in "${missing[@]}"; do
+      printf '%s: missing required command %q. Install: %s\n' \
+        "${PROGNAME}" "${cmd}" "$(install_hint "${cmd}")" >&2
+    done
+    exit 69
+  fi
+}
+
+# Return "FAIL" or "WARN" for a ruff rule code.
+severity_for() {
+  local code="$1"
+  case " ${FAIL_CODES} " in
+    *" ${code} "*) printf 'FAIL' ;;
+    *)             printf 'WARN' ;;
+  esac
+}
+
+# Given a ruff rule code, emit a one-line repair hint.
+recommend_for() {
+  case "$1" in
+    D100)    printf 'Add a module docstring as the first statement, naming the purpose and one example invocation.' ;;
+    E722)    printf 'Catch a specific exception type (FileNotFoundError, ValueError, ...) or use except Exception as err in main().' ;;
+    SIM115)  printf "Wrap the open() in a with statement so cleanup runs on exceptions." ;;
+    PLW1514) printf "Pass encoding='utf-8' to open() to avoid platform-dependent defaults." ;;
+    PTH*)    printf 'Use pathlib.Path instead of os.path string manipulation.' ;;
+    S602|S604) printf 'Pass subprocess args as a list; never shell=True with interpolated input.' ;;
+    S307)    printf 'Replace eval/exec with ast.literal_eval or an explicit dispatch table.' ;;
+    F401)    printf 'Remove the unused import.' ;;
+    ANN*)    printf 'Add type annotations to the function signature.' ;;
+    F403)    printf 'Replace wildcard import with explicit named imports.' ;;
+    S108)    printf 'Use tempfile.TemporaryDirectory()/NamedTemporaryFile() instead of hand-built /tmp paths.' ;;
+    UP031|UP032) printf 'Rewrite as an f-string.' ;;
+    *)       printf 'See the ruff docs for this rule.' ;;
+  esac
+}
+
+# Parse one ruff concise line: `<path>:<line>:<col>: <code> <message>`.
+# Emit a single Tier-1 finding in the fixed format. Return FAIL status
+# through the exit variable in the caller (uses global for bash-3.2).
+emit_finding() {
+  local line="$1"
+  local path lineno col code message severity
+  # Split on the first three colons only (paths can contain them too;
+  # relative paths typically don't, so this is robust in practice).
+  path="${line%%:*}"
+  line="${line#*:}"
+  lineno="${line%%:*}"
+  line="${line#*:}"
+  col="${line%%:*}"
+  line="${line#*:}"
+  # Remaining: " <code> <message>"
+  line="${line# }"
+  code="${line%% *}"
+  message="${line#* }"
+
+  severity="$(severity_for "${code}")"
+  printf '%s  %s — ruff-%s: %s (line %s:%s)\n' \
+    "${severity}" "${path}" "${code}" "${message}" "${lineno}" "${col}"
+  printf '  Recommendation: %s\n' "$(recommend_for "${code}")"
+
+  if [ "${severity}" = "FAIL" ]; then
+    return 1
+  fi
+  return 0
+}
+
+check_one() {
+  local target="$1"
+  local any=0
+  local line
+
+  # `ruff check` exits 1 when findings present; we want the output regardless.
+  # `ruff check` output format: `<path>:<line>:<col>: <code> <message>`.
+  while IFS= read -r line; do
+    # Skip ruff's trailing summary lines ("Found N errors.").
+    case "${line}" in
+      ""|"Found "*|"All checks passed"*) continue ;;
+    esac
+    emit_finding "${line}" || any=1
+  done < <(ruff check --no-cache --output-format=concise --select="${RUFF_SELECT}" "${target}" 2>/dev/null || true)
+
+  # Format drift — separate invocation.
+  if ! ruff format --check --no-cache "${target}" >/dev/null 2>&1; then
+    printf 'WARN  %s — ruff-format: formatter drift detected\n' "${target}"
+    printf "  Recommendation: Run 'ruff format %s' to fix.\n" "${target}"
+  fi
+
+  return "${any}"
+}
+
+check_path() {
+  local target="$1"
+  local any=0
+  local file
+
+  if [ -f "${target}" ]; then
+    case "${target}" in
+      *.py) check_one "${target}" || any=1 ;;
+    esac
+  elif [ -d "${target}" ]; then
+    while IFS= read -r file; do
+      check_one "${file}" || any=1
+    done < <(find "${target}" -maxdepth 1 -type f -name '*.py' 2>/dev/null)
+  else
+    printf '%s: path not found: %s\n' "${PROGNAME}" "${target}" >&2
+    return 64
+  fi
+  return "${any}"
+}
+
+main() {
+  if [ "$#" -eq 0 ]; then
+    usage >&2
+    exit 64
+  fi
+
+  case "${1:-}" in
+    -h|--help) usage; exit 0 ;;
+  esac
+
+  preflight
+
+  # Ruff is optional — emit an INFO and exit 0 if absent.
+  if ! command -v ruff >/dev/null 2>&1; then
+    printf 'INFO  <ruff> — tool-missing: ruff not installed; %d AST/format checks skipped\n' 14
+    printf "  Recommendation: Install ruff to enable D100 / E722 / SIM115 / PLW1514 / "
+    printf 'PTH / S602 / S307 / F401 / ANN / F403 / S108 / UP031 / UP032 / format checks. '
+    printf "Try 'pip install ruff' or 'brew install ruff'.\n"
+    exit 0
+  fi
+
+  local any=0
+  local target
+  for target in "$@"; do
+    check_path "${target}" || any=1
+  done
+
+  exit "${any}"
+}
+
+if [ "${0}" = "${BASH_SOURCE[0]:-$0}" ]; then
+  main "$@"
+fi

--- a/plugins/build/skills/check-python-script/scripts/check_secrets.sh
+++ b/plugins/build/skills/check-python-script/scripts/check_secrets.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+#
+# check_secrets.sh — Scan Python scripts for committed secrets.
+#
+# Deterministic Tier-1 Safety check invoked by /build:check-python-script.
+# Scans *.py files for well-known API key patterns and for
+# credential-shaped variable assignments, skipping obvious placeholders.
+#
+# Toolkit convention — not from the ensemble synthesis. Adapted from the
+# peer check-rule/scripts/scan_secrets.sh. A FAIL finding excludes the
+# file from Tier-2 judgment (the model should not evaluate content that
+# leaks credentials).
+#
+# Usage:
+#   check_secrets.sh <path> [<path> ...]
+#
+# Paths may be .py files or directories (top-level .py only).
+#
+# Exit codes:
+#   0   no findings
+#   1   one or more FAIL findings
+#   64  usage error
+#   69  missing dependency
+#
+# Dependencies:
+#   grep, find, basename
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+PROGNAME="$(basename "${0}")"
+
+REQUIRED_CMDS=(grep find basename)
+
+usage() {
+  cat <<'EOF'
+check_secrets.sh — Scan Python scripts for committed secrets.
+
+Usage:
+  check_secrets.sh <path> [<path> ...]
+
+Arguments:
+  <path>   A .py file or directory to scan (top-level .py only).
+
+Options:
+  -h, --help   Show this help and exit.
+
+Exit codes:
+  0   no findings
+  1   one or more FAIL findings
+  64  usage error
+  69  missing dependency
+EOF
+}
+
+install_hint() {
+  case "${1}" in
+    grep|find|basename) printf 'should be preinstalled on any POSIX system' ;;
+    *)                  printf 'see your package manager' ;;
+  esac
+}
+
+preflight() {
+  local missing=()
+  local cmd
+  for cmd in "${REQUIRED_CMDS[@]}"; do
+    if ! command -v "${cmd}" >/dev/null 2>&1; then
+      missing+=("${cmd}")
+    fi
+  done
+  if [ "${#missing[@]}" -gt 0 ]; then
+    for cmd in "${missing[@]}"; do
+      printf '%s: missing required command %q. Install: %s\n' \
+        "${PROGNAME}" "${cmd}" "$(install_hint "${cmd}")" >&2
+    done
+    exit 69
+  fi
+}
+
+emit_finding() {
+  local path="$1" name="$2" line="$3"
+  printf 'FAIL  %s — secret: %s at line %s\n' "${path}" "${name}" "${line}"
+  printf '  Recommendation: Remove the secret, rotate the credential, '
+  printf 'and read it from os.environ.get("<VAR_NAME>") instead.\n'
+}
+
+# Parallel arrays: specific API key patterns and their display names.
+# bash 3.2 has no associative arrays — use ordered arrays.
+PATTERN_NAMES=(
+  "AWS access key"
+  "GitHub personal access token"
+  "GitHub fine-grained PAT"
+  "OpenAI API key"
+  "Anthropic API key"
+  "Stripe live key"
+)
+PATTERN_REGEXES=(
+  'AKIA[0-9A-Z]{16}'
+  'ghp_[A-Za-z0-9]{36}'
+  'github_pat_[A-Za-z0-9_]{82}'
+  'sk-[A-Za-z0-9]{48}'
+  'sk-ant-[A-Za-z0-9_-]{80,}'
+  'sk_live_[A-Za-z0-9]{24}'
+)
+
+# Credential-shaped variable assignment with a non-empty quoted value.
+# Python idiom — looks for `NAME = "value"` at any indent level.
+GENERIC_VAR_REGEX="(password|secret|token|api_key|access_key|private_key)[[:space:]]*=[[:space:]]*[\"'][^\"']+[\"']"
+
+scan_file() {
+  local file="$1"
+  local found=0
+  local i name pattern hit line
+
+  i=0
+  while [ "${i}" -lt "${#PATTERN_REGEXES[@]}" ]; do
+    name="${PATTERN_NAMES[${i}]}"
+    pattern="${PATTERN_REGEXES[${i}]}"
+    while IFS= read -r hit; do
+      line="${hit%%:*}"
+      emit_finding "${file}" "${name}" "${line}"
+      found=1
+    done < <(grep -nE "${pattern}" "${file}" 2>/dev/null || true)
+    i=$((i + 1))
+  done
+
+  # Credential-shaped assignments, minus obvious placeholders.
+  while IFS= read -r hit; do
+    line="${hit%%:*}"
+    emit_finding "${file}" "credential variable assignment" "${line}"
+    found=1
+  done < <(
+    grep -niE "${GENERIC_VAR_REGEX}" "${file}" 2>/dev/null \
+      | grep -Ev "=[[:space:]]*[\"']\\\$" \
+      | grep -Ev "=[[:space:]]*[\"']\\{" \
+      | grep -Ev "=[[:space:]]*[\"']<" \
+      | grep -iEv "=[[:space:]]*[\"'](your[-_]|example|redacted|null|none|undefined|placeholder|todo|fixme|xxx|changeme|change[-_]me|foo|bar|baz|abc|xyz)" \
+      || true
+  )
+
+  return "${found}"
+}
+
+scan_path() {
+  local target="$1"
+  local any=0
+  local file
+
+  if [ -f "${target}" ]; then
+    case "${target}" in
+      *.py) scan_file "${target}" || any=1 ;;
+    esac
+  elif [ -d "${target}" ]; then
+    while IFS= read -r file; do
+      scan_file "${file}" || any=1
+    done < <(find "${target}" -maxdepth 1 -type f -name '*.py' 2>/dev/null)
+  else
+    printf '%s: path not found: %s\n' "${PROGNAME}" "${target}" >&2
+    return 64
+  fi
+  return "${any}"
+}
+
+main() {
+  if [ "$#" -eq 0 ]; then
+    usage >&2
+    exit 64
+  fi
+
+  case "${1:-}" in
+    -h|--help) usage; exit 0 ;;
+  esac
+
+  preflight
+
+  local any=0
+  local target
+  for target in "$@"; do
+    scan_path "${target}" || any=1
+  done
+
+  exit "${any}"
+}
+
+if [ "${0}" = "${BASH_SOURCE[0]:-$0}" ]; then
+  main "$@"
+fi

--- a/plugins/build/skills/check-python-script/scripts/check_size.sh
+++ b/plugins/build/skills/check-python-script/scripts/check_size.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#
+# check_size.sh — Deterministic Tier-1 size check for Python scripts.
+#
+# Single-file scripts past ~500 non-blank lines are an anti-pattern —
+# the convention is to graduate to a proper package. This check emits
+# a WARN at the threshold; no FAIL, since line count is a heuristic.
+#
+# Usage:
+#   check_size.sh <path> [<path> ...]
+#
+# Paths may be .py files or directories (top-level .py only; scripts
+# are single-file by definition — no recursion into subpackages).
+#
+# Exit codes:
+#   0   no FAIL findings (WARN findings exit 0 per the Tier-1 contract)
+#   1   one or more FAIL findings (not produced by this script)
+#   64  usage error
+#   69  missing dependency
+#
+# Dependencies:
+#   awk, find, basename, wc
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+PROGNAME="$(basename "${0}")"
+
+# Threshold lives here so it is trivial to locate and adjust.
+MAX_NON_BLANK_LINES=500
+
+REQUIRED_CMDS=(awk find basename wc)
+
+usage() {
+  cat <<'EOF'
+check_size.sh — Flag Python scripts exceeding the size threshold.
+
+Usage:
+  check_size.sh <path> [<path> ...]
+
+Arguments:
+  <path>   A .py file or directory to scan (top-level .py only).
+
+Options:
+  -h, --help   Show this help and exit.
+
+Exit codes:
+  0   no FAIL findings
+  1   one or more FAIL findings (not produced by this script)
+  64  usage error
+  69  missing dependency
+EOF
+}
+
+install_hint() {
+  case "${1}" in
+    awk|find|basename|wc) printf 'should be preinstalled on any POSIX system' ;;
+    *)                    printf 'see your package manager' ;;
+  esac
+}
+
+preflight() {
+  local missing=()
+  local cmd
+  for cmd in "${REQUIRED_CMDS[@]}"; do
+    if ! command -v "${cmd}" >/dev/null 2>&1; then
+      missing+=("${cmd}")
+    fi
+  done
+  if [ "${#missing[@]}" -gt 0 ]; then
+    for cmd in "${missing[@]}"; do
+      printf '%s: missing required command %q. Install: %s\n' \
+        "${PROGNAME}" "${cmd}" "$(install_hint "${cmd}")" >&2
+    done
+    exit 69
+  fi
+}
+
+# Count non-blank lines — blank = empty or whitespace-only.
+non_blank_count() {
+  awk 'NF { count++ } END { print count + 0 }' "$1"
+}
+
+check_file() {
+  local file="$1"
+  local count
+  count="$(non_blank_count "${file}")"
+  if [ "${count}" -gt "${MAX_NON_BLANK_LINES}" ]; then
+    printf 'WARN  %s — size: %s non-blank lines (threshold %s)\n' \
+      "${file}" "${count}" "${MAX_NON_BLANK_LINES}"
+    printf '  Recommendation: Extract cohesive sections into helper '
+    printf 'functions, or convert to a package (pyproject.toml + src/<pkg>/).\n'
+  fi
+}
+
+check_path() {
+  local target="$1"
+  local file
+
+  if [ -f "${target}" ]; then
+    case "${target}" in
+      *.py) check_file "${target}" ;;
+    esac
+  elif [ -d "${target}" ]; then
+    while IFS= read -r file; do
+      check_file "${file}"
+    done < <(find "${target}" -maxdepth 1 -type f -name '*.py' 2>/dev/null)
+  else
+    printf '%s: path not found: %s\n' "${PROGNAME}" "${target}" >&2
+    return 64
+  fi
+}
+
+main() {
+  if [ "$#" -eq 0 ]; then
+    usage >&2
+    exit 64
+  fi
+
+  case "${1:-}" in
+    -h|--help) usage; exit 0 ;;
+  esac
+
+  preflight
+
+  local target
+  for target in "$@"; do
+    check_path "${target}" || exit "$?"
+  done
+
+  exit 0
+}
+
+if [ "${0}" = "${BASH_SOURCE[0]:-$0}" ]; then
+  main "$@"
+fi

--- a/plugins/build/skills/check-python-script/scripts/check_structure.sh
+++ b/plugins/build/skills/check-python-script/scripts/check_structure.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+#
+# check_structure.sh — Deterministic Tier-1 structural checks for
+# Python scripts: shebang, __main__ guard shape, main() return
+# annotation, KeyboardInterrupt handler, executable bit.
+#
+# Thin wrapper around _ast_checks.py structure <file>. Lives next to
+# the helper; resolves it via the script's own directory so paths are
+# stable regardless of the invoker's cwd.
+#
+# Usage:
+#   check_structure.sh <path> [<path> ...]
+#
+# Paths may be .py files or directories (top-level .py only — scripts
+# are single-file by definition, no recursion into subpackages).
+#
+# Exit codes:
+#   0   no FAIL findings
+#   1   one or more FAIL findings
+#   64  usage error
+#   69  missing dependency
+#
+# Dependencies:
+#   python3, find, basename
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+PROGNAME="$(basename "${0}")"
+SCRIPT_DIR="$(cd "$(dirname "${0}")" && pwd)"
+HELPER="${SCRIPT_DIR}/_ast_checks.py"
+
+REQUIRED_CMDS=(python3 find basename)
+
+usage() {
+  cat <<'EOF'
+check_structure.sh — Structural checks for Python scripts.
+
+Usage:
+  check_structure.sh <path> [<path> ...]
+
+Checks:
+  shebang             first line is exactly '#!/usr/bin/env python3'
+  guard               '__main__' guard exists and invokes sys.exit(main())
+  main-returns        main() signature declares '-> int'
+  keyboard-interrupt  main() has an 'except KeyboardInterrupt' handler
+  exec-bit            executable bit set when shebang present
+
+Options:
+  -h, --help   Show this help and exit.
+
+Exit codes:
+  0   no FAIL findings
+  1   one or more FAIL findings
+  64  usage error
+  69  missing dependency
+EOF
+}
+
+install_hint() {
+  case "${1}" in
+    python3)            printf 'brew install python  |  apt install python3  |  dnf install python3' ;;
+    find|basename)      printf 'should be preinstalled on any POSIX system' ;;
+    *)                  printf 'see your package manager' ;;
+  esac
+}
+
+preflight() {
+  local missing=()
+  local cmd
+  for cmd in "${REQUIRED_CMDS[@]}"; do
+    if ! command -v "${cmd}" >/dev/null 2>&1; then
+      missing+=("${cmd}")
+    fi
+  done
+  if [ "${#missing[@]}" -gt 0 ]; then
+    for cmd in "${missing[@]}"; do
+      printf '%s: missing required command %q. Install: %s\n' \
+        "${PROGNAME}" "${cmd}" "$(install_hint "${cmd}")" >&2
+    done
+    exit 69
+  fi
+  if [ ! -f "${HELPER}" ]; then
+    printf '%s: helper not found: %s\n' "${PROGNAME}" "${HELPER}" >&2
+    exit 69
+  fi
+}
+
+check_file() {
+  # Propagate helper exit code: 1 on FAIL, 0 on clean/WARN/INFO-only.
+  python3 "${HELPER}" structure "$1" || return "$?"
+}
+
+check_path() {
+  local target="$1"
+  local any=0
+  local file
+
+  if [ -f "${target}" ]; then
+    case "${target}" in
+      *.py) check_file "${target}" || any=1 ;;
+    esac
+  elif [ -d "${target}" ]; then
+    while IFS= read -r file; do
+      check_file "${file}" || any=1
+    done < <(find "${target}" -maxdepth 1 -type f -name '*.py' 2>/dev/null)
+  else
+    printf '%s: path not found: %s\n' "${PROGNAME}" "${target}" >&2
+    return 64
+  fi
+  return "${any}"
+}
+
+main() {
+  if [ "$#" -eq 0 ]; then
+    usage >&2
+    exit 64
+  fi
+
+  case "${1:-}" in
+    -h|--help) usage; exit 0 ;;
+  esac
+
+  preflight
+
+  local any=0
+  local target
+  for target in "$@"; do
+    check_path "${target}" || any=1
+  done
+
+  exit "${any}"
+}
+
+if [ "${0}" = "${BASH_SOURCE[0]:-$0}" ]; then
+  main "$@"
+fi


### PR DESCRIPTION
## Summary

- Adds the `build-python-script` / `check-python-script` skill pair to the `build` plugin, produced by running the `synthesis-to-skill-pair` prompt over `ensemble-rules/examples/python-scripts`.
- Extends `primitive-routing.md` with a *Language Selection* section (shell vs. Python when the routing test has landed on "a script"); makes `build-shell`'s Route symmetric so the two authoring skills point at the same decision.
- Ships a new shared principles doc `python-scripts-best-practices.md` — ~1,450 words, sourced from 6 models (OpenAI / Anthropic / Google / xAI) plus *Clean Code* / *Pragmatic Programmer* / *Effective Python* for dimensions the ensemble undersampled (naming, function scope, magic numbers, module-scope discipline, commenting intent, DRY).
- Bumps plugin `build` from `0.6.0` → `0.7.0`.

## Commits (read in order)

1. `cf7fcc9` docs(build): add python-script principles + language-selection guide
2. `adfe5f1` docs(build-shell): make Route symmetric with build-python-script
3. `7bb33af` feat(build): add build-python-script skill
4. `097889b` feat(build): add check-python-script skill + audit rubric + repair playbook
5. `5261bcf` feat(build): add check-python-script Tier-1 scripts
6. `6b2065f` chore(build): bump plugin 0.6.0 → 0.7.0, restore AGENTS.md hand-curated sections

## Architecture

### Three-tier audit (`check-python-script`)

- **Tier-1** — six bash scripts emit FAIL/WARN/INFO findings against 22 atomic deterministic checks. Hybrid design: bash entry points wrap a single Python AST helper (`_ast_checks.py`) for parts POSIX awk can't express (guard-invokes-sys.exit shape, subprocess result-inspection, argparse help=, etc.). `check_ruff.sh` wraps `ruff`; when ruff is absent it emits one INFO line naming reduced coverage and exits 0.
- **Tier-2** — single locked-rubric LLM call evaluating all nine judgment dimensions always-on (Output Discipline, Input Validation, Dependency Posture, Performance Intent, Naming, Function Design, Module-Scope Discipline, Literal Intent, Commenting Intent). Dimensions that don't apply return PASS silently.
- **Tier-3** — cross-entity collision detection in directory-mode scopes.

Severities / exit codes follow the fixed contract (`0` clean/WARN/INFO · `1` FAIL · `64` arg error · `69` missing dep). Secrets + syntax errors + critical safety FAILs (eval/exec, shell=True, /tmp/ literals, bare except, wildcard imports) exclude the file from Tier-2.

### Language-selection rule

`primitive-routing.md`'s new closing section names pick-signals for both languages, three cost axes (testing, dependency, failure mode), and a **tiebreaker: balanced case → Python wins on interpretability**. `build-shell` and `build-python-script` Route steps are structurally identical now — same *wrong primitive / wrong language / right primitive and right language* triage, each pointing at the shared decision for ambiguous cases.

## Inclusion-bar details (captured here because `.plans/` is gitignored)

The ensemble-to-principles filter: a rule enters the Core principles doc only if **(1)** raised by ≥2 distinct model families AND **(2)** either Haiku (affordable-tier Anthropic) raised it OR the check is mechanically deterministic. Out of ~59 candidate rules, 31 survived as Core (23 Tier-1 + 8 Tier-2); 6 external-source additions (A–F) cover dimensions the ensemble undersampled.

Notable drops (single-family or deployment-guarantee failures): `__version__` constant, `-v/-q` flag shape, `sys.path` mutation, relative imports, mutable default args, `yaml.safe_load` (not currently covered), `asyncio`/threading, log secrets, keep functions ≤50 lines, pin requirements with `==`/`~=`, capture_output/text=True. See the commit messages for rationale per area.

## Existing-shell-script rewrite audit

Per convention review: three existing shell scripts meet the Language Selection criteria for Python (>100 LOC of business logic, structured data parsing, testable seams):

- `check-rule/scripts/check_paths_glob.sh` (267 lines)
- `check-skill/scripts/check_frontmatter.sh` (290 lines)
- `check-skill/scripts/check_structure.sh` (298 lines)

**Not porting in this PR** — they work, they're CI-tested, they cross the toolkit's canonical audit surface. The Language Selection rule is forward-looking; existing scripts port when they need substantive changes anyway.

## Dogfood findings (captured for future prompt/skill refinement)

1. `$ARGUMENTS` substitution bleeds into `/build:build-skill`'s loaded body when `argument-hint` is set — documentation examples in Step 4 get substituted with the user's args string 4 times. Readability degrades with arg-string length. Flag for build-skill author.
2. build-skill workflow doesn't surface sibling-layer routing decisions (shell-vs-Python only surfaced because the user asked mid-draft). Flag for synthesis-to-skill-pair prompt's Phase 4 checklist.
3. `lint.py` reference-TOC static-check is documented but didn't fire on `repair-playbook.md` (665 lines, no TOC). Either under-implemented or scoped narrower than the doc suggests. Added TOC manually; follow-up to fix or drop the claim.
4. build-skill Step 6 "Narrate the Draft" duplicates work when the author has already narrated externally (common in multi-phase workflows like synthesis-to-skill-pair).
5. Finding subtypes drifted between Phase 4 (drafting) and Phase 6 (implementation): `guard-missing` + `guard-shape` were both emitted but only `guard-shape` was in the docs; `ruff-S604` wasn't listed alongside `ruff-S602`; `syntax` wasn't anticipated. Phase 8 cross-check caught all three.
6. Local ruff absence exercised the graceful-degradation path (INFO + exit 0) but not the full-coverage path. CI covers it. Recommend Phase 10 in the synthesis-to-skill-pair prompt explicitly note ruff as an e2e precondition.
7. Duplicate `syntax` findings when three AST-parsing scripts each re-parse a syntactically broken file. Expected; added dedup guidance to the Report step at SKILL.md.
8. **`AGENTS.md` regression caught in self-review** — my two `reindex.py` runs stripped hand-curated *Plugin Structure* and *Preferences* sections that lived inside the `<!-- wiki:begin/end -->` auto-managed region. Restored outside the auto region in commit 6 so future reindex runs won't drop them.
9. Pre-commit hook runs `ruff check plugins/` tree-wide, not just staged files. First commit attempt (docs-only) was blocked by ruff findings in `_ast_checks.py` (commit 5's content). Fixed the helper, then every commit passed.

## Test plan

- [ ] `python3 plugins/wiki/scripts/lint.py --root . --no-urls` — clean
- [ ] `ruff check plugins/` — clean (CI)
- [ ] `ruff format --check plugins/build/skills/check-python-script/scripts/_ast_checks.py` — clean
- [ ] Each Tier-1 script's `-h` prints usage
- [ ] Tier-1 scripts smoke-tested against `clean.py` fixture (0 findings across all six)
- [ ] Tier-1 scripts smoke-tested against `bad.py` / `secret.py` / `oversize.py` / `broken.py` fixtures (expected findings fire, exit codes match contract)
- [ ] Dogfood: Tier-1 scripts audit `_ast_checks.py` itself (0 findings)
- [ ] Directory-mode scanning walks top-level `.py` only (no recursion into subpackages)
- [ ] `check_ruff.sh` graceful-degradation path fires when ruff is absent (INFO + exit 0); full-coverage path exercised in CI with ruff installed
- [ ] `/build:check-skill plugins/build/skills/build-python-script/SKILL.md` — clean
- [ ] `/build:check-skill plugins/build/skills/check-python-script/SKILL.md` — clean
- [ ] Manual review of `python-scripts-best-practices.md` for principles-doc quality
- [ ] Manual review of language-selection section in `primitive-routing.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)