### PR TITLE
chore(build): align check-python-script Tier-1 scripts with bash-script rubric

### DIFF
--- a/plugins/build/skills/check-python-script/scripts/check_argparse.sh
+++ b/plugins/build/skills/check-python-script/scripts/check_argparse.sh
@@ -22,10 +22,12 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 PROGNAME="$(basename "${0}")"
+readonly PROGNAME
 SCRIPT_DIR="$(cd "$(dirname "${0}")" && pwd)"
-HELPER="${SCRIPT_DIR}/_ast_checks.py"
+readonly SCRIPT_DIR
+readonly HELPER="${SCRIPT_DIR}/_ast_checks.py"
 
-REQUIRED_CMDS=(python3 find basename)
+readonly REQUIRED_CMDS=(python3 find basename)
 
 usage() {
   cat <<'EOF'
@@ -52,9 +54,9 @@ EOF
 
 install_hint() {
   case "${1}" in
-    python3)       printf 'brew install python  |  apt install python3  |  dnf install python3' ;;
-    find|basename) printf 'should be preinstalled on any POSIX system' ;;
-    *)             printf 'see your package manager' ;;
+    python3) printf 'brew install python  |  apt install python3  |  dnf install python3' ;;
+    find | basename) printf 'should be preinstalled on any POSIX system' ;;
+    *) printf 'see your package manager' ;;
   esac
 }
 
@@ -66,14 +68,14 @@ preflight() {
       missing+=("${cmd}")
     fi
   done
-  if [ "${#missing[@]}" -gt 0 ]; then
+  if [[ "${#missing[@]}" -gt 0 ]]; then
     for cmd in "${missing[@]}"; do
       printf '%s: missing required command %q. Install: %s\n' \
         "${PROGNAME}" "${cmd}" "$(install_hint "${cmd}")" >&2
     done
     exit 69
   fi
-  if [ ! -f "${HELPER}" ]; then
+  if [[ ! -f "${HELPER}" ]]; then
     printf '%s: helper not found: %s\n' "${PROGNAME}" "${HELPER}" >&2
     exit 69
   fi
@@ -88,11 +90,11 @@ check_path() {
   local any=0
   local file
 
-  if [ -f "${target}" ]; then
+  if [[ -f "${target}" ]]; then
     case "${target}" in
       *.py) check_file "${target}" || any=1 ;;
     esac
-  elif [ -d "${target}" ]; then
+  elif [[ -d "${target}" ]]; then
     while IFS= read -r file; do
       check_file "${file}" || any=1
     done < <(find "${target}" -maxdepth 1 -type f -name '*.py' 2>/dev/null)
@@ -104,13 +106,16 @@ check_path() {
 }
 
 main() {
-  if [ "$#" -eq 0 ]; then
+  if [[ "$#" -eq 0 ]]; then
     usage >&2
     exit 64
   fi
 
   case "${1:-}" in
-    -h|--help) usage; exit 0 ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
   esac
 
   preflight
@@ -124,6 +129,6 @@ main() {
   exit "${any}"
 }
 
-if [ "${0}" = "${BASH_SOURCE[0]:-$0}" ]; then
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   main "$@"
 fi

--- a/plugins/build/skills/check-python-script/scripts/check_deps.sh
+++ b/plugins/build/skills/check-python-script/scripts/check_deps.sh
@@ -23,10 +23,12 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 PROGNAME="$(basename "${0}")"
+readonly PROGNAME
 SCRIPT_DIR="$(cd "$(dirname "${0}")" && pwd)"
-HELPER="${SCRIPT_DIR}/_ast_checks.py"
+readonly SCRIPT_DIR
+readonly HELPER="${SCRIPT_DIR}/_ast_checks.py"
 
-REQUIRED_CMDS=(python3 find basename)
+readonly REQUIRED_CMDS=(python3 find basename)
 
 usage() {
   cat <<'EOF'
@@ -52,9 +54,9 @@ EOF
 
 install_hint() {
   case "${1}" in
-    python3)       printf 'brew install python  |  apt install python3  |  dnf install python3' ;;
-    find|basename) printf 'should be preinstalled on any POSIX system' ;;
-    *)             printf 'see your package manager' ;;
+    python3) printf 'brew install python  |  apt install python3  |  dnf install python3' ;;
+    find | basename) printf 'should be preinstalled on any POSIX system' ;;
+    *) printf 'see your package manager' ;;
   esac
 }
 
