### PR TITLE
chore(build): self-audit cleanup for check-rule's two kept bash scripts

### DIFF
--- a/plugins/build/skills/check-rule/scripts/check_size.sh
+++ b/plugins/build/skills/check-rule/scripts/check_size.sh
@@ -25,11 +25,12 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 PROGNAME="$(basename "${0}")"
+readonly PROGNAME
 
-REQUIRED_CMDS=(awk find basename)
+readonly REQUIRED_CMDS=(awk find basename)
 
-WARN_THRESHOLD=200
-FAIL_THRESHOLD=500
+readonly WARN_THRESHOLD=200
+readonly FAIL_THRESHOLD=500
 
 usage() {
   cat <<'EOF'
@@ -55,8 +56,8 @@ EOF
 
 install_hint() {
   case "${1}" in
-    awk|find|basename) printf 'should be preinstalled on any POSIX system' ;;
-    *)                 printf 'see your package manager' ;;
+    awk | find | basename) printf 'should be preinstalled on any POSIX system' ;;
+    *) printf 'see your package manager' ;;
   esac
 }
 
@@ -68,7 +69,7 @@ preflight() {
       missing+=("${cmd}")
     fi
   done
-  if [ "${#missing[@]}" -gt 0 ]; then
+  if [[ "${#missing[@]}" -gt 0 ]]; then
     for cmd in "${missing[@]}"; do
       printf '%s: missing required command %q. Install: %s\n' \
         "${PROGNAME}" "${cmd}" "$(install_hint "${cmd}")" >&2
@@ -99,12 +100,12 @@ check_file() {
   local count
   count="$(count_nonblank "${file}")"
 
-  if [ "${count}" -gt "${FAIL_THRESHOLD}" ]; then
+  if [[ "${count}" -gt "${FAIL_THRESHOLD}" ]]; then
     emit_fail "${file}" "file size" \
       "${count} non-blank lines exceeds ${FAIL_THRESHOLD}-line hard cap" \
       "Split into rules and move long-form rationale to .context/<name>.md or a CLAUDE.md section"
     return 1
-  elif [ "${count}" -gt "${WARN_THRESHOLD}" ]; then
+  elif [[ "${count}" -gt "${WARN_THRESHOLD}" ]]; then
     emit_warn "${file}" "file size" \
       "${count} non-blank lines exceeds ${WARN_THRESHOLD}-line soft cap" \
       "Split into topic files (e.g., testing-unit.md + testing-integration.md)"
@@ -117,9 +118,9 @@ check_path() {
   local any=0
   local file
 
-  if [ -f "${target}" ]; then
+  if [[ -f "${target}" ]]; then
     check_file "${target}" || any=1
-  elif [ -d "${target}" ]; then
+  elif [[ -d "${target}" ]]; then
     while IFS= read -r file; do
       check_file "${file}" || any=1
     done < <(find "${target}" -type f -name '*.md' 2>/dev/null)
@@ -131,13 +132,16 @@ check_path() {
 }
 
 main() {
-  if [ "$#" -eq 0 ]; then
+  if [[ "$#" -eq 0 ]]; then
     usage >&2
     exit 64
   fi
 
   case "${1:-}" in
-    -h|--help) usage; exit 0 ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
   esac
 
   preflight
@@ -151,6 +155,6 @@ main() {
   exit "${any}"
 }
 
-if [ "${0}" = "${BASH_SOURCE[0]:-$0}" ]; then
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   main "$@"
 fi

--- a/plugins/build/skills/check-rule/scripts/emit_shape_hints.sh
+++ b/plugins/build/skills/check-rule/scripts/emit_shape_hints.sh
@@ -36,8 +36,9 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 PROGNAME="$(basename "${0}")"
+readonly PROGNAME
 
-REQUIRED_CMDS=(awk find basename)
+readonly REQUIRED_CMDS=(awk find basename)
 
 usage() {
   cat <<'EOF'
@@ -64,8 +65,8 @@ EOF
 
 install_hint() {
   case "${1}" in
-    awk|find|basename) printf 'should be preinstalled on any POSIX system' ;;
-    *)                 printf 'see your package manager' ;;
+    awk | find | basename) printf 'should be preinstalled on any POSIX system' ;;
+    *) printf 'see your package manager' ;;
   esac
 }
 
@@ -77,7 +78,7 @@ preflight() {
       missing+=("${cmd}")
     fi
   done
-  if [ "${#missing[@]}" -gt 0 ]; then
+  if [[ "${#missing[@]}" -gt 0 ]]; then
     for cmd in "${missing[@]}"; do
       printf '%s: missing required command %q. Install: %s\n' \
         "${PROGNAME}" "${cmd}" "$(install_hint "${cmd}")" >&2
@@ -127,9 +128,9 @@ scan_path() {
   local target="$1"
   local file
 
-  if [ -f "${target}" ]; then
+  if [[ -f "${target}" ]]; then
     scan_file "${target}"
-  elif [ -d "${target}" ]; then
+  elif [[ -d "${target}" ]]; then
     while IFS= read -r file; do
       scan_file "${file}"
     done < <(find "${target}" -type f -name '*.md' 2>/dev/null)
@@ -140,13 +141,16 @@ scan_path() {
 }
 
 main() {
-  if [ "$#" -eq 0 ]; then
+  if [[ "$#" -eq 0 ]]; then
     usage >&2
     exit 64
   fi
 
   case "${1:-}" in
-    -h|--help) usage; exit 0 ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
   esac
 
   preflight
@@ -157,12 +161,12 @@ main() {
     scan_path "${target}" || arg_err=1
   done
 
-  if [ "${arg_err}" -ne 0 ]; then
+  if [[ "${arg_err}" -ne 0 ]]; then
     exit 64
   fi
   exit 0
 }
 
-if [ "${0}" = "${BASH_SOURCE[0]:-$0}" ]; then
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   main "$@"
 fi


### PR DESCRIPTION
## Summary

- Applies the \`/build:check-bash-script\` remediation rubric (same one used in PRs #351 and #353) to the two shell scripts left in \`plugins/build/skills/check-rule/scripts/\` after the Python migration in #355: \`check_size.sh\` and \`emit_shape_hints.sh\`.
- No behavior change — this is formatting and idiom normalization only.

Normalization applied:

- \`if [ ... ]; then\` / \`elif [ ... ]\` → \`[[ ... ]]\` (9 sites across both files)
- Sourceable guard rewritten to canonical \`if [[ "\${BASH_SOURCE[0]}" == "\${0}" ]]; then main "\$@"; fi\`
- Top-level UPPERCASE constants promoted to \`readonly\` in SC2155-safe split-assign form (\`PROGNAME\`, \`REQUIRED_CMDS\`, \`WARN_THRESHOLD\`, \`FAIL_THRESHOLD\`)
- \`shfmt -i 2 -ci -bn -w\` normalizes spacing and case-branch layout

Follow-up to #355. The two scripts were deliberately kept in bash per the *Language Selection* guidance in \`primitive-routing.md\` (pure glue / pure text-stream regex).

## Test plan

- [x] \`/build:check-bash-script\` on both scripts: **0 fail / 0 warn**
- [x] \`bash -n\` syntax check passes on both
- [x] \`/build:check-rule\` functional smoke test: synthetic rule fixtures still trigger size WARN/FAIL and shape HINT lines unchanged
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)