### PR TITLE
Add target prefixes to skill-pair authoring (plugin/project/user)

### DIFF
--- a/plugins/build/_shared/references/skill-locations.md
+++ b/plugins/build/_shared/references/skill-locations.md
@@ -1,0 +1,93 @@
+---
+name: Skill Locations
+description: Resolves the three target scopes — plugin, project, user — to the on-disk path prefixes that build-* and check-* skills use when reading or writing skill artifacts. Centralizes placement so all primitive-pair skills share one rule.
+related:
+  - plugins/build/skills/build-skill-pair/SKILL.md
+  - plugins/build/skills/check-skill-pair/SKILL.md
+  - plugins/build/_shared/references/skill-pair-best-practices.md
+---
+
+# Skill Locations
+
+A `build-<primitive>` / `check-<primitive>` pair scaffolds the same five
+artifacts regardless of where they live. What changes between scopes is
+the path prefix. This doc names the three supported targets, defines the
+prefix each one resolves to, and gives the inference rule build- and
+check- skills use to pick a target when the user does not specify one.
+
+## Targets
+
+Three target values are supported. Skills accept them via a `--target`
+flag or equivalent intake question.
+
+| Target | When to use | `<SKILL_ROOT>` | `<SHARED_REF_DIR>` |
+|--------|-------------|----------------|--------------------|
+| `plugin` | Authoring inside a plugin source tree (e.g., this toolkit's `plugins/build/`) | `plugins/<plugin>/skills` | `plugins/<plugin>/_shared/references` |
+| `project` | Skill is repo-specific — rubric depends on this repo's conventions | `.claude/skills` | `.claude/skills/_shared/references` |
+| `user` | Skill is reusable across any project but not distributed as a marketplace plugin | `~/.claude/skills` | `~/.claude/skills/_shared/references` |
+
+The five-artifact pair resolves as:
+
+```
+<SHARED_REF_DIR>/<primitive>-best-practices.md      ← principles doc
+<SKILL_ROOT>/build-<primitive>/SKILL.md             ← scaffolder
+<SKILL_ROOT>/check-<primitive>/SKILL.md             ← auditor
+<SKILL_ROOT>/check-<primitive>/references/audit-dimensions.md
+<SKILL_ROOT>/check-<primitive>/references/repair-playbook.md
+```
+
+The `references:` frontmatter inside each generated SKILL.md uses the
+relative path `../../_shared/references/<primitive>-best-practices.md`
+in all three targets — the structure mirrors across scopes by design,
+so the relative reference is target-invariant.
+
+## Routing-doc registration
+
+`primitive-routing.md` is a plugin-scoped artifact. The toolkit's own
+copy lives at `plugins/build/_shared/references/primitive-routing.md`.
+
+- **`plugin`** — registration is required. Append the two route lines
+  per the build-skill-pair Register step.
+- **`project`** / **`user`** — registration is optional. If
+  `<SHARED_REF_DIR>/primitive-routing.md` exists in the chosen scope,
+  update it; otherwise note in the handoff that no routing doc was
+  found and proceed.
+
+A pair without a routing-doc entry is still discoverable in
+project/user scope via Claude Code's normal skill-loading path —
+routing docs are an authoring convention, not a runtime requirement.
+
+## Inference rule
+
+When a target is not specified, infer from CWD in this order. Stop at
+the first match.
+
+1. **`plugin`** — CWD is inside a plugin source tree. Detect by walking
+   up from CWD until either (a) `<dir>/.claude-plugin/plugin.json`
+   exists, or (b) `<dir>/plugins/<name>/.claude-plugin/plugin.json`
+   exists for some `<name>`. The plugin root is the matching directory.
+2. **`project`** — CWD is inside a repo with a `.claude/` directory.
+   Detect by walking up from CWD until `<dir>/.claude/` exists and
+   `<dir>` is a git repo (or contains `.claude/skills/`).
+3. **`user`** — fallback when neither plugin nor project shape is
+   detected.
+
+If the inference produces an unexpected result, the skill must surface
+the detected target to the user and ask for confirmation before
+writing. Inference is a default, not a commitment.
+
+## Why three targets
+
+A primitive-pair builder that only writes to `plugins/build/...` works
+when authoring the toolkit itself but fails for the toolkit's actual
+audience: users who want pairs scoped to their repo or their personal
+skill library. The three-target shape covers the realistic cases:
+
+- **Plugin** — distributing the pair through the marketplace.
+- **Project** — the rubric is repo-specific (file conventions, domain
+  rules, layout) so the pair has no value outside this repo.
+- **User** — reusable across projects but private to one workstation,
+  so a marketplace plugin is overkill.
+
+Anything beyond these three (enterprise-shared, monorepo-cross-package)
+can compose: pick the closest target, then move artifacts post-write.

--- a/plugins/build/skills/build-skill-pair/SKILL.md
+++ b/plugins/build/skills/build-skill-pair/SKILL.md
@@ -17,6 +17,7 @@ references:
   - ../../_shared/references/skill-best-practices.md
   - ../../_shared/references/primitive-routing.md
   - ../../_shared/references/skill-pair-best-practices.md
+  - ../../_shared/references/skill-locations.md
 ---
 
 # Build Skill Pair
@@ -27,27 +28,52 @@ point at the same principles doc so creation and review never drift.
 The distillation step — reconciling multiple inputs into one
 internally-consistent rubric — is where this skill earns its keep.
 
-**Workflow sequence:** 1. Route → 2. Scope Gate → 3. Intake →
-4. Distill → 5. Draft → 6. Review Gate → 7. Save → 8. Register →
-9. Handoff
+**Workflow sequence:** 1. Route → 2. Target → 3. Scope Gate →
+4. Intake → 5. Distill → 6. Draft → 7. Review Gate → 8. Save →
+9. Register → 10. Handoff
+
+Throughout this skill, `<SKILL_ROOT>` and `<SHARED_REF_DIR>` are
+placeholders that resolve from the chosen target — see
+[skill-locations.md](../../_shared/references/skill-locations.md) for
+the prefix table.
 
 ## 1. Route
 
 Confirm the user wants a *pair*, not a single skill. Single skills
 route to `/build:build-skill`; auditing an existing pair routes to
 `/build:check-skill` on each half. If the principles doc already
-exists at `plugins/build/_shared/references/<primitive>-best-practices.md`,
-Distill becomes a pass-through — read the existing doc and proceed to
-Draft without regenerating.
+exists at `<SHARED_REF_DIR>/<primitive>-best-practices.md`, Distill
+becomes a pass-through — read the existing doc and proceed to Draft
+without regenerating.
 
-## 2. Scope Gate
+## 2. Target
+
+Pick the placement scope before any path-dependent step.
+[skill-locations.md](../../_shared/references/skill-locations.md)
+defines three targets — `plugin`, `project`, `user` — and the prefix
+each one resolves to. Resolution rule:
+
+1. If `$ARGUMENTS` carries a `--target <plugin|project|user>` flag,
+   use it. Otherwise apply the inference rule from skill-locations.md
+   (CWD walk-up: plugin source tree → project `.claude/` → user
+   fallback).
+2. Surface the resolved target to the user with the resolved
+   `<SKILL_ROOT>` and `<SHARED_REF_DIR>`. Wait for explicit
+   confirmation before continuing — inference is a default, not a
+   commitment.
+3. The Register step (#9) is required for `plugin` and optional for
+   `project` / `user` per the routing-doc rule in
+   skill-locations.md.
+
+## 3. Scope Gate
 
 Refuse — and recommend an alternative — when any of these signal:
 
 1. **Primitive already has a pair.** If
-   `plugins/build/skills/build-<primitive>/` exists, stop. Offer to
-   revise the existing pair (run `/build:check-skill` on both halves
-   and iterate from findings) instead of scaffolding over it.
+   `<SKILL_ROOT>/build-<primitive>/` exists at the resolved target,
+   stop. Offer to revise the existing pair (run `/build:check-skill`
+   on both halves and iterate from findings) instead of scaffolding
+   over it.
 2. **No best-practice material at all.** Distillation needs raw
    material. The skill's value is synthesis, not invention —
    scaffolding without input produces a rubric indistinguishable
@@ -63,7 +89,7 @@ Refuse — and recommend an alternative — when any of these signal:
 If any signal fires, state the signal, name the alternative, and
 stop. Do not proceed to Intake.
 
-## 3. Intake
+## 4. Intake
 
 If `$ARGUMENTS` is non-empty, parse it as `[primitive-name]` and
 pre-fill question 1. Otherwise ask, one question at a time:
@@ -97,7 +123,7 @@ Provenance does not survive into the distilled doc — git history
 (the PR or the commit that landed the pair) is where that lives.
 This intake is purely raw material for the Distill step.
 
-**5. Routing-doc placement** — does the new primitive belong as:
+**5. Routing-doc placement** *(plugin target only — skip otherwise)* — does the new primitive belong as:
 
 - **A new top-level primitive class** (new category alongside rules,
   hooks, skills, subagents, scripts) → append a paragraph to
@@ -111,7 +137,7 @@ If unclear, read
 [primitive-routing.md](../../_shared/references/primitive-routing.md)
 and propose a placement; confirm with the user.
 
-## 4. Distill
+## 5. Distill
 
 For each piece of input material from Intake #4: extract patterns
 *and the rationale behind each*. Patterns without rationale are
@@ -123,8 +149,8 @@ resolution does not need to be recorded in the distilled doc (git
 history carries that); what matters is that the final rubric is
 internally consistent.
 
-Produce `plugins/build/_shared/references/<primitive>-best-practices.md`
-with this structure:
+Produce `<SHARED_REF_DIR>/<primitive>-best-practices.md` with this
+structure:
 
 ```
 ---
@@ -151,7 +177,7 @@ description: Authoring guide for <primitive> — ... Referenced by build-<primit
 <how to keep the primitive honest over time>
 ```
 
-## 5. Draft (five artifacts)
+## 6. Draft (five artifacts)
 
 Produce all five before the Review Gate — present them together so the
 user sees the whole pair.
@@ -183,27 +209,27 @@ One entry per dimension: *finding* → *diagnosis* → *fix recipe*
 (code snippet or prose). The repair playbook is what turns an audit
 finding into a pull request; it must be concrete, not advisory.
 
-## 6. Review Gate
+## 7. Review Gate
 
-Present all five artifacts plus the proposed diff to
-`primitive-routing.md`. Wait for explicit user approval before writing
-any file. If the user requests changes, revise and re-present —
-continue until the user approves or cancels. Proceed to Save only on
+Present all five artifacts plus — for `plugin` target — the proposed
+diff to `primitive-routing.md`. Wait for explicit user approval before
+writing any file. If the user requests changes, revise and re-present
+— continue until the user approves or cancels. Proceed to Save only on
 explicit approval.
 
-This gate exists because five new files + a routing-doc change is a
-large commit to land silently. The user needs to see the whole shape,
-not just the parts.
+This gate exists because five new files (plus a routing-doc change in
+plugin mode) is a large commit to land silently. The user needs to
+see the whole shape, not just the parts.
 
-## 7. Save
+## 8. Save
 
-Write all five files to their paths:
+Resolve the five paths against the target chosen in Step 2 and write:
 
-- `plugins/build/_shared/references/<primitive>-best-practices.md`
-- `plugins/build/skills/build-<primitive>/SKILL.md`
-- `plugins/build/skills/check-<primitive>/SKILL.md`
-- `plugins/build/skills/check-<primitive>/references/audit-dimensions.md`
-- `plugins/build/skills/check-<primitive>/references/repair-playbook.md`
+- `<SHARED_REF_DIR>/<primitive>-best-practices.md`
+- `<SKILL_ROOT>/build-<primitive>/SKILL.md`
+- `<SKILL_ROOT>/check-<primitive>/SKILL.md`
+- `<SKILL_ROOT>/check-<primitive>/references/audit-dimensions.md`
+- `<SKILL_ROOT>/check-<primitive>/references/repair-playbook.md`
 
 Do not `chmod` — these are markdown. Tier-1 deterministic-check
 scripts under `check-<primitive>/scripts/` are out of scope here —
@@ -211,9 +237,10 @@ this skill scaffolds the SKILL.md contract and the rubric, not the
 scripts that enforce deterministic dimensions. Route those to the
 script-building skills; see the Handoff for the dogfooding rule.
 
-## 8. Register
+## 9. Register
 
-Update `plugins/build/_shared/references/primitive-routing.md`:
+**Plugin target** — required. Update
+`<SHARED_REF_DIR>/primitive-routing.md`:
 
 - **New top-level primitive class** — add a one-paragraph entry under
   *What Each Primitive Was Designed For* and extend the *Routing Test*
@@ -227,14 +254,21 @@ The diff was presented at the Review Gate; write it now.
 
 A pair that's not in `primitive-routing.md` is discoverable only by
 grep — the routing doc is how other skills and future authors find
-the new primitive. Skipping this step is how pairs become orphans.
+the new primitive. Skipping this step (in plugin mode) is how pairs
+become orphans.
 
-## 9. Handoff
+**Project / user target** — optional. If
+`<SHARED_REF_DIR>/primitive-routing.md` exists at the resolved scope,
+update it the same way. If not, skip with an informational note in the
+handoff: project- and user-scoped pairs are still discoverable through
+Claude Code's normal skill loader.
+
+## 10. Handoff
 
 Offer the audit:
 
-> "Run `/build:check-skill plugins/build/skills/build-<name>/SKILL.md`
-> and `/build:check-skill plugins/build/skills/check-<name>/SKILL.md`
+> "Run `/build:check-skill <SKILL_ROOT>/build-<name>/SKILL.md`
+> and `/build:check-skill <SKILL_ROOT>/check-<name>/SKILL.md`
 > to audit both halves?"
 
 Also flag follow-on work the user may want: bumping the build plugin
@@ -308,12 +342,12 @@ Output: five files plus a routing-doc diff adding a paragraph under
   would bypass the rubric this skill's whole design tells users to
   respect.
 - Recovery if the pair is scaffolded in error: `rm -rf
-  plugins/build/skills/build-<name>/ plugins/build/skills/check-<name>/
-  plugins/build/_shared/references/<name>-best-practices.md` and
-  revert the `primitive-routing.md` change. The artifacts are
+  <SKILL_ROOT>/build-<name>/ <SKILL_ROOT>/check-<name>/
+  <SHARED_REF_DIR>/<name>-best-practices.md` and revert the
+  `primitive-routing.md` change (plugin mode). The artifacts are
   self-contained (no settings.json entries, no shared-module
-  registration beyond the routing doc), so removal leaves no
-  dangling state.
+  registration beyond the routing doc), so removal leaves no dangling
+  state.
 
 ## Handoff
 
@@ -322,13 +356,14 @@ best-practice input material (files / URLs / pasted text /
 named-model-knowledge), and a routing-doc placement decision (new
 top-level class or variant of an existing class).
 
-**Produces:** five files — the distilled principles doc under
-`plugins/build/_shared/references/`, `build-<primitive>/SKILL.md`,
+**Produces:** five files at the chosen target — the distilled
+principles doc under `<SHARED_REF_DIR>/`, `build-<primitive>/SKILL.md`,
 `check-<primitive>/SKILL.md`,
 `check-<primitive>/references/audit-dimensions.md`, and
-`check-<primitive>/references/repair-playbook.md` — plus one updated
-`primitive-routing.md` registering the new primitive and its two
-routes.
+`check-<primitive>/references/repair-playbook.md`. In `plugin` mode,
+also produces an updated `primitive-routing.md`. In `project` /
+`user` mode, the routing-doc update is skipped unless one already
+exists at the chosen scope.
 
 **Chainable to:** `/build:check-skill-pair <primitive>` for
 pair-level integrity (principles doc present, audit/playbook

--- a/plugins/build/skills/check-skill-pair/SKILL.md
+++ b/plugins/build/skills/check-skill-pair/SKILL.md
@@ -21,6 +21,7 @@ references:
   - ../../_shared/references/skill-best-practices.md
   - ../../_shared/references/primitive-routing.md
   - ../../_shared/references/skill-pair-best-practices.md
+  - ../../_shared/references/skill-locations.md
   - references/audit-dimensions.md
   - references/repair-playbook.md
 ---
@@ -46,8 +47,12 @@ section), accepted either labeled (`**Pass:**`) or inferred
 ("Passes when…"). This check is prose-heuristic and stays out of the
 script.
 
-**Workflow sequence:** 1. Scope → 2. Run audit_pair.py →
-3. Required-Fields Pass → 4. Report → 5. Opt-In Repair Loop
+**Workflow sequence:** 1. Scope → 2. Target → 3. Run audit_pair.py →
+4. Required-Fields Pass → 5. Report → 6. Opt-In Repair Loop
+
+`<SKILL_ROOT>` and `<SHARED_REF_DIR>` resolve from the chosen target
+— see [skill-locations.md](../../_shared/references/skill-locations.md)
+for the prefix table.
 
 ## 1. Scope
 
@@ -58,20 +63,35 @@ primitive, not a configuration. Confirm scope aloud in one line:
 
 The six artifact slots `audit_pair.py` inspects:
 
-- Principles doc: `plugins/build/_shared/references/<name>-best-practices.md`
-- Build skill: `plugins/build/skills/build-<name>/SKILL.md`
-- Check skill: `plugins/build/skills/check-<name>/SKILL.md`
-- Audit dimensions: `plugins/build/skills/check-<name>/references/audit-dimensions.md`
-- Repair playbook: `plugins/build/skills/check-<name>/references/repair-playbook.md`
-- Routing registration: `plugins/build/_shared/references/primitive-routing.md` (both route lines)
+- Principles doc: `<SHARED_REF_DIR>/<name>-best-practices.md`
+- Build skill: `<SKILL_ROOT>/build-<name>/SKILL.md`
+- Check skill: `<SKILL_ROOT>/check-<name>/SKILL.md`
+- Audit dimensions: `<SKILL_ROOT>/check-<name>/references/audit-dimensions.md`
+- Repair playbook: `<SKILL_ROOT>/check-<name>/references/repair-playbook.md`
+- Routing registration: `<SHARED_REF_DIR>/primitive-routing.md` (both route lines; required for `plugin` target, optional otherwise)
 
-## 2. Run audit_pair.py
+## 2. Target
 
-Execute the deterministic audit:
+Pick the placement scope before invoking the script. If `$ARGUMENTS`
+includes `--target <plugin|project|user>`, use it. Otherwise apply
+the inference rule from
+[skill-locations.md](../../_shared/references/skill-locations.md):
+walk up CWD for a plugin source tree, then for a project `.claude/`
+directory, falling back to `user`. Surface the inferred target in
+one line and confirm before invoking the script.
+
+## 3. Run audit_pair.py
+
+Execute the deterministic audit, passing the resolved target:
 
 ```bash
-python3 plugins/build/skills/check-skill-pair/scripts/audit_pair.py <name>
+python3 plugins/build/skills/check-skill-pair/scripts/audit_pair.py \
+  --target <plugin|project|user> <name>
 ```
+
+The default target is `plugin` (back-compat). Project- and
+user-target audits resolve artifacts under `.claude/skills/` or
+`~/.claude/skills/` respectively.
 
 The script emits a findings table, a summary line, and an exit code
 (non-zero if any `fail` findings). If the script prints `No pair
@@ -84,7 +104,7 @@ coverage, and Tier-3 shared principles path + check-half frontmatter
 refs + build→check handoff + routing registration + dogfood-script
 info.
 
-## 3. Required-Fields Pass
+## 4. Required-Fields Pass
 
 The one check the script leaves to judgment: each dimension entry
 in `audit-dimensions.md` should carry six fields — *name*, *what it
@@ -100,7 +120,7 @@ there is nothing to read.
 Read the file once, iterate dimension entries (H3 headings), and
 append any findings to the Tier-1/2/3 set the script produced.
 
-## 4. Report
+## 5. Report
 
 The script already emits a findings table and summary line. If the
 Required-Fields Pass added any findings, merge them into the
@@ -122,7 +142,7 @@ Example script output (shape):
 0 fail, 1 warn, 1 info across 6 artifact slots
 ```
 
-## 5. Opt-In Repair Loop
+## 6. Opt-In Repair Loop
 
 Ask exactly once:
 
@@ -231,7 +251,8 @@ plugins/build/skills/check-skill-pair/scripts/audit_pair.py`.
 ## Handoff
 
 **Receives:** primitive name — kebab-case, no path prefix (e.g.,
-`bash-script`, not `plugins/build/skills/build-bash-script/`).
+`bash-script`, not `<SKILL_ROOT>/build-bash-script/`); optional
+`--target` flag selecting `plugin` (default), `project`, or `user`.
 
 **Produces:** a findings table with one row per audit-dimension /
 slot, each row carrying the check name, the artifact path, the

--- a/plugins/build/skills/check-skill-pair/references/audit-dimensions.md
+++ b/plugins/build/skills/check-skill-pair/references/audit-dimensions.md
@@ -20,7 +20,7 @@ Severity:
 
 ### principles-doc-presence
 
-**What it checks:** `plugins/build/_shared/references/<primitive>-best-practices.md` exists and is a non-empty file.
+**What it checks:** `<SHARED_REF_DIR>/<primitive>-best-practices.md` exists and is a non-empty file.
 **Pass:** file exists with at least one H1.
 **Fail:** file is missing or empty.
 **Severity:** fail.
@@ -28,7 +28,7 @@ Severity:
 
 ### build-skill-presence
 
-**What it checks:** `plugins/build/skills/build-<primitive>/SKILL.md` exists.
+**What it checks:** `<SKILL_ROOT>/build-<primitive>/SKILL.md` exists.
 **Pass:** file exists with valid YAML frontmatter (`name` present).
 **Fail:** file is missing, empty, or lacks frontmatter.
 **Severity:** fail.
@@ -36,7 +36,7 @@ Severity:
 
 ### check-skill-presence
 
-**What it checks:** `plugins/build/skills/check-<primitive>/SKILL.md` exists.
+**What it checks:** `<SKILL_ROOT>/check-<primitive>/SKILL.md` exists.
 **Pass:** file exists with valid YAML frontmatter (`name` present).
 **Fail:** file is missing, empty, or lacks frontmatter.
 **Severity:** fail.
@@ -44,7 +44,7 @@ Severity:
 
 ### audit-dimensions-presence
 
-**What it checks:** `plugins/build/skills/check-<primitive>/references/audit-dimensions.md` exists.
+**What it checks:** `<SKILL_ROOT>/check-<primitive>/references/audit-dimensions.md` exists.
 **Pass:** file exists with at least one dimension entry.
 **Fail:** file is missing or has no dimensions.
 **Severity:** fail.
@@ -52,7 +52,7 @@ Severity:
 
 ### repair-playbook-presence
 
-**What it checks:** `plugins/build/skills/check-<primitive>/references/repair-playbook.md` exists.
+**What it checks:** `<SKILL_ROOT>/check-<primitive>/references/repair-playbook.md` exists.
 **Pass:** file exists with at least one repair entry.
 **Fail:** file is missing or has no repair entries.
 **Severity:** fail.
@@ -60,7 +60,7 @@ Severity:
 
 ### routing-registration-presence
 
-**What it checks:** `plugins/build/_shared/references/primitive-routing.md` contains both route lines: `/build:build-<primitive>` and `/build:check-<primitive>`.
+**What it checks:** `<SHARED_REF_DIR>/primitive-routing.md` contains both route lines: `/build:build-<primitive>` and `/build:check-<primitive>`.
 **Pass:** both route lines appear as literal strings in the doc.
 **Fail:** both route lines are absent.
 **Severity:** fail (both missing) / warn (one missing).

--- a/plugins/build/skills/check-skill-pair/references/repair-playbook.md
+++ b/plugins/build/skills/check-skill-pair/references/repair-playbook.md
@@ -27,7 +27,7 @@ ensures the rubric is internally consistent with the input.
 
 ### build-skill-presence
 
-**Finding:** `plugins/build/skills/build-<primitive>/SKILL.md` is
+**Finding:** `<SKILL_ROOT>/build-<primitive>/SKILL.md` is
 missing.
 **Diagnosis:** the scaffold half was deleted or never created.
 **Fix:** run `/build:build-skill-pair <primitive>` — the Save step
@@ -37,7 +37,7 @@ written.
 
 ### check-skill-presence
 
-**Finding:** `plugins/build/skills/check-<primitive>/SKILL.md` is
+**Finding:** `<SKILL_ROOT>/check-<primitive>/SKILL.md` is
 missing.
 **Diagnosis:** the audit half was deleted or never created.
 **Fix:** run `/build:build-skill-pair <primitive>`. Same rationale

--- a/plugins/build/skills/check-skill-pair/scripts/audit_pair.py
+++ b/plugins/build/skills/check-skill-pair/scripts/audit_pair.py
@@ -15,6 +15,23 @@ from pathlib import Path
 # resolution (Path(__file__).parents[1]) would be wrong.
 DEFAULT_REPO_ROOT = Path(__file__).resolve().parents[5]
 
+# Target prefixes per skill-locations.md. `<SKILL_ROOT>` is where build-/check-
+# skills live; `<SHARED_REF_DIR>` holds the principles doc and routing doc.
+TARGET_PREFIXES: dict[str, dict[str, str]] = {
+    "plugin": {
+        "skill_root": "plugins/build/skills",
+        "shared_ref_dir": "plugins/build/_shared/references",
+    },
+    "project": {
+        "skill_root": ".claude/skills",
+        "shared_ref_dir": ".claude/skills/_shared/references",
+    },
+    "user": {
+        "skill_root": "~/.claude/skills",
+        "shared_ref_dir": "~/.claude/skills/_shared/references",
+    },
+}
+
 
 @dataclass(frozen=True)
 class Finding:
@@ -193,33 +210,41 @@ def resolve_reference(skill_dir: Path, ref: str) -> Path:
     return (skill_dir / ref).resolve()
 
 
+def resolve_target_paths(target: str, root: Path) -> tuple[Path, Path]:
+    """Resolve `<SKILL_ROOT>` and `<SHARED_REF_DIR>` for a target.
+
+    `plugin` and `project` prefixes are interpreted relative to ``root``.
+    ``user`` prefixes start with ``~`` and are expanded to the user's home
+    directory; ``root`` is ignored for that target.
+    """
+    prefixes = TARGET_PREFIXES[target]
+    if target == "user":
+        skill_root = Path(prefixes["skill_root"]).expanduser()
+        shared_ref_dir = Path(prefixes["shared_ref_dir"]).expanduser()
+    else:
+        skill_root = root / prefixes["skill_root"]
+        shared_ref_dir = root / prefixes["shared_ref_dir"]
+    return skill_root, shared_ref_dir
+
+
 def tier1_existence(
-    primitive: str, root: Path
+    primitive: str, root: Path, target: str = "plugin"
 ) -> tuple[list[Finding], dict[str, Path]]:
     """Return findings plus a dict of resolved artifact paths (even if missing)."""
+    skill_root, shared_ref_dir = resolve_target_paths(target, root)
     paths = {
-        "principles_doc": root
-        / "plugins/build/_shared/references"
-        / f"{primitive}-best-practices.md",
-        "build_skill": root
-        / "plugins/build/skills"
-        / f"build-{primitive}"
-        / "SKILL.md",
-        "check_skill": root
-        / "plugins/build/skills"
-        / f"check-{primitive}"
-        / "SKILL.md",
-        "audit_dims": root
-        / "plugins/build/skills"
+        "principles_doc": shared_ref_dir / f"{primitive}-best-practices.md",
+        "build_skill": skill_root / f"build-{primitive}" / "SKILL.md",
+        "check_skill": skill_root / f"check-{primitive}" / "SKILL.md",
+        "audit_dims": skill_root
         / f"check-{primitive}"
         / "references"
         / "audit-dimensions.md",
-        "repair_playbook": root
-        / "plugins/build/skills"
+        "repair_playbook": skill_root
         / f"check-{primitive}"
         / "references"
         / "repair-playbook.md",
-        "routing_doc": root / "plugins/build/_shared/references/primitive-routing.md",
+        "routing_doc": shared_ref_dir / "primitive-routing.md",
     }
     findings: list[Finding] = []
 
@@ -274,7 +299,16 @@ def tier1_existence(
             )
         )
 