@@ -66,14 +68,14 @@ preflight() {
       missing+=("${cmd}")
     fi
   done
-  if [ "${#missing[@]}" -gt 0 ]; then
+  if [[ "${#missing[@]}" -gt 0 ]]; then
     for cmd in "${missing[@]}"; do
       printf '%s: missing required command %q. Install: %s\n' \
         "${PROGNAME}" "${cmd}" "$(install_hint "${cmd}")" >&2
     done
     exit 69
   fi
-  if [ ! -f "${HELPER}" ]; then
+  if [[ ! -f "${HELPER}" ]]; then
     printf '%s: helper not found: %s\n' "${PROGNAME}" "${HELPER}" >&2
     exit 69
   fi
@@ -88,11 +90,11 @@ check_path() {
   local any=0
   local file
 
-  if [ -f "${target}" ]; then
+  if [[ -f "${target}" ]]; then
     case "${target}" in
       *.py) check_file "${target}" || any=1 ;;
     esac
-  elif [ -d "${target}" ]; then
+  elif [[ -d "${target}" ]]; then
     while IFS= read -r file; do
       check_file "${file}" || any=1
     done < <(find "${target}" -maxdepth 1 -type f -name '*.py' 2>/dev/null)
@@ -104,13 +106,16 @@ check_path() {
 }
 
 main() {
-  if [ "$#" -eq 0 ]; then
+  if [[ "$#" -eq 0 ]]; then
     usage >&2
     exit 64
   fi
 
   case "${1:-}" in
-    -h|--help) usage; exit 0 ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
   esac
 
   preflight
@@ -124,6 +129,6 @@ main() {
   exit "${any}"
 }
 
-if [ "${0}" = "${BASH_SOURCE[0]:-$0}" ]; then
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   main "$@"
 fi

--- a/plugins/build/skills/check-python-script/scripts/check_ruff.sh
+++ b/plugins/build/skills/check-python-script/scripts/check_ruff.sh
@@ -38,16 +38,17 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 PROGNAME="$(basename "${0}")"
+readonly PROGNAME
 
-REQUIRED_CMDS=(awk find basename)
+readonly REQUIRED_CMDS=(awk find basename)
 
 # Rule codes that escalate to FAIL; all other ruff findings are WARN.
 # S604 is included with S602 (subprocess shell=True variants).
-FAIL_CODES="E722 F403 S108 S307 S602 S604"
+readonly FAIL_CODES="E722 F403 S108 S307 S602 S604"
 
 # The explicit selector set we pass to ruff. Kept in lockstep with the
 # severity map in emit_finding() so drift is visible at review time.
-RUFF_SELECT="D100,E722,SIM115,PLW1514,PTH,S602,S604,S307,F401,ANN,F403,S108,UP031,UP032"
+readonly RUFF_SELECT="D100,E722,SIM115,PLW1514,PTH,S602,S604,S307,F401,ANN,F403,S108,UP031,UP032"
 
 usage() {
   cat <<'EOF'
@@ -72,9 +73,9 @@ EOF
 
 install_hint() {
   case "${1}" in
-    awk|find|basename) printf 'should be preinstalled on any POSIX system' ;;
-    python3)           printf 'brew install python  |  apt install python3  |  dnf install python3' ;;
-    *)                 printf 'see your package manager' ;;
+    awk | find | basename) printf 'should be preinstalled on any POSIX system' ;;
+    python3) printf 'brew install python  |  apt install python3  |  dnf install python3' ;;
+    *) printf 'see your package manager' ;;
   esac
 }
 
