### PR TITLE
chore(skills): add license: MIT to all skills; teach scaffolder + check-skill

### DIFF
--- a/plugins/build/_shared/references/skill-best-practices.md
+++ b/plugins/build/_shared/references/skill-best-practices.md
@@ -17,6 +17,7 @@ name: kebab-case-slug
 description: Use when <concrete trigger>. <One sentence of purpose.>
 version: 1.0.0
 owner: team-or-person
+license: MIT
 ---
 
 # <Human-readable title>
@@ -46,7 +47,7 @@ Load-bearing elements: the frontmatter identity (`name`, `description`, `version
 
 **Write the description as a retrieval signal.** Lead with "Use when…" and enumerate concrete invocation triggers — user phrases, file extensions, error strings, event types. Keep it short; long descriptions dilute the signal.
 
-**Declare identity in frontmatter.** Ship `name`, `description`, `version` (semver), and `owner`. Version bumps are the cache-busting signal consumers rely on; owner is who gets pinged when the skill rots. Invent no keys the skill spec does not sanction.
+**Declare identity in frontmatter.** Ship `name`, `description`, `version` (semver), and `owner`. Version bumps are the cache-busting signal consumers rely on; owner is who gets pinged when the skill rots. Add `license` (SPDX identifier such as `MIT`, or a short reference to a bundled `LICENSE` file) so reusers know the redistribution terms — match the host repo's license unless the skill ships under different terms. Invent no keys the skill spec does not sanction.
 
 **Keep the body short.** Under 300 lines, hard ceiling 400; lines under 120 characters. Move long scripts and reference material to sibling files. Every line is paid for in context tokens.
 

--- a/plugins/build/skills/build-bash-script/SKILL.md
+++ b/plugins/build/skills/build-bash-script/SKILL.md
@@ -15,6 +15,7 @@ user-invocable: true
 references:
   - ../../_shared/references/bash-script-best-practices.md
   - ../../_shared/references/primitive-routing.md
+license: MIT
 ---
 
 # Build Bash Script

--- a/plugins/build/skills/build-github-workflow/SKILL.md
+++ b/plugins/build/skills/build-github-workflow/SKILL.md
@@ -17,6 +17,7 @@ user-invocable: true
 references:
   - ../../_shared/references/github-workflow-best-practices.md
   - ../../_shared/references/primitive-routing.md
+license: MIT
 ---
 
 # Build GitHub Workflow

--- a/plugins/build/skills/build-hook/SKILL.md
+++ b/plugins/build/skills/build-hook/SKILL.md
@@ -12,6 +12,7 @@ references:
   - ../../_shared/references/hook-best-practices.md
   - ../../_shared/references/primitive-routing.md
   - references/hook-testing.md
+license: MIT
 ---
 
 # Build Hook

--- a/plugins/build/skills/build-makefile/SKILL.md
+++ b/plugins/build/skills/build-makefile/SKILL.md
@@ -13,6 +13,7 @@ user-invocable: true
 references:
   - ../../_shared/references/makefile-best-practices.md
   - ../../_shared/references/primitive-routing.md
+license: MIT
 ---
 
 # Build Makefile

--- a/plugins/build/skills/build-pre-commit-config/SKILL.md
+++ b/plugins/build/skills/build-pre-commit-config/SKILL.md
@@ -18,6 +18,7 @@ user-invocable: true
 references:
   - ../../_shared/references/pre-commit-config-best-practices.md
   - ../../_shared/references/primitive-routing.md
+license: MIT
 ---
 
 # Build Pre-Commit Config

--- a/plugins/build/skills/build-python-script/SKILL.md
+++ b/plugins/build/skills/build-python-script/SKILL.md
@@ -15,6 +15,7 @@ user-invocable: true
 references:
   - ../../_shared/references/python-script-best-practices.md
   - ../../_shared/references/primitive-routing.md
+license: MIT
 ---
 
 # Build Python Script

--- a/plugins/build/skills/build-readme/SKILL.md
+++ b/plugins/build/skills/build-readme/SKILL.md
@@ -18,6 +18,7 @@ user-invocable: true
 references:
   - ../../_shared/references/readme-best-practices.md
   - ../../_shared/references/primitive-routing.md
+license: MIT
 ---
 
 # Build README

--- a/plugins/build/skills/build-resolver/SKILL.md
+++ b/plugins/build/skills/build-resolver/SKILL.md
@@ -6,6 +6,7 @@ user-invocable: true
 references:
   - ../../_shared/references/resolver-best-practices.md
   - ../../_shared/references/primitive-routing.md
+license: MIT
 ---
 
 # /build:build-resolver

--- a/plugins/build/skills/build-rule/SKILL.md
+++ b/plugins/build/skills/build-rule/SKILL.md
@@ -6,6 +6,7 @@ user-invocable: true
 references:
   - ../../_shared/references/rule-best-practices.md
   - ../../_shared/references/primitive-routing.md
+license: MIT
 ---
 
 # /build:build-rule

--- a/plugins/build/skills/build-skill-pair/SKILL.md
+++ b/plugins/build/skills/build-skill-pair/SKILL.md
@@ -18,6 +18,7 @@ references:
   - ../../_shared/references/primitive-routing.md
   - ../../_shared/references/skill-pair-best-practices.md
   - ../../_shared/references/skill-locations.md
+license: MIT
 ---
 
 # Build Skill Pair

--- a/plugins/build/skills/build-skill/SKILL.md
+++ b/plugins/build/skills/build-skill/SKILL.md
@@ -13,6 +13,7 @@ references:
   - ../../_shared/references/skill-best-practices.md
   - ../../_shared/references/primitive-routing.md
   - references/platform-notes.md
+license: MIT
 ---
 
 # /build:build-skill
@@ -88,7 +89,9 @@ This skill is the workflow; the principles doc is the rubric.
    Required frontmatter: `name`, `description`, `version`, `owner`.
    Required body sections: `## When to use`, `## Prerequisites`,
    `## Steps`, `## Failure modes`, `## Examples`. Optional frontmatter
-   fields — `argument-hint`, `when_to_use`, `user-invocable: false`,
+   fields — `license` (SPDX id like `MIT`, or a short reference to a
+   bundled `LICENSE` file; default to the host repo's license),
+   `argument-hint`, `when_to_use`, `user-invocable: false`,
    `disable-model-invocation: true`, `paths:`, `allowed-tools`,
    `context: fork` + `agent:`, `model`, `effort`, `hooks`,
    `tested_with` — reach for only when the use case calls.

--- a/plugins/build/skills/build-subagent/SKILL.md
+++ b/plugins/build/skills/build-subagent/SKILL.md
@@ -14,6 +14,7 @@ user-invocable: true
 references:
   - ../../_shared/references/subagent-best-practices.md
   - ../../_shared/references/primitive-routing.md
+license: MIT
 ---
 
 # Build Subagent

--- a/plugins/build/skills/check-bash-script/SKILL.md
+++ b/plugins/build/skills/check-bash-script/SKILL.md
@@ -18,6 +18,7 @@ references:
   - ../../_shared/references/bash-script-best-practices.md
   - references/audit-dimensions.md
   - references/repair-playbook.md
+license: MIT
 ---
 
 # Check Bash Script

--- a/plugins/build/skills/check-github-workflow/SKILL.md
+++ b/plugins/build/skills/check-github-workflow/SKILL.md
@@ -19,6 +19,7 @@ references:
   - ../../_shared/references/github-workflow-best-practices.md
   - references/audit-dimensions.md
   - references/repair-playbook.md
+license: MIT
 ---
 
 # Check GitHub Workflow

--- a/plugins/build/skills/check-hook/SKILL.md
+++ b/plugins/build/skills/check-hook/SKILL.md
@@ -13,6 +13,7 @@ references:
   - references/audit-dimensions.md
   - references/repair-playbook.md
   - references/platform-limitations.md
+license: MIT
 ---
 
 # Check Hook

--- a/plugins/build/skills/check-makefile/SKILL.md
+++ b/plugins/build/skills/check-makefile/SKILL.md
@@ -15,6 +15,7 @@ references:
   - ../../_shared/references/makefile-best-practices.md
   - references/audit-dimensions.md
   - references/repair-playbook.md
+license: MIT
 ---
 
 # Check Makefile

--- a/plugins/build/skills/check-pre-commit-config/SKILL.md
+++ b/plugins/build/skills/check-pre-commit-config/SKILL.md
@@ -17,6 +17,7 @@ references:
   - ../../_shared/references/pre-commit-config-best-practices.md
   - references/audit-dimensions.md
   - references/repair-playbook.md
+license: MIT
 ---
 
 # Check Pre-Commit Config

--- a/plugins/build/skills/check-python-script/SKILL.md
+++ b/plugins/build/skills/check-python-script/SKILL.md
@@ -18,6 +18,7 @@ references:
   - ../../_shared/references/python-script-best-practices.md
   - references/audit-dimensions.md
   - references/repair-playbook.md
+license: MIT
 ---
 
 # Check Python Script

--- a/plugins/build/skills/check-readme/SKILL.md
+++ b/plugins/build/skills/check-readme/SKILL.md
@@ -23,6 +23,7 @@ references:
   - ../../_shared/references/readme-best-practices.md
   - references/audit-dimensions.md
   - references/repair-playbook.md
+license: MIT
 ---
 
 # Check README

--- a/plugins/build/skills/check-resolver/SKILL.md
+++ b/plugins/build/skills/check-resolver/SKILL.md
@@ -7,6 +7,7 @@ references:
   - ../../_shared/references/resolver-best-practices.md
   - references/audit-dimensions.md
   - references/repair-playbook.md
+license: MIT
 ---
 
 # /build:check-resolver

--- a/plugins/build/skills/check-rule/SKILL.md
+++ b/plugins/build/skills/check-rule/SKILL.md
@@ -7,6 +7,7 @@ references:
   - ../../_shared/references/rule-best-practices.md
   - references/audit-dimensions.md
   - references/repair-playbook.md
+license: MIT
 ---
 
 # /build:check-rule

--- a/plugins/build/skills/check-skill-chain/SKILL.md
+++ b/plugins/build/skills/check-skill-chain/SKILL.md
@@ -7,6 +7,7 @@ description: >
   or "repair a chain".
 argument-hint: "[workflow goal or path/to/manifest.chain.md]"
 user-invocable: true
+license: MIT
 ---
 
 # Check Skill-Chain

--- a/plugins/build/skills/check-skill-pair/SKILL.md
+++ b/plugins/build/skills/check-skill-pair/SKILL.md
@@ -24,6 +24,7 @@ references:
   - ../../_shared/references/skill-locations.md
   - references/audit-dimensions.md
   - references/repair-playbook.md
+license: MIT
 ---
 
 # Check Skill Pair

--- a/plugins/build/skills/check-skill/SKILL.md
+++ b/plugins/build/skills/check-skill/SKILL.md
@@ -14,6 +14,7 @@ references:
   - ../../_shared/references/skill-best-practices.md
   - references/audit-dimensions.md
   - references/repair-playbook.md
+license: MIT
 ---
 
 # /build:check-skill
@@ -82,9 +83,11 @@ doc changes, the dimensions should follow.
    ```
 
    Emit all Tier-1 output immediately, before any LLM work. Exit
-   codes: 0 on clean / WARN-only, 1 on FAIL, 64 on arg error, 69 on
-   missing dependency. Treat exit 1 as the "exclude from Tier 2"
-   signal.
+   codes: 0 on clean / WARN-only / INFO-only, 1 on FAIL, 64 on arg
+   error, 69 on missing dependency. Treat exit 1 as the "exclude
+   from Tier 2" signal. INFO findings are toolkit-opinion advisories
+   (no spec backing) — surface them in the report but do not exclude
+   from Tier 2.
 
 3. **Apply orchestration rules.** Skills with a FAIL from
    `check_identity.sh`, `check_frontmatter.sh`, `check_structure.sh`
@@ -132,9 +135,9 @@ doc changes, the dimensions should follow.
    [repair-playbook.md](references/repair-playbook.md). Sort within
    each severity: Tier-1 deterministic first, then Tier-2 in
    dimension order, then Tier-3 collisions; ties break
-   alphabetically. FAIL precedes WARN overall. Close with a summary
-   line: `N skills audited, M findings (X fail, Y warn)` or
-   `N skills audited — no findings`.
+   alphabetically. Severity order: FAIL → WARN → INFO. Close with a
+   summary line: `N skills audited, M findings (X fail, Y warn,
+   Z info)` or `N skills audited — no findings`.
 
 7. **Offer the opt-in repair loop.** Ask: "Apply fixes? Enter y
    (all), n (skip), or comma-separated numbers." For each selected

--- a/plugins/build/skills/check-skill/references/audit-dimensions.md
+++ b/plugins/build/skills/check-skill/references/audit-dimensions.md
@@ -68,6 +68,7 @@ excluded from Tier 2.
 | Required frontmatter | canonical | Any of `name` / `description` / `version` / `owner` is missing or empty | fail |
 | Version shape | principle — *Declare identity* | `version` does not match `^\d+\.\d+\.\d+$` | fail |
 | Description cap | canonical | `description` exceeds 1024 chars, or combined with `when_to_use` exceeds 1536 | fail |
+| License presence | toolkit-opinion | Frontmatter has no `license` key. Spec-optional per Agent Skills; flagged as house-style guidance so reusers know redistribution terms | info |
 | Required sections | principle — *Declare triggers / preconditions / failure contract / example* | Missing any of `## When to use`, `## Prerequisites`, `## Steps`, `## Failure modes`, `## Examples` | fail |
 | Steps shape | principle — *Steps as numbered sequence* | Steps section is not an ordered list starting at 1 with sequential increments | fail (not ordered list) / warn (non-sequential) |
 | Examples content | principle — *Anchor with a concrete example* | Examples section lacks at least one fenced code block | warn |
@@ -87,6 +88,7 @@ excluded from Tier 2.
 - **Secrets scan:** the script prefers `gitleaks detect --no-git --source <file>`. When `gitleaks` is absent, it falls back to a built-in regex set (AWS keys `AKIA[0-9A-Z]{16}`, GitHub PATs `ghp_[A-Za-z0-9]{36}` / `github_pat_[A-Za-z0-9_]{82}`, OpenAI keys `sk-[A-Za-z0-9]{48}`, Anthropic keys `sk-ant-[A-Za-z0-9\-_]{80,}`, Stripe live keys `sk_live_[A-Za-z0-9]{24}`, and generic `password|secret|token|api_key|access_key|private_key` assignments). Any match is FAIL.
 - **Remote-exec / destructive-cmd:** emitted as WARN rather than FAIL — destructive commands are often legitimate when gated, and D7 Safety Gating judges whether the gate exists. The WARN text feeds Tier-2 as context.
 - **Prose pre-check:** wordlist and absolute-path matches emit WARN only. D4 Clarity and Consistency catches the non-obvious tail.
+- **License presence:** emits INFO (advisory, never affects exit code). The Agent Skills spec lists `license` as optional, not recommended — this finding is toolkit-opinion: setting `license` (an SPDX identifier or a short reference to a bundled `LICENSE` file) lets downstream reusers know the redistribution terms. Default to the host repo's license unless the skill ships under different terms.
 
 ---
 

--- a/plugins/build/skills/check-skill/references/repair-playbook.md
+++ b/plugins/build/skills/check-skill/references/repair-playbook.md
@@ -22,6 +22,7 @@ before applying.
   - [Required frontmatter](#required-frontmatter)
   - [Version shape](#version-shape)
   - [Description cap](#description-cap)
+  - [License presence](#license-presence)
   - [Required sections](#required-sections)
   - [Steps shape](#steps-shape)
   - [Examples content](#examples-content)
@@ -130,6 +131,15 @@ Covers three subtypes:
 **FROM:** 1100-char description cramming capability + every trigger phrase into one field
 **TO:** description stays ≤1024 (the trigger opener and one-sentence purpose); trigger enumeration moves to `when_to_use`
 **REASON:** Description is the primary retrieval signal; compressing it erodes the routing surface. The `when_to_use` split preserves the full trigger set without truncating the routing-critical opener.
+
+### License presence
+
+**Signal:** Frontmatter has no `license` key (INFO; toolkit-opinion advisory).
+
+**CHANGE:** Add `license:` with an SPDX identifier or a short reference to a bundled `LICENSE` file.
+**FROM:** frontmatter lists `name` / `description` / `version` / `owner` only
+**TO:** same fields plus `license: MIT` (or whatever matches the host repo's `LICENSE`; use `license: Proprietary. LICENSE.txt has complete terms` when the skill bundles its own)
+**REASON:** Spec-optional per Agent Skills, but downstream reusers need to know redistribution terms before they can fork or ship a skill they discovered. Defaulting to the host repo's license keeps the contract honest without forcing per-skill licensing decisions. INFO only — never blocks Tier-2 evaluation.
 
 ### Required sections
 

--- a/plugins/build/skills/check-skill/scripts/check_frontmatter.sh
+++ b/plugins/build/skills/check-skill/scripts/check_frontmatter.sh
@@ -7,6 +7,9 @@
 # Required keys:    `name`, `description`, `version`, `owner` present and non-empty.
 # Version shape:    matches ^[0-9]+\.[0-9]+\.[0-9]+$ (semver).
 # Description cap:  `description` ≤ 1024 chars; combined with `when_to_use` ≤ 1536.
+# License (INFO):   advisory — emits INFO when `license` is absent. Spec-optional
+#                   per Agent Skills, but recommended as toolkit house style so
+#                   reusers know redistribution terms. Never changes exit code.
 #
 # Name slug format and reserved-token checks live in check_identity.sh.
 #
@@ -43,6 +46,8 @@ Checks:
   Required keys   `name` / `description` / `version` / `owner` present, non-empty
   Version shape   ^[0-9]+\.[0-9]+\.[0-9]+$ (semver MAJOR.MINOR.PATCH)
   Description cap `description` ≤ 1024 chars (combined with `when_to_use` ≤ 1536)
+  License (INFO)  `license` advisory — emits INFO when absent (toolkit-opinion;
+                  never affects exit code)
 
 Options:
   -h, --help   Show this help and exit.
@@ -82,6 +87,12 @@ preflight() {
 emit_fail() {
   local path="$1" check="$2" detail="$3" rec="$4"
   printf 'FAIL  %s — %s: %s\n' "${path}" "${check}" "${detail}"
+  printf '  Recommendation: %s\n' "${rec}"
+}
+
+emit_info() {
+  local path="$1" check="$2" detail="$3" rec="$4"
+  printf 'INFO  %s — %s: %s\n' "${path}" "${check}" "${detail}"
   printf '  Recommendation: %s\n' "${rec}"
 }
 
@@ -165,6 +176,20 @@ check_required_key() {
   return 0
 }
 
+check_license_present() {
+  # Toolkit-opinion advisory: emit INFO when `license` is absent.
+  # Spec-optional per Agent Skills; flagged here as house style.
+  # Never changes exit code.
+  local file="$1"
+  if read_value "${file}" "license" >/dev/null 2>&1; then
+    return 0
+  fi
+  emit_info "${file}" "License field" \
+    "frontmatter has no 'license' key (toolkit-opinion advisory)" \
+    "Add 'license: <SPDX id or LICENSE-file reference>' — match the host repo's license unless the skill ships under different terms"
+  return 0
+}
+
 check_version_shape() {
   local file="$1"
   local val
@@ -238,6 +263,7 @@ check_file() {
 
   check_version_shape    "${file}" || fail=1
   check_description_cap  "${file}" || fail=1
+  check_license_present  "${file}"  # advisory; never affects exit code
 
   return "${fail}"
 }

--- a/plugins/build/skills/check-subagent/SKILL.md
+++ b/plugins/build/skills/check-subagent/SKILL.md
@@ -17,6 +17,7 @@ references:
   - ../../_shared/references/subagent-best-practices.md
   - references/audit-dimensions.md
   - references/repair-playbook.md
+license: MIT
 ---
 
 # Check Subagent

--- a/plugins/build/skills/refine-prompt/SKILL.md
+++ b/plugins/build/skills/refine-prompt/SKILL.md
@@ -11,6 +11,7 @@ user-invocable: true
 references:
   - references/technique-registry.md
   - references/assessment-rubric.md
+license: MIT
 ---
 
 # Refine Prompt

--- a/plugins/consider/skills/10-10-10/SKILL.md
+++ b/plugins/consider/skills/10-10-10/SKILL.md
@@ -3,6 +3,7 @@ name: 10-10-10
 description: Evaluate decisions by considering impact across three time horizons — use when short-term emotions and long-term consequences may point in different directions
 argument-hint: "[decision you're weighing or struggling with]"
 user-invocable: true
+license: MIT
 ---
 
 <objective>

--- a/plugins/consider/skills/5-whys/SKILL.md
+++ b/plugins/consider/skills/5-whys/SKILL.md
@@ -3,6 +3,7 @@ name: 5-whys
 description: Drill to root cause by asking why repeatedly until fundamentals emerge — use when a problem recurs or the quick fix keeps failing to hold
 argument-hint: "[problem or symptom to trace to its root cause]"
 user-invocable: true
+license: MIT
 ---
 
 <objective>

--- a/plugins/consider/skills/circle-of-competence/SKILL.md
+++ b/plugins/consider/skills/circle-of-competence/SKILL.md
@@ -3,6 +3,7 @@ name: circle-of-competence
 description: Scope decisions by distinguishing what you know well from what you don't — use when expertise boundaries are uncertain or a decision requires knowledge outside your direct experience
 argument-hint: "[domain or decision where expertise boundaries matter]"
 user-invocable: true
+license: MIT
 ---
 
 <objective>

--- a/plugins/consider/skills/consider/SKILL.md
+++ b/plugins/consider/skills/consider/SKILL.md
@@ -3,6 +3,7 @@ name: consider
 description: Apply structured mental models to think through problems. Use when the user wants to "analyze", "evaluate", "think through", "decide between", "weigh tradeoffs", or needs a framework for a decision.
 argument-hint: "{model-name} [topic to analyze]"
 user-invocable: true
+license: MIT
 ---
 
 Apply structured mental models to problems. If a specific model was requested,

--- a/plugins/consider/skills/eisenhower-matrix/SKILL.md
+++ b/plugins/consider/skills/eisenhower-matrix/SKILL.md
@@ -3,6 +3,7 @@ name: eisenhower-matrix
 description: Prioritize tasks and decisions by mapping urgency against importance — use when facing competing demands and unclear where to focus first
 argument-hint: "[list of tasks, decisions, or competing priorities]"
 user-invocable: true
+license: MIT
 ---
 
 <objective>

--- a/plugins/consider/skills/first-principles/SKILL.md
+++ b/plugins/consider/skills/first-principles/SKILL.md
@@ -3,6 +3,7 @@ name: first-principles
 description: Break down assumptions and rebuild reasoning from fundamental truths — use when a standard approach feels wrong or produces diminishing returns but no one has questioned its underlying assumptions
 argument-hint: "[problem or system to deconstruct]"
 user-invocable: true
+license: MIT
 ---
 
 <objective>

--- a/plugins/consider/skills/hanlons-razor/SKILL.md
+++ b/plugins/consider/skills/hanlons-razor/SKILL.md
@@ -3,6 +3,7 @@ name: hanlons-razor
 description: Interpret behavior charitably — attribute to mistakes before malice; use when behavior seems hostile or frustrating and an adversarial interpretation is forming
 argument-hint: "[situation where someone's behavior seems problematic]"
 user-invocable: true
+license: MIT
 ---
 
 <objective>

--- a/plugins/consider/skills/inversion/SKILL.md
+++ b/plugins/consider/skills/inversion/SKILL.md
@@ -3,6 +3,7 @@ name: inversion
 description: Solve problems backwards by identifying what would guarantee failure — use when direct optimization feels stuck or failure modes are unclear
 argument-hint: "[goal or outcome to achieve]"
 user-invocable: true
+license: MIT
 ---
 
 <objective>

--- a/plugins/consider/skills/map-vs-territory/SKILL.md
+++ b/plugins/consider/skills/map-vs-territory/SKILL.md
@@ -3,6 +3,7 @@ name: map-vs-territory
 description: Recognize where your mental model diverges from reality — use when a plan or model is driving decisions and its assumptions haven't been stress-tested
 argument-hint: "[situation where assumptions may not match reality]"
 user-invocable: true
+license: MIT
 ---
 
 <objective>

--- a/plugins/consider/skills/occams-razor/SKILL.md
+++ b/plugins/consider/skills/occams-razor/SKILL.md
@@ -3,6 +3,7 @@ name: occams-razor
 description: Find the simplest explanation or solution that accounts for all known facts — use when there are multiple competing explanations and the simplest hasn't been tried first
 argument-hint: "[phenomenon or problem with multiple possible explanations]"
 user-invocable: true
+license: MIT
 ---
 
 <objective>

--- a/plugins/consider/skills/one-thing/SKILL.md
+++ b/plugins/consider/skills/one-thing/SKILL.md
@@ -3,6 +3,7 @@ name: one-thing
 description: Identify the single highest-leverage action that makes everything else easier — use when there are too many competing priorities and focus needs to be established before work begins
 argument-hint: "[goal or area where focus is needed]"
 user-invocable: true
+license: MIT
 ---
 
 <objective>

--- a/plugins/consider/skills/opportunity-cost/SKILL.md
+++ b/plugins/consider/skills/opportunity-cost/SKILL.md
@@ -3,6 +3,7 @@ name: opportunity-cost
 description: Evaluate what you give up by choosing one option over alternatives — use when a decision is being made without explicitly naming the best alternative foregone
 argument-hint: "[decision with multiple options to compare]"
 user-invocable: true
+license: MIT
 ---
 
 <objective>

--- a/plugins/consider/skills/pareto/SKILL.md
+++ b/plugins/consider/skills/pareto/SKILL.md
@@ -3,6 +3,7 @@ name: pareto
 description: Apply the 80/20 rule to find the highest-leverage inputs — use when effort and results feel misaligned or there are too many things competing for attention
 argument-hint: "[area where effort and results feel misaligned]"
 user-invocable: true
+license: MIT
 ---
 
 <objective>

--- a/plugins/consider/skills/pick-model/SKILL.md
+++ b/plugins/consider/skills/pick-model/SKILL.md
@@ -3,6 +3,7 @@ name: pick-model
 description: "Select the right AI model for a task based on external benchmarks, pricing, and effort tradeoffs. Use when the user asks \"which model should I use?\", \"what's the best model for X?\", \"help me pick a model\", \"model comparison\", \"should I use Opus or Sonnet?\", or needs to decide between AI models for a specific workload. Also use when someone mentions cost optimization for LLM usage or wants to know if a cheaper model would work."
 argument-hint: "[task or workload to select a model for]"
 user-invocable: true
+license: MIT
 ---
 
 <objective>

--- a/plugins/consider/skills/reversibility/SKILL.md
+++ b/plugins/consider/skills/reversibility/SKILL.md
@@ -3,6 +3,7 @@ name: reversibility
 description: Assess decision risk by classifying as one-way or two-way door — use when calibrating how much analysis a decision deserves before committing
 argument-hint: "[decision to evaluate for reversibility]"
 user-invocable: true
+license: MIT
 ---
 
 <objective>

--- a/plugins/consider/skills/second-order/SKILL.md
+++ b/plugins/consider/skills/second-order/SKILL.md
@@ -3,6 +3,7 @@ name: second-order
 description: Think through the consequences of consequences before acting — use when an action has obvious immediate effects but the downstream consequences haven't been traced
 argument-hint: "[decision or action to evaluate]"
 user-invocable: true
+license: MIT
 ---
 
 <objective>

--- a/plugins/consider/skills/swot/SKILL.md
+++ b/plugins/consider/skills/swot/SKILL.md
@@ -3,6 +3,7 @@ name: swot
 description: Map strengths, weaknesses, opportunities, and threats systematically — use when evaluating a strategic position or deciding how to proceed with both internal and external factors at play
 argument-hint: "[project, product, team, or strategy to evaluate]"
 user-invocable: true
+license: MIT
 ---
 
 <objective>

--- a/plugins/consider/skills/via-negativa/SKILL.md
+++ b/plugins/consider/skills/via-negativa/SKILL.md
@@ -3,6 +3,7 @@ name: via-negativa
 description: Improve by removing problems rather than adding solutions — use when a system or process has accumulated complexity and improvement by addition has hit diminishing returns
 argument-hint: "[system, process, or situation to improve]"
 user-invocable: true
+license: MIT
 ---
 
 <objective>

--- a/plugins/wiki/skills/ingest/SKILL.md
+++ b/plugins/wiki/skills/ingest/SKILL.md
@@ -6,6 +6,7 @@ description: >
   URL, file path, or pasted text for knowledge capture.
 argument-hint: "[URL | file path | pasted content]"
 user-invocable: true
+license: MIT
 ---
 
 # Ingest

--- a/plugins/wiki/skills/lint/SKILL.md
+++ b/plugins/wiki/skills/lint/SKILL.md
@@ -9,6 +9,7 @@ description: >
 argument-hint: "[path/to/file.md]"
 user-invocable: true
 references: []
+license: MIT
 ---
 
 # Audit Skill

--- a/plugins/wiki/skills/research/SKILL.md
+++ b/plugins/wiki/skills/research/SKILL.md
@@ -24,6 +24,7 @@ references:
   - references/research-modes.md
   - references/cli-commands.md
   - references/MANIFEST.md
+license: MIT
 ---
 
 # Research Skill

--- a/plugins/wiki/skills/setup/SKILL.md
+++ b/plugins/wiki/skills/setup/SKILL.md
@@ -9,6 +9,7 @@ argument-hint: "[project root — defaults to CWD]"
 user-invocable: true
 references:
   - references/working-agreements-capture.md
+license: MIT
 ---
 
 # Wiki Setup

--- a/plugins/work/skills/finish-work/SKILL.md
+++ b/plugins/work/skills/finish-work/SKILL.md
@@ -12,6 +12,7 @@ disable-model-invocation: true
 references:
   - references/option-execution.md
   - ../../_shared/references/plan-format.md
+license: MIT
 ---
 
 # Finish Work

--- a/plugins/work/skills/plan-work/SKILL.md
+++ b/plugins/work/skills/plan-work/SKILL.md
@@ -15,6 +15,7 @@ references:
   - references/plan-template.md
   - references/examples/small-plan.md
   - references/examples/medium-plan.md
+license: MIT
 ---
 
 # Plan Work

--- a/plugins/work/skills/scope-work/SKILL.md
+++ b/plugins/work/skills/scope-work/SKILL.md
@@ -11,6 +11,7 @@ user-invocable: true
 references:
   - references/spec-format-guide.md
   - references/exploration-patterns.md
+license: MIT
 ---
 
 # Scope Work

--- a/plugins/work/skills/start-work/SKILL.md
+++ b/plugins/work/skills/start-work/SKILL.md
@@ -12,6 +12,7 @@ references:
   - references/execution-guide.md
   - references/recovery-patterns.md
   - references/multi-session-resumption.md
+license: MIT
 ---
 
 # Start Work

--- a/plugins/work/skills/verify-work/SKILL.md
+++ b/plugins/work/skills/verify-work/SKILL.md
@@ -16,6 +16,7 @@ references:
   - references/adhoc-validation.md
   - references/failure-diagnosis.md
   - ../../_shared/references/plan-format.md
+license: MIT
 ---
 
 # Verify Work


### PR DESCRIPTION
## Summary

- **53 SKILL.md files** now declare `license: MIT`, matching the repo `LICENSE`. Downstream reusers can see redistribution terms without inferring them.
- **Scaffolder + best-practices doc updated** so future skills inherit this convention. `build-skill-pair` eager-loads `skill-best-practices.md`, so the change propagates to every primitive pair without per-pair edits.
- **`check-skill` gains an INFO tier.** License-presence is a `toolkit-opinion` advisory (the Agent Skills spec marks `license` optional, not recommended). The new finding never affects exit code and never excludes a skill from Tier-2 evaluation.

## Why

The Agent Skills spec defines `license` as optional, but skills shipped publicly need a clear redistribution signal. Setting it once across the toolkit, plus teaching the scaffolder and lint, prevents drift on new skills and gives reusers a deterministic place to look.

## Test plan

- [x] `bash plugins/build/skills/check-skill/scripts/check_frontmatter.sh plugins/` shows **0 INFO findings** (all 53 skills now have `license: MIT`).
- [x] Smoke-tested with a synthetic skill missing `license:` — emits `INFO  ... — License field: ...`, exit code remains `0`.
- [x] Smoke-tested with a synthetic skill that has `license: MIT` — silent.
- [x] Pre-commit hooks pass.
- [ ] Reviewer: confirm `chore(skills)` prefix matches repo conventions and that MIT is the right default for every plugin (everything is in-house work; no third-party skill carve-outs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)