### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/bcbeidel/toolkit/security/code-scanning/1](https://github.com/bcbeidel/toolkit/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root so it applies to all jobs (including `test`) unless overridden. For this CI workflow, the minimal and appropriate permission is:

- `contents: read`

This preserves existing functionality (`actions/checkout` can operate with read access) while enforcing least privilege and satisfying CodeQL.

Edit only `.github/workflows/ci.yml`, inserting the `permissions` section between the `on:` block and `jobs:` block (or anywhere at root level with correct YAML indentation).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