@@ -86,7 +87,7 @@ preflight() {
       missing+=("${cmd}")
     fi
   done
-  if [ "${#missing[@]}" -gt 0 ]; then
+  if [[ "${#missing[@]}" -gt 0 ]]; then
     for cmd in "${missing[@]}"; do
       printf '%s: missing required command %q. Install: %s\n' \
         "${PROGNAME}" "${cmd}" "$(install_hint "${cmd}")" >&2
@@ -100,26 +101,26 @@ severity_for() {
   local code="$1"
   case " ${FAIL_CODES} " in
     *" ${code} "*) printf 'FAIL' ;;
-    *)             printf 'WARN' ;;
+    *) printf 'WARN' ;;
   esac
 }
 
 # Given a ruff rule code, emit a one-line repair hint.
 recommend_for() {
   case "$1" in
-    D100)    printf 'Add a module docstring as the first statement, naming the purpose and one example invocation.' ;;
-    E722)    printf 'Catch a specific exception type (FileNotFoundError, ValueError, ...) or use except Exception as err in main().' ;;
-    SIM115)  printf "Wrap the open() in a with statement so cleanup runs on exceptions." ;;
+    D100) printf 'Add a module docstring naming the purpose and one example invocation.' ;;
+    E722) printf "Catch a specific exception or use 'except Exception as err' in main()." ;;
+    SIM115) printf "Wrap the open() in a with statement so cleanup runs on exceptions." ;;
     PLW1514) printf "Pass encoding='utf-8' to open() to avoid platform-dependent defaults." ;;
-    PTH*)    printf 'Use pathlib.Path instead of os.path string manipulation.' ;;
-    S602|S604) printf 'Pass subprocess args as a list; never shell=True with interpolated input.' ;;
-    S307)    printf 'Replace eval/exec with ast.literal_eval or an explicit dispatch table.' ;;
-    F401)    printf 'Remove the unused import.' ;;
-    ANN*)    printf 'Add type annotations to the function signature.' ;;
-    F403)    printf 'Replace wildcard import with explicit named imports.' ;;
-    S108)    printf 'Use tempfile.TemporaryDirectory()/NamedTemporaryFile() instead of hand-built /tmp paths.' ;;
-    UP031|UP032) printf 'Rewrite as an f-string.' ;;
-    *)       printf 'See the ruff docs for this rule.' ;;
+    PTH*) printf 'Use pathlib.Path instead of os.path string manipulation.' ;;
+    S602 | S604) printf 'Pass subprocess args as a list; never shell=True with input.' ;;
+    S307) printf 'Replace eval/exec with ast.literal_eval or an explicit dispatch table.' ;;
+    F401) printf 'Remove the unused import.' ;;
+    ANN*) printf 'Add type annotations to the function signature.' ;;
+    F403) printf 'Replace wildcard import with explicit named imports.' ;;
+    S108) printf 'Use tempfile.NamedTemporaryFile/TemporaryDirectory, not hand-built /tmp paths.' ;;
+    UP031 | UP032) printf 'Rewrite as an f-string.' ;;
+    *) printf 'See the ruff docs for this rule.' ;;
   esac
 }
 
@@ -147,7 +148,7 @@ emit_finding() {
     "${severity}" "${path}" "${code}" "${message}" "${lineno}" "${col}"
   printf '  Recommendation: %s\n' "$(recommend_for "${code}")"
 
-  if [ "${severity}" = "FAIL" ]; then
+  if [[ "${severity}" = "FAIL" ]]; then
     return 1
   fi
   return 0
@@ -163,10 +164,13 @@ check_one() {
   while IFS= read -r line; do
     # Skip ruff's trailing summary lines ("Found N errors.").
     case "${line}" in
-      ""|"Found "*|"All checks passed"*) continue ;;
+      "" | "Found "* | "All checks passed"*) continue ;;
     esac
     emit_finding "${line}" || any=1
-  done < <(ruff check --no-cache --output-format=concise --select="${RUFF_SELECT}" "${target}" 2>/dev/null || true)
+  done < <(
+    ruff check --no-cache --output-format=concise \
+      --select="${RUFF_SELECT}" "${target}" 2>/dev/null || true
+  )
 
   # Format drift — separate invocation.
   if ! ruff format --check --no-cache "${target}" >/dev/null 2>&1; then
@@ -182,11 +186,11 @@ check_path() {
   local any=0
   local file
 
-  if [ -f "${target}" ]; then
+  if [[ -f "${target}" ]]; then
     case "${target}" in
       *.py) check_one "${target}" || any=1 ;;
     esac
-  elif [ -d "${target}" ]; then
+  elif [[ -d "${target}" ]]; then
     while IFS= read -r file; do
       check_one "${file}" || any=1
     done < <(find "${target}" -maxdepth 1 -type f -name '*.py' 2>/dev/null)
