### PR TITLE
Loosen context paths; add nested-resolver groundwork

### DIFF
--- a/RESOLVER.md
+++ b/RESOLVER.md
@@ -35,3 +35,5 @@ Routing table for filing new content and loading context. Machine-managed region
 ## Notes
 
 Add context bundles or filing conventions here; prose outside the managed region survives regeneration.
+
+When filing into a directory not listed above (and not in **Out of scope**), run `/build:check-resolver` first. It either confirms the directory is a dark capability that needs a filing row, or surfaces drift to regenerate. Routing follows the most specific `RESOLVER.md` on the filing path — today the root resolver is the only one, but nested resolvers may be introduced for directories with rich substructure.

--- a/plugins/build/_shared/references/resolver-best-practices.md
+++ b/plugins/build/_shared/references/resolver-best-practices.md
@@ -35,11 +35,11 @@ Routing table for filing new content and loading context. Machine-managed region
 | scoped context | `.context/` | `<slug>.context.md` |
 | shared reference | `plugins/<plugin>/_shared/references/` | `<slug>.md` |
 
-## Context — what to load before acting
+## Context — what to look at before acting
 
-| When doing… | Load first |
+| When doing… | Look in |
 |---|---|
-| planning research | `.research/_index.md` |
+| planning research | `.research/` |
 | planning work | `.plans/_index.md` |
 | authoring a rule | `_shared/references/rule-best-practices.md` |
 
@@ -82,7 +82,7 @@ cases:
 
 **Disk-derived, not hand-curated.** Hand-editing the filing table is the failure mode the check catches. The filing table reflects observable reality (what directories exist, what their `_index.md` says); the check flags drift in both directions — tables that lie about the repo and repos that grew directories the table doesn't know about.
 
-**Cross-link, don't restate.** Filing rows point at `_index.md` files and directory conventions; they don't copy contents. Context rows point at shared-reference docs; they don't summarize them. Duplication produces drift on the first rename and rewards maintenance effort in the wrong place.
+**Cross-link, don't restate.** Filing rows point at `_index.md` files and directory conventions; they don't copy contents. Context rows point at specific files to read or directories to look in (the agent consults `_index.md` first, descending on need); they don't summarize the docs. Duplication produces drift on the first rename and rewards maintenance effort in the wrong place.
 
 **Primary-subject filing.** Content is filed by its primary subject, not by source format, producing skill, or incidental metadata. A Slack thread about a person goes to `.people/`, not `.inbox/`; a research doc about a pipeline goes to `.research/`, not `.pipelines/`. The filing row's column order — *content type first, location second* — enforces this.
 
@@ -98,7 +98,7 @@ cases:
 
 **Filing rows point at directories, not individual files.** Directories evolve; filenames don't. A row pointing at `.research/` with a naming pattern survives a hundred new files; a row pointing at `.research/2026-04-21-resolvers.research.md` rots on the next entry.
 
-**Context rows bundle the 2–3 docs a task needs.** A task rarely needs one doc — authoring a hook needs routing + hook best practices + the relevant primitive doc. Bundling is how the resolver compresses context; single-doc rows leave Claude to assemble the bundle at invocation time.
+**Context rows bundle the 2–3 entries a task needs.** A task rarely needs one entry — authoring a hook needs routing + hook best practices + the relevant primitive doc. An entry is either a specific file or a directory to look in; a directory counts as one entry, not N files. Bundling is how the resolver compresses context; single-entry rows leave Claude to assemble the bundle at invocation time.
 
 **Explicit out-of-scope list.** Directories the resolver intentionally ignores (`.raw/`, `.cache/`, `node_modules/`, `.git/`) are listed by name so the auditor doesn't flag them as dark capabilities. Silence is ambiguous; explicit exclusion is load-bearing.
 
@@ -123,6 +123,16 @@ cases:
 **Deep nested resolver hierarchy before the flat one earns its keep.** One resolver at the root handles the vast majority of filing and context decisions. Nested per-plugin resolvers are a scaling option, not a starting shape. Build the root resolver first; add nesting when cross-plugin routing genuinely conflicts.
 
 **Skill-dispatch entries in the filing/context tables.** "When user says 'plan something' → run `/work:plan-work`" belongs in skill descriptions, not the resolver. Conflating dispatch with information routing bloats the resolver and duplicates logic Anthropic already ships.