-    routing_text = read_text(paths["routing_doc"]) or ""
+    # Routing-doc registration is required for `plugin` target, optional
+    # for `project` / `user`. When the routing doc is absent at a non-plugin
+    # target, the registration check is skipped silently — projects and
+    # users that maintain a routing doc still get the same enforcement.
+    routing_text = read_text(paths["routing_doc"])
+    if routing_text is None and target != "plugin":
+        return findings, paths
+    routing_text = routing_text or ""
+    severity_both_missing = "fail" if target == "plugin" else "warn"
+    severity_one_missing = "warn"
     build_route = f"/build:build-{primitive}"
     check_route = f"/build:check-{primitive}"
     has_build_route = build_route in routing_text
@@ -286,7 +320,7 @@ def tier1_existence(
                 "routing-registration-presence",
                 rel(paths["routing_doc"]),
                 f"both {build_route} and {check_route} route lines missing",
-                "fail",
+                severity_both_missing,
             )
         )
     elif not has_build_route:
@@ -296,7 +330,7 @@ def tier1_existence(
                 "routing-registration-presence",
                 rel(paths["routing_doc"]),
                 f"{build_route} route line missing",
-                "warn",
+                severity_one_missing,
             )
         )
     elif not has_check_route:
@@ -306,7 +340,7 @@ def tier1_existence(
                 "routing-registration-presence",
                 rel(paths["routing_doc"]),
                 f"{check_route} route line missing",
-                "warn",
+                severity_one_missing,
             )
         )
 
