### PR TITLE
chore(build): bump to 0.16.0 for resolver context-path + nesting changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ Pre-restructure releases used a single version. Post-restructure, each plugin
 
 ## [Unreleased]
 
+## [build-0.16.0] - 2026-04-27
+
+### Changed
+
+- **Resolver context entries may be files OR directories (#364).** The
+  `context-paths-resolve` Tier-1 check accepts either; a directory
+  counts as one entry, and the agent consults its `_index.md` first
+  and descends on need. Removes the "directory pointers cost re-scan"
+  anti-pattern from the audit rubric and repair playbook. Updates
+  `check_resolver.py`, `audit-dimensions.md`, `repair-playbook.md`,
+  and `resolver-best-practices.md`.
+- **Resolver skills walk up to the nearest `RESOLVER.md` (#364).**
+  `build-resolver` and `check-resolver` no longer assume the target
+  is the repo root — they walk up from any target directory and scope
+  work to the discovered resolver root. `.resolver/evals.yml` lives
+  as a sibling of each `RESOLVER.md` so nested resolvers stay
+  self-contained. `resolver-best-practices.md` gains a `## Nesting`
+  section documenting the model.
+- **Regenerate auto-runs evals (#364).** `build-resolver` Step 8
+  invokes `/build:check-resolver --run-evals` automatically in
+  regenerate mode, enforcing the Step-1 "re-run evals after writing"
+  promise that previously had no enforcement.
+- **`check_resolver.py` cleanup (#364).** Extracts `SECONDS_PER_DAY`
+  and `STALE_DAYS` named constants; renames `repo_root` →
+  `resolver_root` in helper signatures for terminological consistency
+  with the new nesting model.
+
 ## [build-0.15.0] - 2026-04-23
 
 ### Added

--- a/plugins/build/.claude-plugin/plugin.json
+++ b/plugins/build/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "build",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Skills for creating and refining Claude Code skills, rules, hooks, and subagents.",
   "author": {
     "name": "Brandon Beidel"

--- a/plugins/build/pyproject.toml
+++ b/plugins/build/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "check"
-version = "0.15.0"
+version = "0.16.0"
 description = "Claude Code plugin for auditing Claude Code skills and rules for quality issues."
 requires-python = ">=3.9"
 dependencies = []


### PR DESCRIPTION
## Summary

- Bumps `build` plugin from 0.15.0 → 0.16.0 (`pyproject.toml`, `.claude-plugin/plugin.json`)
- Adds `[build-0.16.0] - 2026-04-27` CHANGELOG entry summarizing the four behavioral changes from #364 (loosened context paths, walk-up resolver discovery, auto-eval after regenerate, script cleanup)
- Minor bump per CONTRIBUTING.md — behavioral changes to existing skills/scripts

## Test plan

- [x] `git diff` scope is exactly three files: CHANGELOG, plugin.json, pyproject.toml
- [x] Both build version files agree on `0.16.0`
- [x] `marketplace.json` does not pin a plugin version, so no update needed there

🤖 Generated with [Claude Code](https://claude.com/claude-code)