+
+## Nesting
+
+Nesting is a scaling option: a directory with enough internal filing and context structure to warrant its own routing table gets its own `RESOLVER.md`. Routing follows the **most specific resolver on the filing path** — walking up from the target directory, the nearest `RESOLVER.md` wins. The root resolver covers everything not claimed by a nested one.
+
+**Each resolver owns its evals.** A nested `plugins/build/RESOLVER.md` carries a sibling `plugins/build/.resolver/evals.yml`; the root `.resolver/evals.yml` does not test nested rows. Co-location matches how the auditor operates — one resolver at a time — and keeps nested resolvers self-contained when copied, moved, or extracted.
+
+**The auditor scopes to one resolver.** `/build:check-resolver` takes a target path, walks up to the nearest `RESOLVER.md`, and audits that file plus its sibling `.resolver/evals.yml`. Auditing every resolver in a repo means running the skill once per resolver root; there is no recursive whole-repo mode.
+
+**Don't nest until the flat resolver hurts.** A single root resolver handles most repos indefinitely. Nest only when filing rules genuinely diverge per subtree — a plugin's content really does file differently from the project's — not when the root table feels long. Long is cheap; nested drift is expensive.
 
 ## Safety & Maintenance
 

--- a/plugins/build/skills/build-resolver/SKILL.md
+++ b/plugins/build/skills/build-resolver/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: build-resolver
 description: Scaffold a root-level RESOLVER.md — a dual routing table (filing for writes, context for reads) plus an AGENTS.md pointer and a trigger-eval sidecar at `.resolver/evals.yml`. Use when the user wants to "create a resolver", "scaffold RESOLVER.md", "add a routing table for filing and context", or "set up dynamic context routing".
-argument-hint: "[repo root path — defaults to CWD]"
+argument-hint: "[target directory — defaults to CWD; walks up to nearest existing RESOLVER.md, or scaffolds at target]"
 user-invocable: true
 references:
   - ../../_shared/references/resolver-best-practices.md
@@ -28,18 +28,22 @@ Redirect when:
 
 ### 1. Detect Existing Resolver
 
-Check `RESOLVER.md` and `.resolver/evals.yml` at the target root. If either exists, switch to regenerate mode:
+Walk up from the target directory looking for an existing `RESOLVER.md`. The first ancestor that has one becomes the **resolver root** for this run.
 
-- Preserve human prose outside `<!-- resolver:begin -->` / `<!-- resolver:end -->` markers
-- Preserve existing context-table rows and out-of-scope list
-- Rebuild the filing table from a fresh disk scan
-- Re-run evals after writing
+- **Found** → regenerate mode at the discovered resolver root:
+  - Preserve human prose outside `<!-- resolver:begin -->` / `<!-- resolver:end -->` markers
+  - Preserve existing context-table rows and out-of-scope list
+  - Rebuild the filing table from a fresh disk scan scoped to the resolver root's subtree
+  - Re-run evals after writing (Step 8)
+- **Not found** → scaffold mode at the target directory itself:
+  - The target becomes the resolver root
+  - Confirm with the user before scaffolding a nested resolver (anything other than the repo root) — nesting earns its place only when filing rules genuinely diverge per subtree (see [resolver-best-practices.md](../../_shared/references/resolver-best-practices.md) → "Nesting")
 
-Announce the mode and what will change before proceeding.
+Announce the mode, the resolver root, and what will change before proceeding. All subsequent steps operate scoped to the resolver root, not necessarily the repo root.
 
-### 2. Scan Target Repo
+### 2. Scan Resolver Root
 
-Walk the repo root and collect:
+Walk the resolver root's subtree (depth 1–2) and collect:
 
 - **Directories with `_index.md`** — primary filing targets. Read each `_index.md`'s frontmatter `name` and `description`.
 - **Directories without `_index.md` but with frontmatter-tagged files** (e.g., `type: research` across files in `.research/`) — secondary filing candidates.
@@ -63,7 +67,7 @@ This is human-provided. Ask:
 
 > "Name up to 5 recurring tasks whose reference-doc set should be bundled. Examples: 'authoring a hook', 'planning research', 'debugging the data pipeline'. For each, list the docs to load first."
 
-Validate that each listed doc path resolves. If not, flag and ask for a correction before writing.
+Validate that each listed entry resolves to a file or directory. Directory entries are valid — the convention is "look in this directory's `_index.md` first, descend on need." If a path doesn't resolve, flag and ask for a correction before writing.
 
 ### 5. Seed Trigger Evals
 
@@ -85,15 +89,17 @@ Iterate on feedback. Hold the write until the user approves.
 
 ### 7. Write
 
