### PR TITLE
fix(security-scan): show all findings, fix scanner_version, publish PR check

### DIFF
--- a/.github/scripts/evaluate-findings.py
+++ b/.github/scripts/evaluate-findings.py
@@ -151,16 +151,17 @@ def call_evaluator(
     plugin_name: str,
     findings: list[dict],
 ) -> dict:
+    """Ask Claude for a narrative + recommendation only.
+
+    The findings table is rendered deterministically by write-comment.py;
+    the LLM contributes only the human-readable framing.
+    """
     severity_counts = {
         sev: sum(1 for f in findings if f["severity"] == sev)
         for sev in ("CRITICAL", "HIGH", "MEDIUM", "LOW")
     }
 
-    sorted_findings = sorted(
-        findings,
-        key=lambda f: SEVERITY_ORDER.get(f["severity"], 0),
-        reverse=True,
-    )[:20]
+    sample = findings[:20]
 
     prompt = (
         f"Plugin: {plugin_name}\n"
@@ -170,14 +171,10 @@ def call_evaluator(
         f"HIGH={severity_counts['HIGH']}, "
         f"MEDIUM={severity_counts['MEDIUM']}, "
         f"LOW={severity_counts['LOW']}\n\n"
-        f"Findings (structured metadata only):\n"
-        f"{json.dumps(sorted_findings, indent=2)}\n\n"
+        f"Highest-severity findings (structured metadata only, up to 20):\n"
+        f"{json.dumps(sample, indent=2)}\n\n"
         "Produce a JSON object with exactly these fields:\n"
-        '- "overall_severity": one of "none", "low", "medium", "high"\n'
         '- "narrative": 2–3 sentence summary of the security posture\n'
-        '- "top_findings": list of up to 5 most critical findings, '
-        'each with "severity", "analyzer", "description" fields\n'
-        '- "finding_count": integer total\n'
         '- "recommendation": one sentence on what the reviewer should do\n\n'
         "Return only valid JSON. No markdown fences, no explanation."
     )
@@ -234,6 +231,12 @@ def run(args: argparse.Namespace) -> int:
     critical_signals = parse_simple_yaml_list(policy_file, "critical_signals")
     findings = apply_escalation(findings, escalation_signals, critical_signals)
 
+    # Sort by severity desc once; this ordering is what the comment renders.
+    findings.sort(
+        key=lambda f: SEVERITY_ORDER.get(f["severity"], 0),
+        reverse=True,
+    )
+
     overall_severity = compute_overall_severity(findings)
     if scan_failed:
         overall_severity = "high"
@@ -246,6 +249,7 @@ def run(args: argparse.Namespace) -> int:
     # Authoritative fields the LLM cannot override.
     summary["overall_severity"] = overall_severity
     summary["finding_count"] = len(findings)
+    summary["findings"] = findings
     summary["scan_failed"] = scan_failed
     summary["policy_fingerprint"] = policy_fingerprint(policy_file)
     summary["scanner_version"] = scanner_version
@@ -259,7 +263,6 @@ def run(args: argparse.Namespace) -> int:
         if scan_failed
         else f"Scan completed for {plugin_name}. {len(findings)} finding(s) detected.",
     )
