### PR TITLE
chore(build): name magic scan-window constants in _ast_checks.py

### DIFF
--- a/plugins/build/skills/check-python-script/scripts/_ast_checks.py
+++ b/plugins/build/skills/check-python-script/scripts/_ast_checks.py
@@ -30,6 +30,11 @@ EXIT_CLEAN = 0
 EXIT_FAIL = 1
 EXIT_USAGE = 64
 
+# How far into a file to scan for a PEP 723 `# /// script` block.
+PEP723_SCAN_LINES = 50
+# How many top-of-file comment/docstring lines to consider a "header".
+HEADER_SCAN_LINES = 30
+
 # Stdlib module names available from Python 3.10 onward via sys.stdlib_module_names.
 # Fall back to a baked-in set for 3.9 compatibility.
 try:
@@ -444,8 +449,8 @@ def top_level_imports(tree: ast.Module) -> set[str]:
 
 
 def has_pep723_block(source: str) -> bool:
-    """Look for the `# /// script` PEP 723 block anywhere in the first 50 lines."""
-    for line in source.splitlines()[:50]:
+    """Look for the `# /// script` PEP 723 block in the header window."""
+    for line in source.splitlines()[:PEP723_SCAN_LINES]:
         if line.strip() == "# /// script":
             return True
     return False
@@ -464,7 +469,7 @@ def has_top_of_file_deps_comment(source: str) -> bool:
             or stripped.startswith("'''")
         ):
             header_lines.append(stripped.lower())
-            if len(header_lines) >= 30:
+            if len(header_lines) >= HEADER_SCAN_LINES:
                 break
         else:
             break


### PR DESCRIPTION
## Summary

- Surfaced by `/build:check-skill-pair python-script` dogfood of the Tier-1 scripts: the pair audit was clean, but running `/build:check-python-script` on `_ast_checks.py` flagged D8 Literal Intent for two unnamed header-scan windows (`50` and `30`).
- Hoisted to module-scope constants `PEP723_SCAN_LINES = 50` and `HEADER_SCAN_LINES = 30` so the intent of each window size is named where readers expect it.
- The six sibling shell scripts were also dogfooded against `/build:check-bash-script`: 0 fail / 0 warn / 2 info. The INFOs suggested a shared `_helpers.sh` and consolidating three Python-wrapper scripts; both were declined as deliberate design choices — the 1:1 mapping between Tier-1 scripts and the audit-dimensions table is part of the skill contract.

## Test plan

- [x] `bash plugins/build/skills/check-python-script/scripts/check_*.sh _ast_checks.py` — all six checkers clean post-edit
- [x] `python3 plugins/build/skills/check-skill-pair/scripts/audit_pair.py python-script` — 0 fail, 0 warn, 2 info (dogfood advisories only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)