-- Create `RESOLVER.md` at the target repo root
-- Create `.resolver/evals.yml` (create `.resolver/` if missing)
-- Apply the AGENTS.md pointer diff (create AGENTS.md with just the pointer if it doesn't exist; warn that an AGENTS.md with more context is recommended)
+- Create `RESOLVER.md` at the resolver root
+- Create `.resolver/evals.yml` as a sibling under the resolver root (create `.resolver/` if missing) — co-located so the resolver and its evals move together
+- Apply the AGENTS.md pointer diff (use the AGENTS.md at the resolver root; create one with just the pointer if it doesn't exist; warn that an AGENTS.md with more context is recommended)
 
 Report each file path.
 
 ### 8. Hand Off
 
-Offer: "Run `/build:check-resolver` against the new resolver?" Run it on approval. Evals failing on the first run means the seeded expectations don't match the filing/context shape — fix the evals, not the resolver.
+In **regenerate mode** (Step 1), run `/build:check-resolver --run-evals` automatically after writing — the managed region changed, so the seeded prompts must be re-proven against the new routing. Report the eval pass rate alongside the audit findings.
+
+In **fresh-scaffold mode**, offer: "Run `/build:check-resolver` against the new resolver?" Run it on approval; pass `--run-evals` only if the user asks. Evals failing on the first run means the seeded expectations don't match the filing/context shape — fix the evals, not the resolver.
 
 ## Example
 
@@ -137,6 +143,6 @@ Step 8: runs `/build:check-resolver`. All Tier-1 checks PASS; two Tier-2 WARN on
 
 ## Handoff
 
-**Receives:** Target repo root (defaults to CWD).
-**Produces:** `RESOLVER.md` at root, `.resolver/evals.yml`, and an AGENTS.md pointer line (appended or created).
+**Receives:** Target directory (defaults to CWD); walks up to the nearest existing `RESOLVER.md` for regenerate mode, or scaffolds at the target for fresh-scaffold mode.
+**Produces:** `RESOLVER.md` at the resolver root, sibling `.resolver/evals.yml`, and an AGENTS.md pointer line at the resolver root (appended or created).
 **Chainable to:** `/build:check-resolver` (audits the three artifacts; runs evals; flags dark capabilities).

--- a/plugins/build/skills/check-resolver/SKILL.md
+++ b/plugins/build/skills/check-resolver/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: check-resolver
 description: Audit a root-level resolver — verify AGENTS.md pointer, managed-region integrity, filing-table coverage against disk, context-table actionability, and trigger-eval pass rate. Use when the user wants to "audit a resolver", "check RESOLVER.md", "validate routing table", "find dark capabilities", or "are my filing rules current".
-argument-hint: "[repo root path — defaults to CWD]"
+argument-hint: "[target directory — defaults to CWD; walks up to the nearest RESOLVER.md and audits that one]"
 user-invocable: true
 references:
   - ../../_shared/references/resolver-best-practices.md
@@ -19,14 +19,16 @@ The audit rubric mirrors the authoring principles in [resolver-best-practices.md
 
 ### 1. Discover Resolver Artifacts
 
-Locate three artifacts at the target root:
+Walk up from the target directory looking for `RESOLVER.md`. The first ancestor that has one becomes the **resolver root** for this audit; all checks scope to that resolver and its subtree.
+
+Locate three artifacts at the resolver root:
 - `RESOLVER.md`
-- `AGENTS.md` (for the pointer check)
-- `.resolver/evals.yml`
+- `AGENTS.md` (for the pointer check) — at the resolver root
+- `.resolver/evals.yml` — sibling to `RESOLVER.md` under the resolver root
 
-Report: "Found resolver at <path>. Auditing N filing rows, M context rows, K eval cases."
+Report: "Found resolver at <resolver root>. Auditing N filing rows, M context rows, K eval cases."
 
-If `RESOLVER.md` is missing, emit FAIL and stop — nothing to audit.
+If no `RESOLVER.md` is found anywhere up to the filesystem root, emit FAIL and stop — nothing to audit. To audit every resolver in a repo with nested resolvers, run this skill once per resolver root.
 
 ### 2. Tier 1 — Deterministic Checks
 
@@ -59,7 +61,7 @@ Output per dimension: `evidence → reasoning → verdict (WARN or PASS) → rec
 
 ### 4. Tier 3 — Cross-Artifact Checks
 
-**Dark capabilities scan.** For every directory at the repo root (depth 1–2), check whether it appears in the filing table, the out-of-scope list, or a baked-in ambient list (`.git`, `node_modules`, `dist`, `build`, `.cache`, `.venv`, `target`, `__pycache__`). Anything unclassified → WARN.
+**Dark capabilities scan.** Mechanized in `check_resolver.py` as Tier-1 `dark-capability`. For every directory under the resolver root (depth 1–2 from that root), check whether it appears in the filing table, the context table, the out-of-scope list, the ambient default list (`.git`, `node_modules`, `dist`, `build`, `.cache`, `.venv`, `target`, `__pycache__`, `.resolver`), or contains a nested `RESOLVER.md` (delegation — that subtree belongs to the nested resolver, not this one). Anything unclassified → WARN. Subdirectories of a filing dir are not auto-classified.
 
 **Staleness signal.** Compare `RESOLVER.md` mtime against a fresh regeneration output (simulated via the same scan `build-resolver` would run). Differences → WARN ("filing table drifted from disk; regenerate").
 
@@ -138,6 +140,6 @@ WARN  .resolver/evals.yml — no negative cases in 8 eval rows
 
 ## Handoff
 
-**Receives:** Target repo root (defaults to CWD); optional `--run-evals` flag.
+**Receives:** Target directory (defaults to CWD); walks up to the nearest `RESOLVER.md` and audits that resolver. Optional `--run-evals` flag.
 **Produces:** Structured findings report in file/issue/severity format.
 **Chainable to:** `/build:build-resolver --regenerate` (rebuild managed region); `/build:build-resolver --add-filing <type>` (add missing row).

--- a/plugins/build/skills/check-resolver/references/audit-dimensions.md
+++ b/plugins/build/skills/check-resolver/references/audit-dimensions.md
@@ -41,10 +41,11 @@ Handle deterministic checks (pointer presence, path resolution, YAML parse, mtim
 | `check_pointer.py` | `pointer-resolves` | The path named in the pointer exists on disk | FAIL | AGENTS.md pointer, not skill mandates |
 | `check_resolver.py` | `markers-present` | `<!-- resolver:begin -->` and `<!-- resolver:end -->` each appear exactly once | FAIL | Machine-managed region |
 | `check_resolver.py` | `filing-paths-resolve` | Every directory in the filing table exists | FAIL | Disk-derived, not hand-curated |
-| `check_resolver.py` | `context-paths-resolve` | Every doc path in the context table exists | FAIL | Cross-link, don't restate |
+| `check_resolver.py` | `context-paths-resolve` | Every doc path in the context table resolves to a file or directory | FAIL | Cross-link, don't restate |
 | `check_resolver.py` | `filing-rows-unique` | No two filing rows share a content-type | FAIL | Two tables, one file |
 | `check_resolver.py` | `context-rows-unique` | No two context rows share a task | FAIL | Two tables, one file |
 | `check_evals.py` | `evals-parse` | `.resolver/evals.yml` is valid YAML with the expected schema | FAIL | Trigger evals prove routing |
+| `check_resolver.py` | `dark-capability` | Every depth 1–2 directory is in filing, context, out-of-scope, ambient set, or contains a nested `RESOLVER.md` (delegation) | WARN | Reachability + staleness |
 | `check_resolver.py` | `mtime-stale` | `RESOLVER.md` mtime older than 90 days | WARN | Reachability + staleness |
 | `check_evals.py` | `eval-pass-stale` | Last recorded eval-pass timestamp older than 30 days | WARN | Reachability + staleness |
 
@@ -85,18 +86,17 @@ For each dimension: **verdict** (WARN, PASS, or N/A), **evidence**, **recommenda
 
 *(principle — [Cross-link, don't restate](../../../_shared/references/resolver-best-practices.md))*
 
-**What it checks:** Does each context-table row name concrete doc paths (not vague prose)? Is the bundle size appropriate — enough to compress useful context, not so many that the bundle defeats the purpose?
+**What it checks:** Does each context-table row name concrete paths (files or directories), not vague prose? Is the bundle size appropriate — enough to compress useful context, not so many that the bundle defeats the purpose?
 
 **Fail signals (→ WARN):**
-- A context row's "Load first" column contains prose ("the style guide") without a resolvable path
-- A bundle lists zero docs (empty right-hand column)
-- A bundle lists >6 docs (approaching a "just load everything" pattern)
-- Doc paths point at directories rather than files (invites re-scan cost on every task)
+- A context row's column contains prose ("the style guide") without a resolvable path
+- A bundle lists zero entries (empty right-hand column)
+- A bundle lists >6 entries (approaching a "just look everywhere" pattern)
 
 **Pass signals:**
-- Each bundle lists 1–4 concrete file paths
-- Paths are specific files, not directory stems
-- Bundle scope matches the task named (authoring a hook loads hook + routing, not the whole style guide)
+- Each bundle lists 1–4 concrete entries (files or directories)
+- Each entry resolves to a real path; directories follow the convention of having an `_index.md` to consult first
+- Bundle scope matches the task named (authoring a hook points at hook + routing, not the whole style guide)
 
 **Canonical Repair:** See `repair-playbook.md` → Dimension 2.
 
@@ -139,9 +139,11 @@ For each dimension: **verdict** (WARN, PASS, or N/A), **evidence**, **recommenda
 
 ### Signal: dark capabilities — directory on disk not classified
 
-**What it checks:** For every depth 1–2 directory, classify as: in-filing, in-context, in-out-of-scope, or ambient (baked-in list: `.git/`, `node_modules/`, `dist/`, `build/`, `.cache/`, `.venv/`, `target/`, `__pycache__/`). Unclassified directories are "dark capabilities" — reachable on disk but invisible to Claude's filing decisions.
+**What it checks:** For every depth 1–2 directory, classify as: in-filing, in-context, in-out-of-scope, ambient (baked-in list: `.git/`, `node_modules/`, `dist/`, `build/`, `.cache/`, `.venv/`, `target/`, `__pycache__/`, `.resolver/`), or *delegated* (the directory contains a nested `RESOLVER.md`). Unclassified directories are "dark capabilities" — reachable on disk but invisible to Claude's filing decisions. Subdirectories of a filing dir are *not* auto-classified — the filing rule names files directly inside.
 
-**Fail signals (→ WARN):** Depth 1–2 directory exists with no row in filing, context, or out-of-scope, and is not in the ambient default list.
+**Mechanized.** This signal is implemented deterministically by `check_resolver.py` (Tier 1, `dark-capability`) and surfaces here as a Tier-3 cross-reference; the LLM rubric does not re-evaluate it.
+
+**Fail signals (→ WARN):** Depth 1–2 directory exists with no row in filing, context, or out-of-scope; not in the ambient default list; no nested `RESOLVER.md` inside.
 
 **Pass signals:** Every depth 1–2 directory is classified.
 
@@ -186,9 +188,10 @@ PASS anchor: every .research/, .plans/, .designs/ has a filing row; .git/ and no
 FAIL anchor: .inbox/ exists on disk with 10 files; no filing row names it; no out-of-scope entry
 
 ## Dimension 2: Context Actionability
-Criterion: Does each context row list 1-4 concrete file paths that resolve?
+Criterion: Does each context row list 1-4 concrete entries (files or directories) that resolve?
 
 PASS anchor: "authoring a hook" → [_shared/references/primitive-routing.md, _shared/references/hook-best-practices.md]
+PASS anchor: "planning research" → [.research/]   (directory entry; agent consults _index.md first)
 FAIL anchor: "building features" → "read the style guide"
 
 ## Dimension 3: Eval Representativeness

--- a/plugins/build/skills/check-resolver/references/repair-playbook.md
+++ b/plugins/build/skills/check-resolver/references/repair-playbook.md
@@ -47,11 +47,11 @@ Every FAIL and WARN finding maps to a canonical repair. Before applying, state t
 **TO:** Either delete the row or `mkdir .designs/` and add an `_index.md`
 **REASON:** A filing row that doesn't resolve routes new content into nothing.
 
-### Signal: `context-paths-resolve` — context bundle points at missing doc
+### Signal: `context-paths-resolve` — context bundle points at missing path
 
-**CHANGE:** Update the path to the doc's current location, or remove the entry from the bundle
+**CHANGE:** Update the path to its current location (file or directory), or remove the entry from the bundle
 **FROM:** Bundle lists `_shared/references/hook-best-practices.md` at path no longer present
-**TO:** Correct to `plugins/build/_shared/references/hook-best-practices.md` (or remove)
+**TO:** Correct to `plugins/build/_shared/references/hook-best-practices.md` (or remove). A directory entry like `.research/` is also valid — the agent consults its `_index.md` and descends on need.
 **REASON:** Broken context loads train Claude to skip the resolver.
 
 ### Signal: `filing-rows-unique` — duplicate filing rows
@@ -114,15 +114,8 @@ Every FAIL and WARN finding maps to a canonical repair. Before applying, state t
 
 **Signal:** Bundle is empty or has >6 entries.
 
-**CHANGE:** Narrow to 1–4 load-bearing docs
-**REASON:** Empty bundles defeat the purpose; large bundles equal "just load everything" and waste context budget.
-
-**Signal:** Bundle lists directories, not files.
-
-**CHANGE:** Replace directory stems with specific file paths
-**FROM:** `| authoring a hook | [_shared/references/] |`
-**TO:** `| authoring a hook | [_shared/references/hook-best-practices.md, _shared/references/primitive-routing.md] |`
-**REASON:** Directory pointers invite re-scan on every task; file pointers are constant-time loads.
+**CHANGE:** Narrow to 1–4 load-bearing entries (files or directories)
+**REASON:** Empty bundles defeat the purpose; large bundles equal "just look everywhere" and waste context budget. A directory counts as one entry — the agent consults its `_index.md` and descends on need.
 
 ### Dimension 3: Eval Representativeness
 

--- a/plugins/build/skills/check-resolver/scripts/check_resolver.py
+++ b/plugins/build/skills/check-resolver/scripts/check_resolver.py
@@ -1,18 +1,30 @@
 #!/usr/bin/env python3
 """Deterministic Tier-1 checks for the RESOLVER.md managed region.
 
-Six checks per target repo root:
+Given a target directory, walks up to the nearest ``RESOLVER.md`` and
+audits that resolver. The discovered ancestor becomes the resolver
+root, and all checks scope to its subtree (not the filesystem repo).
+
+Seven checks per resolver root:
 
 - **markers-present** — both ``<!-- resolver:begin -->`` and
   ``<!-- resolver:end -->`` appear exactly once. FAIL otherwise.
 - **filing-paths-resolve** — every Location column value in the filing
   table resolves to a directory on disk. FAIL on miss.
 - **context-paths-resolve** — every doc path in the context table's
-  "Load first" column resolves to a file on disk. FAIL on miss.
+  "Load first" column resolves to a file or directory on disk. FAIL
+  on miss. Directories are valid context entries — the convention
+  is to look in the directory's ``_index.md`` first and descend
+  on need.
 - **filing-rows-unique** — the filing table's first column (content
   type) has no duplicates. FAIL on duplicate.
 - **context-rows-unique** — the context table's first column (task)
   has no duplicates. FAIL on duplicate.
+- **dark-capability** — every depth 1–2 directory under the resolver
+  root is classified by filing table, context table, out-of-scope
+  list, the ambient default set, or a nested ``RESOLVER.md``
+  (delegation — that subtree belongs to the nested resolver). WARN
+  on any unclassified directory.
 - **mtime-stale** — RESOLVER.md mtime older than 90 days. WARN.
 
 Paths containing template placeholders (``<...>``, ``*``) are skipped
@@ -38,12 +50,33 @@ EXIT_INTERRUPTED = 130
 RESOLVER_FILENAME = "RESOLVER.md"
 MARKER_BEGIN = "<!-- resolver:begin -->"
 MARKER_END = "<!-- resolver:end -->"
-STALE_SECONDS = 90 * 24 * 60 * 60
+SECONDS_PER_DAY = 24 * 60 * 60
+STALE_DAYS = 90
+STALE_SECONDS = STALE_DAYS * SECONDS_PER_DAY
+
+# Directories ignored by the dark-capability scan regardless of resolver
+# contents. Mirrors the ambient list documented in audit-dimensions.md.
+# `.resolver` is the resolver's own machinery (siblings to RESOLVER.md).
+AMBIENT_BASENAMES = frozenset(
+    {
+        ".git",
+        "node_modules",
+        "dist",
+        "build",
+        ".cache",
+        ".venv",
+        "target",
+        "__pycache__",
+        ".resolver",
+    }
+)
 
 H2_RE = re.compile(r"^##\s+(.+?)\s*$", re.MULTILINE)
 TABLE_ROW_RE = re.compile(r"^\s*\|(.+)\|\s*$")
 SEPARATOR_ROW_RE = re.compile(r"^\s*\|[\s\-|:]+\|\s*$")
 PLACEHOLDER_RE = re.compile(r"[<>*]")
+OOS_BULLET_LINE_RE = re.compile(r"^\s*[-*]\s+")
+OOS_PATH_RE = re.compile(r"`([^`]+)`")
 
 
 def emit_fail(path: Path, check: str, detail: str, recommendation: str) -> None:
@@ -150,7 +183,7 @@ def check_markers(resolver_path: Path, text: str) -> bool:
     return False
 
 
-def check_filing_table(resolver_path: Path, repo_root: Path, region: str) -> bool:
+def check_filing_table(resolver_path: Path, resolver_root: Path, region: str) -> bool:
     rows = find_section_table(region, "Filing")
     ok = True
     seen_keys: dict[str, int] = {}
@@ -174,7 +207,7 @@ def check_filing_table(resolver_path: Path, repo_root: Path, region: str) -> boo
             seen_keys[content_type] = idx
         if PLACEHOLDER_RE.search(location):
             continue
-        resolved = (repo_root / location).resolve()
+        resolved = (resolver_root / location).resolve()
         if not resolved.is_dir():
             emit_fail(
                 resolver_path,
@@ -187,7 +220,7 @@ def check_filing_table(resolver_path: Path, repo_root: Path, region: str) -> boo
     return ok
 
 
-def check_context_table(resolver_path: Path, repo_root: Path, region: str) -> bool:
+def check_context_table(resolver_path: Path, resolver_root: Path, region: str) -> bool:
     rows = find_section_table(region, "Context")
     ok = True
     seen_tasks: dict[str, int] = {}
@@ -211,45 +244,204 @@ def check_context_table(resolver_path: Path, repo_root: Path, region: str) -> bo
         for doc_path in extract_paths_from_load_cell(load_cell):
             if PLACEHOLDER_RE.search(doc_path):
                 continue
-            resolved = (repo_root / doc_path).resolve()
-            if not resolved.is_file():
+            resolved = (resolver_root / doc_path).resolve()
+            if not resolved.exists():
                 emit_fail(
                     resolver_path,
                     "context-paths-resolve",
                     f"context doc '{doc_path}' (task '{task}') "
-                    "does not resolve to a file",
+                    "does not resolve to a file or directory",
                     "Correct the path, or remove the entry from the bundle",
                 )
                 ok = False
     return ok
 
 
+def parse_out_of_scope(region: str) -> set[str]:
+    """Extract directory paths from the 'Out of scope' bullet list."""
+    paths: set[str] = set()
+    in_section = False
+    for line in region.splitlines():
+        h2 = H2_RE.match(line)
+        if h2:
+            heading = h2.group(1).strip().lower()
+            if heading.startswith("out of scope"):
+                in_section = True
+                continue
+            if in_section:
+                break
+            continue
+        if not in_section:
+            continue
+        if not OOS_BULLET_LINE_RE.match(line):
+            continue
+        for match in OOS_PATH_RE.finditer(line):
+            paths.add(match.group(1).strip().rstrip("/"))
+    return paths
+
+
+def collect_classified(region: str) -> tuple[set[str], set[str], set[str]]:
+    """Return (filing_dirs, recursive_dirs, oos_dirs) drawn from the managed region.
+
+    - **filing_dirs**: filing-table locations. Only the directory itself is
+      classified — subdirectories beneath a filing dir are *dark* unless
+      separately classified, since the filing rule names files directly
+      inside.
+    - **recursive_dirs**: context-table paths plus the out-of-scope list.
+      Descendants are classified — the agent descends into context dirs on
+      need and out-of-scope dirs are pruned entirely.
+    - **oos_dirs**: out-of-scope subset of recursive_dirs, used to skip
+      descent during the depth-2 walk.
+    """
+    filing_dirs: set[str] = set()
+    for cells in find_section_table(region, "Filing"):
+        if len(cells) < 2:
+            continue
+        location = strip_backticks(cells[1]).rstrip("/")
+        if location and not PLACEHOLDER_RE.search(location):
+            filing_dirs.add(location)
+    context_dirs: set[str] = set()
+    for cells in find_section_table(region, "Context"):
+        if len(cells) < 2:
+            continue
+        for doc_path in extract_paths_from_load_cell(cells[1]):
+            if PLACEHOLDER_RE.search(doc_path):
+                continue
+            context_dirs.add(doc_path.rstrip("/"))
+    oos_dirs = parse_out_of_scope(region)
+    recursive_dirs = context_dirs | oos_dirs
+    return filing_dirs, recursive_dirs, oos_dirs
+
+
+def is_classified(rel: str, filing_dirs: set[str], recursive_dirs: set[str]) -> bool:
+    if rel in filing_dirs or rel in recursive_dirs:
+        return True
+    if any(rel.startswith(p + "/") for p in recursive_dirs):
+        return True
+    rel_prefix = rel + "/"
+    return any(p.startswith(rel_prefix) for p in (filing_dirs | recursive_dirs))
+
+
+def is_under_oos(rel: str, oos: set[str]) -> bool:
+    return rel in oos or any(rel.startswith(prefix + "/") for prefix in oos)
+
+
+def emit_dark(resolver_path: Path, rel: str) -> None:
+    emit_warn(
+        resolver_path,
+        "dark-capability",
+        f"directory '{rel}/' not in filing table, context table, or out of scope",
+        "Add a filing row, mark out-of-scope, or place a nested "
+        "RESOLVER.md inside it; regenerate via "
+        "/build:build-resolver --regenerate",
+    )
+
+
+def scan_subdir(
+    resolver_path: Path,
+    entry: Path,
+    rel: str,
+    filing_dirs: set[str],
+    recursive_dirs: set[str],
+) -> bool:
+    """Scan one depth-1 directory's children. Returns True if all clean."""
+    ok = True
+    try:
+        children = sorted(entry.iterdir())
+    except (OSError, PermissionError):
+        return ok
+    for sub in children:
+        if not sub.is_dir():
+            continue
+        if sub.name in AMBIENT_BASENAMES:
+            continue
+        if (sub / RESOLVER_FILENAME).is_file():
+            continue
+        sub_rel = f"{rel}/{sub.name}"
+        if is_classified(sub_rel, filing_dirs, recursive_dirs):
+            continue
+        emit_dark(resolver_path, sub_rel)
+        ok = False
+    return ok
+
+
+def check_dark_capabilities(
+    resolver_path: Path, resolver_root: Path, region: str
+) -> bool:
+    """Walk depth 1–2 directories and warn on any unclassified entry.
+
+    A directory is classified when it appears in the filing table, the
+    context table, the out-of-scope list, the ambient basename set, or
+    contains a nested ``RESOLVER.md`` (delegation seed for future
+    nested-resolver work). Subdirectories of a filing dir are *not*
+    auto-classified — the filing rule covers files inside the dir, not
+    nested directories.
+    """
+    filing_dirs, recursive_dirs, oos_dirs = collect_classified(region)
+    ok = True
+    try:
+        depth1 = sorted(resolver_root.iterdir())
+    except (OSError, PermissionError) as err:
+        print(f"error: cannot list {resolver_root}: {err}", file=sys.stderr)
+        return False
+    for entry in depth1:
+        if not entry.is_dir():
+            continue
+        name = entry.name
+        if name in AMBIENT_BASENAMES:
+            continue
+        if (entry / RESOLVER_FILENAME).is_file():
+            continue
+        rel = name
+        if not is_classified(rel, filing_dirs, recursive_dirs):
+            emit_dark(resolver_path, rel)
+            ok = False
+            continue
+        if is_under_oos(rel, oos_dirs):
+            continue
+        if not scan_subdir(resolver_path, entry, rel, filing_dirs, recursive_dirs):
+            ok = False
+    return ok
+
+
 def check_mtime(resolver_path: Path) -> None:
     age_seconds = time.time() - resolver_path.stat().st_mtime
     if age_seconds > STALE_SECONDS:
-        days = int(age_seconds / 86400)
+        days = int(age_seconds / SECONDS_PER_DAY)
         emit_warn(
             resolver_path,
             "mtime-stale",
-            f"RESOLVER.md mtime is {days} days old (threshold 90)",
+            f"RESOLVER.md mtime is {days} days old (threshold {STALE_DAYS})",
             "Run /build:build-resolver --regenerate to refresh "
             "against current disk state",
         )
 
 
-def check_repo(repo_root: Path) -> bool:
-    if not repo_root.is_dir():
-        print(f"error: not a directory: {repo_root}", file=sys.stderr)
+def find_resolver_root(target: Path) -> Path | None:
+    """Walk up from ``target`` returning the nearest dir with RESOLVER.md."""
+    current = target.resolve()
+    while True:
+        if (current / RESOLVER_FILENAME).is_file():
+            return current
+        if current.parent == current:
+            return None
+        current = current.parent
+
+
+def check_target(target: Path) -> bool:
+    if not target.is_dir():
+        print(f"error: not a directory: {target}", file=sys.stderr)
         raise SystemExit(EXIT_USAGE)
-    resolver_path = repo_root / RESOLVER_FILENAME
-    if not resolver_path.is_file():
+    resolver_root = find_resolver_root(target)
+    if resolver_root is None:
         emit_fail(
-            resolver_path,
+            target / RESOLVER_FILENAME,
             "markers-present",
-            f"{RESOLVER_FILENAME} does not exist at repo root",
+            f"no {RESOLVER_FILENAME} found walking up from {target}",
             "Create RESOLVER.md via /build:build-resolver",
         )
         return False
+    resolver_path = resolver_root / RESOLVER_FILENAME
     try:
         text = resolver_path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError) as err:
@@ -262,9 +454,11 @@ def check_repo(repo_root: Path) -> bool:
     region = extract_managed_region(text)
     if region is None:
         return False
-    if not check_filing_table(resolver_path, repo_root, region):
+    if not check_filing_table(resolver_path, resolver_root, region):
         ok = False
-    if not check_context_table(resolver_path, repo_root, region):
+    if not check_context_table(resolver_path, resolver_root, region):
+        ok = False
+    if not check_dark_capabilities(resolver_path, resolver_root, region):
         ok = False
     check_mtime(resolver_path)
     return ok
@@ -280,7 +474,9 @@ def get_parser() -> argparse.ArgumentParser:
         nargs="*",
         type=Path,
         default=[Path()],
-        help="One or more repo-root paths (defaults to current directory).",
+        help="One or more target directories (defaults to current "
+        "directory). Walks up to the nearest RESOLVER.md and audits "
+        "that resolver.",
     )
     return parser
 
@@ -289,8 +485,8 @@ def main(argv: list[str] | None = None) -> int:
     args = get_parser().parse_args(argv)
     try:
         all_ok = True
-        for repo_root in args.paths:
-            if not check_repo(repo_root):
+        for target in args.paths:
+            if not check_target(target):
                 all_ok = False
         return 0 if all_ok else 1
     except KeyboardInterrupt:


### PR DESCRIPTION
## Summary

- **Context-table entries may be files OR directories.** A directory counts as one entry; the agent consults its `_index.md` first and descends on need. Removes the old anti-pattern of "directory pointers cost re-scan." Updates `check_resolver.py` (`context-paths-resolve` accepts files or directories), audit dimensions, repair playbook, and `resolver-best-practices.md`.
- **Resolver walk-up.** `build-resolver` and `check-resolver` walk up from the target directory to the nearest `RESOLVER.md` and scope work to that resolver root. `.resolver/evals.yml` lives as a sibling of each `RESOLVER.md`, so nested resolvers are self-contained. New `## Nesting` section in `resolver-best-practices.md` documents the model.
- **Auto-run evals on regenerate.** `build-resolver` Step 8 now invokes `/build:check-resolver --run-evals` automatically in regenerate mode, enforcing the Step-1 "re-run evals after writing" promise that previously had no enforcement.
- **Script cleanup.** Extracted `SECONDS_PER_DAY` / `STALE_DAYS` constants and renamed `repo_root` → `resolver_root` in `check_resolver.py` for terminological consistency with the new nesting model.

## Test plan

- [x] `check_resolver.py .` passes against this repo (root resolver, exit 0)
- [x] `check_resolver.py plugins/build/skills` walks up, audits the root resolver, exits 0
- [x] `check_resolver.py /tmp` emits FAIL with a clear "no RESOLVER.md found walking up" message
- [x] `/build:check-python-script` clean on `check_resolver.py` (0 fail, 0 warn after applied fixes)
- [ ] Reviewer: confirm whether a plugin version bump (`build/0.15.x → 0.16.0`?) is desired before merge — this PR does not bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)