-    summary.setdefault("top_findings", findings[:5])
     summary.setdefault(
         "recommendation",
         "Scan failed; do not merge until the workflow runs successfully."

--- a/.github/scripts/write-comment.py
+++ b/.github/scripts/write-comment.py
@@ -1,19 +1,18 @@
 #!/usr/bin/env python3
-"""Format a risk-summary.json as a GitHub PR audit comment.
+"""Render a risk-summary.json as a GitHub PR audit comment.
 
 Step 2 of the split evaluator/comment-writer architecture. Receives only
 the structured risk summary produced by evaluate-findings.py — never raw
-skill content — and formats it as Markdown via Claude. Skill content never
-reaches this step, so a malicious skill cannot inject instructions into
-the posted security report.
+skill content — and renders it deterministically as Markdown. No LLM call:
+the narrative + recommendation already live in the summary; the table and
+provenance are pure templating. This makes the comment reproducible and
+removes truncation risk for plugins with many findings.
 
 The output always begins with the stable marker `<!-- skill-audit:report -->`
 so post-audit-comment.sh can upsert by HTML comment match.
 
 Example:
     ./write-comment.py risk-summary.json audit-comment.md
-
-Dependencies: anthropic (declared in .github/scripts/requirements.lock).
 """
 
 from __future__ import annotations
@@ -24,11 +23,8 @@ import os
 import sys
 from pathlib import Path
 
-import anthropic
-
 EXIT_INTERRUPTED = 130
 
-DEFAULT_MODEL = "claude-opus-4-6"
 COMMENT_MARKER = "<!-- skill-audit:report -->"
 
 SEVERITY_BADGE = {
@@ -38,32 +34,101 @@ SEVERITY_BADGE = {
     "high": "![high](https://img.shields.io/badge/severity-HIGH-red)",
 }
 
+MERGE_BLOCKED_NOTICE = (
+    "⛔ **MERGE BLOCKED** — the security scan failed and could not "
+    "produce findings. Resolve the workflow error before merging."
+)
 
-def build_prompt(plugin_name: str, summary: dict) -> str:
-    return (
-        f"Plugin: `{plugin_name}`\n\n"
-        f"Risk Summary (structured data — no raw skill content):\n"
-        f"{json.dumps(summary, indent=2)}\n\n"
-        "Format this as a GitHub PR comment in Markdown. Structure:\n"
-        f"1. Header: `## Security Audit: {plugin_name}`\n"
-        "2. Severity badge on its own line\n"
-        "3. If `scan_failed` is true, lead with a clear MERGE BLOCKED notice; "
-        "otherwise the narrative paragraph\n"
-        "4. A Markdown table of top findings: | Severity | Analyzer | Description |\n"
-        "   (omit the table if there are no findings)\n"
-        "5. **Recommendation:** line\n"
-        "6. A compact provenance footer with: scanner_version, model_used, "
-        "policy_fingerprint, and "
-        "`*Assessed by [skill-scanner](https://github.com/cisco-ai-defense/skill-scanner) + "
-        "Claude evaluator*`\n\n"
-        "Keep it concise and actionable. Do not reproduce raw skill content. "
-        "Output only the Markdown comment body."
+
+def _md_escape_cell(text: str) -> str:
+    """Make a string safe to drop into a Markdown table cell on one line."""
+    return str(text).replace("|", "\\|").replace("\r", " ").replace("\n", " ").strip()
+
+
+def render_findings_table(findings: list[dict]) -> str:
+    if not findings:
+        return "_No findings._"
+    header = "| # | Severity | Analyzer | Rule | Description |\n|---|---|---|---|---|\n"
+    rows = [
+        "| {idx} | {sev} | {analyzer} | {rule} | {desc} |".format(
+            idx=i,
+            sev=_md_escape_cell(f.get("severity", "UNKNOWN")),
+            analyzer=_md_escape_cell(f.get("analyzer", "unknown")),
+            rule=_md_escape_cell(f.get("rule_id", "UNKNOWN")),
+            desc=_md_escape_cell(f.get("description", "")),
+        )
+        for i, f in enumerate(findings, start=1)
+    ]
+    return header + "\n".join(rows) + "\n"
+
+
+def render_comment(plugin_name: str, summary: dict) -> str:
+    severity = summary.get("overall_severity", "none")
+    badge = SEVERITY_BADGE.get(severity, SEVERITY_BADGE["none"])
+    findings = summary.get("findings", [])
+    finding_count = summary.get("finding_count", len(findings))
+    scan_failed = bool(summary.get("scan_failed", False))
+
+    parts: list[str] = [
+        COMMENT_MARKER,
+        "",
+        f"## Security Audit: {plugin_name}",
+        "",
+        badge,
+        "",
+    ]
+
+    if scan_failed:
+        parts.extend([MERGE_BLOCKED_NOTICE, ""])
+    else:
+        narrative = summary.get(
+            "narrative",
+            f"Scan completed for {plugin_name}. {finding_count} finding(s) detected.",
+        )
+        parts.extend([narrative, ""])
+
+    parts.extend(
+        [
+            f"### Findings ({finding_count})",
+            "",
+            render_findings_table(findings),
+            "",
+        ]
     )
+
+    recommendation = summary.get(
+        "recommendation",
+        "Review the findings above before merging.",
+    )
+    parts.extend([f"**Recommendation:** {recommendation}", ""])
+
+    parts.extend(
+        [
+            "---",
+            "",
+            "**Provenance:**",
+            f"- Scanner: `{summary.get('scanner_version', 'unknown')}`",
+            f"- Evaluator model: `{summary.get('model_used', 'unknown')}`",
+            f"- Policy fingerprint: `{summary.get('policy_fingerprint', 'unknown')}`",
+        ]
+    )
+    if summary.get("commit_sha"):
+        parts.append(f"- Commit: `{summary['commit_sha']}`")
+    parts.extend(
+        [
+            "",
+            "*Assessed by [skill-scanner](https://github.com/cisco-ai-defense/skill-scanner) "
+            "+ Claude evaluator.*",
+            "",
+        ]
+    )
+
+    return "\n".join(parts)
 
 
 def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Format risk-summary.json as a GitHub PR audit comment.",
+        description="Render risk-summary.json as a GitHub PR audit comment.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument("summary_file", type=Path, help="Path to risk-summary.json.")
@@ -75,38 +140,14 @@ def get_parser() -> argparse.ArgumentParser:
 
 def run(args: argparse.Namespace) -> int:
     plugin_name = os.environ.get("PLUGIN_NAME", "unknown-plugin")
-    model = os.environ.get("EVALUATOR_MODEL", DEFAULT_MODEL)
-
     try:
         summary = json.loads(args.summary_file.read_text(encoding="utf-8"))
     except (FileNotFoundError, json.JSONDecodeError) as e:
         print(f"error loading summary file: {e}", file=sys.stderr)
         return 1
 
-    severity = summary.get("overall_severity", "none")
-    summary["_severity_badge"] = SEVERITY_BADGE.get(severity, SEVERITY_BADGE["none"])
-
-    client = anthropic.Anthropic()
-    response = client.messages.create(
-        model=model,
-        max_tokens=1024,
-        system=[
-            {
-                "type": "text",
-                "text": (
-                    "You are a security report formatter for GitHub pull requests. "
-                    "You receive only structured risk summaries — never raw skill content. "
-                    "Format summaries as clear, concise, actionable Markdown PR comments. "
-                    "Do not reference or reproduce any skill source content."
-                ),
-                "cache_control": {"type": "ephemeral"},
-            }
-        ],
-        messages=[{"role": "user", "content": build_prompt(plugin_name, summary)}],
-    )
-
-    body = response.content[0].text
-    args.comment_file.write_text(f"{COMMENT_MARKER}\n{body}\n", encoding="utf-8")
+    body = render_comment(plugin_name, summary)
+    args.comment_file.write_text(body, encoding="utf-8")
     print(f"PR comment written to: {args.comment_file}")
     return 0
 

--- a/.github/workflows/skill-audit-report.yml
+++ b/.github/workflows/skill-audit-report.yml
@@ -75,6 +75,7 @@ jobs:
           pattern: scan-*
 
       - name: Process each plugin's scan
+        id: process
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -83,6 +84,8 @@ jobs:
         run: |
           set -euo pipefail
           overall_gate_ok=1
+          head_sha=""
+          summary_lines=()
 
           for artifact_dir in scan-artifacts/*/; do
             [ -d "${artifact_dir}" ] || continue
@@ -98,6 +101,7 @@ jobs:
             pr_number="$(jq -r '.pr_number' "${ctx}")"
             commit_sha="$(jq -r '.commit_sha' "${ctx}")"
             scanner_version="$(jq -r '.scanner_version' "${ctx}")"
+            head_sha="${commit_sha}"
 
             printf '\n── Processing plugin: %s (PR #%s) ──\n' "${plugin}" "${pr_number}"
 
@@ -112,7 +116,7 @@ jobs:
                 "${findings}" \
                 "scan-output/${plugin}/risk-summary.json"
 
-            # 2. Format the PR comment markdown
+            # 2. Render the PR comment markdown (deterministic; no LLM)
             PLUGIN_NAME="${plugin}" \
               python .github/scripts/write-comment.py \
                 "scan-output/${plugin}/risk-summary.json" \
@@ -123,16 +127,63 @@ jobs:
             COMMENT_FILE="scan-output/${plugin}/audit-comment.md" \
               bash .github/scripts/post-audit-comment.sh
 
-            # 4. Enforce gate (records pass/fail per plugin; OR across plugins)
-            if ! PR_NUMBER="${pr_number}" \
-                 SUMMARY_FILE="scan-output/${plugin}/risk-summary.json" \
-                 bash .github/scripts/check-approvals.sh; then
+            # 4. Enforce gate per plugin; OR across plugins for the overall result
+            severity="$(jq -r '.overall_severity' "scan-output/${plugin}/risk-summary.json")"
+            count="$(jq -r '.finding_count' "scan-output/${plugin}/risk-summary.json")"
+            if PR_NUMBER="${pr_number}" \
+               SUMMARY_FILE="scan-output/${plugin}/risk-summary.json" \
+               bash .github/scripts/check-approvals.sh; then
+              summary_lines+=("- ✅ \`${plugin}\` — ${severity} (${count} finding(s))")
+            else
               echo "gate FAILED for plugin: ${plugin}"
               overall_gate_ok=0
+              summary_lines+=("- ❌ \`${plugin}\` — ${severity} (${count} finding(s))")
             fi
           done
+
+          # Persist for the publish-check step. workflow_run jobs do not
+          # auto-create PR-level checks; we publish one explicitly below.
+          {
+            printf 'head_sha=%s\n' "${head_sha}"
+            printf 'gate_ok=%s\n' "${overall_gate_ok}"
+          } >>"$GITHUB_OUTPUT"
+          printf '%s\n' "${summary_lines[@]}" >scan-output/check-summary.md
 
           if [[ "${overall_gate_ok}" -eq 0 ]]; then
             printf '\none or more plugins failed the severity gate.\n'
             exit 1
           fi
+
+      # Publish the gate decision as a check-run on the PR's head SHA so it
+      # appears in `gh pr checks` and can be required in branch protection.
+      # workflow_run jobs do not surface as PR checks by default.
+      - name: Publish PR-level check
+        if: always() && steps.process.outputs.head_sha != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          HEAD_SHA: ${{ steps.process.outputs.head_sha }}
+          GATE_OK: ${{ steps.process.outputs.gate_ok }}
+        run: |
+          set -euo pipefail
+          if [[ "${GATE_OK}" == "1" ]]; then
+            conclusion="success"
+            title="Skill security gate passed"
+          else
+            conclusion="failure"
+            title="Skill security gate failed — apply 'security-override' label and re-run to override"
+          fi
+          summary_body="$(cat scan-output/check-summary.md 2>/dev/null || printf 'No plugin scans processed.\n')"
+
+          jq -n \
+            --arg name "Skill Security Audit Report" \
+            --arg head_sha "${HEAD_SHA}" \
+            --arg conclusion "${conclusion}" \
+            --arg title "${title}" \
+            --arg summary "${summary_body}" \
+            '{name: $name, head_sha: $head_sha, status: "completed", conclusion: $conclusion, output: {title: $title, summary: $summary}}' \
+          | gh api "repos/${GITHUB_REPOSITORY}/check-runs" \
+              --method POST \
+              --input - \
+              --silent
+          printf 'published check-run: %s on %s\n' "${conclusion}" "${HEAD_SHA}"

--- a/.github/workflows/skill-audit-scan.yml
+++ b/.github/workflows/skill-audit-scan.yml
@@ -170,7 +170,7 @@ jobs:
             "plugin": "${PLUGIN}",
             "pr_number": "${PR_NUMBER}",
             "commit_sha": "${HEAD_SHA}",
-            "scanner-version": "${SCANNER_VERSION:-unknown}",
+            "scanner_version": "${SCANNER_VERSION:-unknown}",
             "prohibit_outcome": "${PROHIBIT_OUTCOME}",
             "scan_outcome": "${SCAN_OUTCOME}"
           }


### PR DESCRIPTION
## Summary

Three bugs surfaced by smoke testing #372 (low-risk) and #373 (high-risk):

1. **Findings table showed wrong rows.** PR comment listed the first 5 findings in scanner order, hiding the HIGH/CRITICAL triggers behind license-warning INFO rows. Fix: `evaluate-findings.py` sorts findings by severity desc and stores the full list under `findings`. `write-comment.py` renders the table deterministically in Python (no LLM call) — full list, no truncation risk.
2. **`scanner_version: null`.** `context.json` wrote the kebab-case key `scanner-version` while the report workflow read `.scanner_version`. Reverted the JSON key.
3. **No PR-level check published.** `workflow_run`-triggered jobs do not surface as PR status checks, so a HIGH gate failure didn't block merge. Added a `Publish PR-level check` step that calls the Checks API with the PR head SHA + aggregate gate decision. Surfaces in `gh pr checks` under the name `Skill Security Audit Report` and can be required in branch protection.

## Test plan

- [ ] Re-trigger smoke PRs #372 and #373; confirm:
  - [ ] Comments show all findings sorted by severity (HIGH/CRITICAL at top)
  - [ ] Provenance footer shows the real scanner version (not `null`)
  - [ ] `Skill Security Audit Report` appears as a PR check on both PRs
  - [ ] PR #372 shows the check passing
  - [ ] PR #373 shows the check failing
  - [ ] Apply `security-override` to #373 and re-run report → check flips to passing