@@ -198,13 +202,16 @@ check_path() {
 }
 
 main() {
-  if [ "$#" -eq 0 ]; then
+  if [[ "$#" -eq 0 ]]; then
     usage >&2
     exit 64
   fi
 
   case "${1:-}" in
-    -h|--help) usage; exit 0 ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
   esac
 
   preflight
@@ -227,6 +234,6 @@ main() {
   exit "${any}"
 }
 
-if [ "${0}" = "${BASH_SOURCE[0]:-$0}" ]; then
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   main "$@"
 fi

--- a/plugins/build/skills/check-python-script/scripts/check_secrets.sh
+++ b/plugins/build/skills/check-python-script/scripts/check_secrets.sh
@@ -29,8 +29,9 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 PROGNAME="$(basename "${0}")"
+readonly PROGNAME
 
-REQUIRED_CMDS=(grep find basename)
+readonly REQUIRED_CMDS=(grep find basename)
 
 usage() {
   cat <<'EOF'
@@ -55,8 +56,8 @@ EOF
 
 install_hint() {
   case "${1}" in
-    grep|find|basename) printf 'should be preinstalled on any POSIX system' ;;
-    *)                  printf 'see your package manager' ;;
+    grep | find | basename) printf 'should be preinstalled on any POSIX system' ;;
+    *) printf 'see your package manager' ;;
   esac
 }
 