@@ -384,7 +418,7 @@ def tier2_content(paths: dict[str, Path], root: Path) -> list[Finding]:
 
 
 def tier3_cross_reference(
-    primitive: str, paths: dict[str, Path], root: Path
+    primitive: str, paths: dict[str, Path], root: Path, target: str = "plugin"
 ) -> list[Finding]:
     findings: list[Finding] = []
 
@@ -488,7 +522,8 @@ def tier3_cross_reference(
                 )
             )
 
-    scripts_dir = root / "plugins/build/skills" / f"check-{primitive}" / "scripts"
+    skill_root, _ = resolve_target_paths(target, root)
+    scripts_dir = skill_root / f"check-{primitive}" / "scripts"
     if scripts_dir.is_dir():
         py_scripts = list(scripts_dir.glob("*.py"))
         sh_scripts = list(scripts_dir.glob("*.sh")) + list(scripts_dir.glob("*.bash"))
@@ -539,9 +574,11 @@ def summary_counts(findings: list[Finding]) -> tuple[int, int, int]:
     return fails, warns, infos
 
 
-def audit(primitive: str, root: Path) -> tuple[list[Finding], bool]:
+def audit(
+    primitive: str, root: Path, target: str = "plugin"
+) -> tuple[list[Finding], bool]:
     """Return (findings, no_pair_found)."""
