### PR TITLE
test(security-scan): low-risk smoke (consider plugin)

### DIFF
--- a/plugins/consider/skills/5-whys/SKILL.md
+++ b/plugins/consider/skills/5-whys/SKILL.md
@@ -86,3 +86,4 @@ Create per-suite database instances in CI using a template database that's clone
 **Produces:** A why-chain trace leading to root cause(s), with verification and a specific action
 **Chainable to:** `consider` (to apply additional mental models), `inversion` (to verify by imagining how to reproduce the problem)
 
+


### PR DESCRIPTION
## Summary

Smoke test of the security-scan workflow against a clean baseline.
Trivial whitespace tweak in `plugins/consider/skills/5-whys/SKILL.md`.

Pre-flight local scan: 0 HIGH, 0 MEDIUM, 18 INFO, 2 LOW. **Expected gate: pass.**

Pairs with the high-risk smoke PR for end-to-end verification of:
- `Skill Security Audit Scan` triggers on `plugins/**` change
- `Skill Security Audit Report` fires via `workflow_run` (now that workflows are on `main`)
- Single PR comment posted with `<!-- skill-audit:report -->` marker
- Gate evaluates `overall_severity` and passes for non-HIGH content

Will close without merging.