@@ -68,7 +69,7 @@ preflight() {
       missing+=("${cmd}")
     fi
   done
-  if [ "${#missing[@]}" -gt 0 ]; then
+  if [[ "${#missing[@]}" -gt 0 ]]; then
     for cmd in "${missing[@]}"; do
       printf '%s: missing required command %q. Install: %s\n' \
         "${PROGNAME}" "${cmd}" "$(install_hint "${cmd}")" >&2
@@ -86,7 +87,7 @@ emit_finding() {
 
 # Parallel arrays: specific API key patterns and their display names.
 # bash 3.2 has no associative arrays — use ordered arrays.
-PATTERN_NAMES=(
+readonly PATTERN_NAMES=(
   "AWS access key"
   "GitHub personal access token"
   "GitHub fine-grained PAT"
@@ -94,7 +95,7 @@ PATTERN_NAMES=(
   "Anthropic API key"
   "Stripe live key"
 )
-PATTERN_REGEXES=(
+readonly PATTERN_REGEXES=(
   'AKIA[0-9A-Z]{16}'
   'ghp_[A-Za-z0-9]{36}'
   'github_pat_[A-Za-z0-9_]{82}'
@@ -105,7 +106,8 @@ PATTERN_REGEXES=(
 
 # Credential-shaped variable assignment with a non-empty quoted value.
 # Python idiom — looks for `NAME = "value"` at any indent level.
-GENERIC_VAR_REGEX="(password|secret|token|api_key|access_key|private_key)[[:space:]]*=[[:space:]]*[\"'][^\"']+[\"']"
+readonly GENERIC_VAR_REGEX="(password|secret|token|api_key|access_key|private_key)""\
+[[:space:]]*=[[:space:]]*[\"'][^\"']+[\"']"
 
 scan_file() {
   local file="$1"
@@ -113,7 +115,7 @@ scan_file() {
   local i name pattern hit line
 
   i=0
-  while [ "${i}" -lt "${#PATTERN_REGEXES[@]}" ]; do
+  while [[ "${i}" -lt "${#PATTERN_REGEXES[@]}" ]]; do
     name="${PATTERN_NAMES[${i}]}"
     pattern="${PATTERN_REGEXES[${i}]}"
     while IFS= read -r hit; do
@@ -134,7 +136,8 @@ scan_file() {
       | grep -Ev "=[[:space:]]*[\"']\\\$" \
       | grep -Ev "=[[:space:]]*[\"']\\{" \
       | grep -Ev "=[[:space:]]*[\"']<" \
-      | grep -iEv "=[[:space:]]*[\"'](your[-_]|example|redacted|null|none|undefined|placeholder|todo|fixme|xxx|changeme|change[-_]me|foo|bar|baz|abc|xyz)" \
+      | grep -iEv "=[[:space:]]*[\"'](your[-_]|example|redacted|null|none|undefined|""\
+placeholder|todo|fixme|xxx|changeme|change[-_]me|foo|bar|baz|abc|xyz)" \
       || true
   )
 
@@ -146,11 +149,11 @@ scan_path() {
   local any=0
   local file
 
-  if [ -f "${target}" ]; then
+  if [[ -f "${target}" ]]; then
     case "${target}" in
       *.py) scan_file "${target}" || any=1 ;;
     esac
-  elif [ -d "${target}" ]; then
+  elif [[ -d "${target}" ]]; then
     while IFS= read -r file; do
       scan_file "${file}" || any=1
     done < <(find "${target}" -maxdepth 1 -type f -name '*.py' 2>/dev/null)
@@ -162,13 +165,16 @@ scan_path() {
 }
 
 main() {
-  if [ "$#" -eq 0 ]; then
+  if [[ "$#" -eq 0 ]]; then
     usage >&2
     exit 64
   fi
 
   case "${1:-}" in
-    -h|--help) usage; exit 0 ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
   esac
 
   preflight
@@ -182,6 +188,6 @@ main() {
   exit "${any}"
 }
 
-if [ "${0}" = "${BASH_SOURCE[0]:-$0}" ]; then
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   main "$@"
 fi

--- a/plugins/build/skills/check-python-script/scripts/check_size.sh
+++ b/plugins/build/skills/check-python-script/scripts/check_size.sh
@@ -25,11 +25,12 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 PROGNAME="$(basename "${0}")"
+readonly PROGNAME
 
 # Threshold lives here so it is trivial to locate and adjust.
-MAX_NON_BLANK_LINES=500
+readonly MAX_NON_BLANK_LINES=500
 
-REQUIRED_CMDS=(awk find basename wc)
+readonly REQUIRED_CMDS=(awk find basename wc)
 
 usage() {
   cat <<'EOF'
@@ -54,8 +55,8 @@ EOF
 
 install_hint() {
   case "${1}" in
-    awk|find|basename|wc) printf 'should be preinstalled on any POSIX system' ;;
-    *)                    printf 'see your package manager' ;;
+    awk | find | basename | wc) printf 'should be preinstalled on any POSIX system' ;;
+    *) printf 'see your package manager' ;;
   esac
 }
 
@@ -67,7 +68,7 @@ preflight() {
       missing+=("${cmd}")
     fi
   done
-  if [ "${#missing[@]}" -gt 0 ]; then
+  if [[ "${#missing[@]}" -gt 0 ]]; then
     for cmd in "${missing[@]}"; do
       printf '%s: missing required command %q. Install: %s\n' \
         "${PROGNAME}" "${cmd}" "$(install_hint "${cmd}")" >&2
@@ -85,7 +86,7 @@ check_file() {
   local file="$1"
   local count
   count="$(non_blank_count "${file}")"
-  if [ "${count}" -gt "${MAX_NON_BLANK_LINES}" ]; then
+  if [[ "${count}" -gt "${MAX_NON_BLANK_LINES}" ]]; then
     printf 'WARN  %s — size: %s non-blank lines (threshold %s)\n' \
       "${file}" "${count}" "${MAX_NON_BLANK_LINES}"
     printf '  Recommendation: Extract cohesive sections into helper '
@@ -97,11 +98,11 @@ check_path() {
   local target="$1"
   local file
 
-  if [ -f "${target}" ]; then
+  if [[ -f "${target}" ]]; then
     case "${target}" in
       *.py) check_file "${target}" ;;
     esac
-  elif [ -d "${target}" ]; then
+  elif [[ -d "${target}" ]]; then
     while IFS= read -r file; do
       check_file "${file}"
     done < <(find "${target}" -maxdepth 1 -type f -name '*.py' 2>/dev/null)
@@ -112,13 +113,16 @@ check_path() {
 }
 
 main() {
-  if [ "$#" -eq 0 ]; then
+  if [[ "$#" -eq 0 ]]; then
     usage >&2
     exit 64
   fi
 
   case "${1:-}" in
-    -h|--help) usage; exit 0 ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
   esac
 
   preflight
@@ -131,6 +135,6 @@ main() {
   exit 0
 }
 
-if [ "${0}" = "${BASH_SOURCE[0]:-$0}" ]; then
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   main "$@"
 fi

--- a/plugins/build/skills/check-python-script/scripts/check_structure.sh
+++ b/plugins/build/skills/check-python-script/scripts/check_structure.sh
@@ -27,10 +27,12 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 PROGNAME="$(basename "${0}")"
+readonly PROGNAME
 SCRIPT_DIR="$(cd "$(dirname "${0}")" && pwd)"
-HELPER="${SCRIPT_DIR}/_ast_checks.py"
+readonly SCRIPT_DIR
+readonly HELPER="${SCRIPT_DIR}/_ast_checks.py"
 
-REQUIRED_CMDS=(python3 find basename)
+readonly REQUIRED_CMDS=(python3 find basename)
 
 usage() {
   cat <<'EOF'
@@ -59,9 +61,9 @@ EOF
 
 install_hint() {
   case "${1}" in
-    python3)            printf 'brew install python  |  apt install python3  |  dnf install python3' ;;
-    find|basename)      printf 'should be preinstalled on any POSIX system' ;;
-    *)                  printf 'see your package manager' ;;
+    python3) printf 'brew install python  |  apt install python3  |  dnf install python3' ;;
+    find | basename) printf 'should be preinstalled on any POSIX system' ;;
+    *) printf 'see your package manager' ;;
   esac
 }
 
@@ -73,14 +75,14 @@ preflight() {
       missing+=("${cmd}")
     fi
   done
-  if [ "${#missing[@]}" -gt 0 ]; then
+  if [[ "${#missing[@]}" -gt 0 ]]; then
     for cmd in "${missing[@]}"; do
       printf '%s: missing required command %q. Install: %s\n' \
         "${PROGNAME}" "${cmd}" "$(install_hint "${cmd}")" >&2
     done
     exit 69
   fi
-  if [ ! -f "${HELPER}" ]; then
+  if [[ ! -f "${HELPER}" ]]; then
     printf '%s: helper not found: %s\n' "${PROGNAME}" "${HELPER}" >&2
     exit 69
   fi
@@ -96,11 +98,11 @@ check_path() {
   local any=0
   local file
 
-  if [ -f "${target}" ]; then
+  if [[ -f "${target}" ]]; then
     case "${target}" in
       *.py) check_file "${target}" || any=1 ;;
     esac
-  elif [ -d "${target}" ]; then
+  elif [[ -d "${target}" ]]; then
     while IFS= read -r file; do
       check_file "${file}" || any=1
     done < <(find "${target}" -maxdepth 1 -type f -name '*.py' 2>/dev/null)
@@ -112,13 +114,16 @@ check_path() {
 }
 
 main() {
-  if [ "$#" -eq 0 ]; then
+  if [[ "$#" -eq 0 ]]; then
     usage >&2
     exit 64
   fi
 
   case "${1:-}" in
-    -h|--help) usage; exit 0 ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
   esac
 
   preflight
@@ -132,6 +137,6 @@ main() {
   exit "${any}"
 }
 
-if [ "${0}" = "${BASH_SOURCE[0]:-$0}" ]; then
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   main "$@"
 fi


### PR DESCRIPTION
## Summary

- First real dogfooding of `/build:check-skill-pair` against an existing pair (`python-script`) surfaced 42 WARN findings across its six Tier-1 shell scripts — all pre-dating the `build-bash-script`/`check-bash-script` rubric.
- This PR is the full remediation pass: `shfmt -w`, `[ ]`→`[[ ]]` conversion, canonical sourceable-guard rewrite, `readonly` promotion in split-assign form (SC2155-safe), and line-length compression in `check_ruff.sh`.
- After the pass, `/build:check-bash-script plugins/build/skills/check-python-script/scripts/` returns `0 fail / 0 warn / 0 info` (from 42 warns), and every script still exits 0 on smoke tests against `_ast_checks.py`.

## Test plan

- [ ] `/build:check-bash-script plugins/build/skills/check-python-script/scripts/` returns `0 fail / 0 warn / 0 info`
- [ ] `/build:check-skill-pair python-script` still reports `0 fail / 0 warn`
- [ ] Each of the six scripts exits 0 when invoked against `plugins/build/skills/check-python-script/scripts/_ast_checks.py`
- [ ] `python3 plugins/wiki/scripts/lint.py --root . --no-urls` passes
- [ ] CI `ruff check plugins/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)