-    t1, paths = tier1_existence(primitive, root)
+    t1, paths = tier1_existence(primitive, root, target)
     # "No pair found": principles doc + both SKILLs all absent → nothing to audit.
     critical_missing = sum(
         1
@@ -551,7 +588,7 @@ def audit(primitive: str, root: Path) -> tuple[list[Finding], bool]:
     if critical_missing == 3:
         return [], True
     t2 = tier2_content(paths, root)
-    t3 = tier3_cross_reference(primitive, paths, root)
+    t3 = tier3_cross_reference(primitive, paths, root, target)
     return t1 + t2 + t3, False
 
 
@@ -568,10 +605,20 @@ def main(argv: list[str] | None = None) -> int:
         default=DEFAULT_REPO_ROOT,
         help="Repo root (default: resolved from script location).",
     )
+    parser.add_argument(
+        "--target",
+        choices=("plugin", "project", "user"),
+        default="plugin",
+        help=(
+            "Placement scope per skill-locations.md: `plugin` (toolkit-style "
+            "plugins/build/...), `project` (.claude/skills/...), or `user` "
+            "(~/.claude/skills/...). Default: plugin (back-compat)."
+        ),
+    )
     args = parser.parse_args(argv)
 
     try:
-        findings, no_pair = audit(args.primitive, args.root.resolve())
+        findings, no_pair = audit(args.primitive, args.root.resolve(), args.target)
     except KeyboardInterrupt:
         return 130
 


### PR DESCRIPTION
## Summary

- Centralize skill-pair placement rules into `_shared/references/skill-locations.md`, defining three targets (`plugin`, `project`, `user`) and the `<SKILL_ROOT>` / `<SHARED_REF_DIR>` each resolves to.
- Replace hardcoded `plugins/build/...` strings in `build-skill-pair`, `check-skill-pair`, and the pair's audit-dimensions / repair-playbook references with the placeholders.
- `audit_pair.py` now accepts `--target {plugin,project,user}` (default `plugin` for back-compat); plugin mode requires routing-doc registration, project/user modes treat it as optional.

Closes #369.

## Test plan

- [x] `python3 plugins/build/skills/check-skill-pair/scripts/audit_pair.py <pair>` matches main for all 12 existing pairs (no regressions; pre-existing findings on `resolver` and `github-workflow` unchanged).
- [x] Self-audit: `audit_pair.py skill-pair` clean.
- [x] `--target project` / `--target user` resolve to `.claude/skills/...` and `~/.claude/skills/...` and emit the no-pair-found message.
- [x] `python -m pytest plugins/wiki/tests/ -v` — 245 passed.
- [x] `ruff check plugins/build/skills/check-skill-pair/scripts/audit_pair.py` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)