### PR TITLE
Add BRIEF.md pattern to multi-artifact build/* orchestrators

### DIFF
--- a/.briefs/hook.brief.md
+++ b/.briefs/hook.brief.md
@@ -1,0 +1,59 @@
+---
+name: hook build brief
+description: Intent and scope for the (retroactive) build of the hook primitive pair
+type: brief
+related:
+  - plugins/build/_shared/references/hook-best-practices.md
+---
+
+## User ask (verbatim)
+
+(retroactive) — capture intent for the existing hook primitive
+pair (`build-hook` + `check-hook`) so its self-audit produces zero
+`warn` findings on the new `brief-presence-and-content` dimension.
+
+## So-what
+
+CLAUDE.md instructions are advisory; the agent can argue around
+them. Hooks are the deterministic enforcement layer — they fire on
+specific lifecycle events (PreToolUse, PostToolUse, Stop, etc.)
+regardless of LLM judgment. Authors kept conflating hooks with
+permissions (`permissions.deny` is for unconditional blocks) and
+with rules (`/build:build-rule` is for semantic-judgment file
+content checks). The hook pair codifies when a hook is actually the
+right primitive, the script anatomy that makes it auditable, and
+the safety patterns (Stop loop guards, exit-code contract) that
+prevent the most-cited failure modes.
+
+## Scope boundaries
+
+- In: `hook` primitive (event-driven script + settings.json entry,
+  with the audit dimensions covering exit-code contract,
+  async/blocking coherence, Stop-loop guards, injection safety, jq
+  handling, shell hygiene).
+- Out: `permissions.deny` rules (different primitive),
+  `/build:build-rule` (semantic file-content checks),
+  cross-platform hook portability (separate concern in
+  platform-limitations.md).
+
+## Planned artifacts
+
+- [x] `plugins/build/_shared/references/hook-best-practices.md`
+- [x] `plugins/build/skills/build-hook/SKILL.md`
+- [x] `plugins/build/skills/check-hook/SKILL.md`
+- [x] `plugins/build/skills/check-hook/references/audit-dimensions.md`
+- [x] `plugins/build/skills/check-hook/references/repair-playbook.md`
+- [x] `plugins/build/skills/check-hook/references/platform-limitations.md`
+- [x] `plugins/build/_shared/references/primitive-routing.md` registration
+
+## Planned handoffs
+
+- [x] `/build:check-skill-pair hook` — pair-level integrity
+- [x] `/build:check-skill` on each half — per-SKILL.md quality
+
+## Decisions log
+
+- 2026-05-01 — retroactive brief authored to satisfy the new
+  `brief-presence-and-content` audit dimension introduced in PR
+  for issue #379. All checklists marked complete since the artifacts
+  predate this brief.

--- a/.briefs/resolver.brief.md
+++ b/.briefs/resolver.brief.md
@@ -1,0 +1,66 @@
+---
+name: resolver build brief
+description: Intent and scope for the (retroactive) build of the resolver primitive pair
+type: brief
+related:
+  - plugins/build/_shared/references/resolver-best-practices.md
+---
+
+## User ask (verbatim)
+
+(retroactive) — capture intent for the existing resolver primitive
+pair (`build-resolver` + `check-resolver`) so its self-audit
+produces zero `warn` findings on the new
+`brief-presence-and-content` dimension.
+
+## So-what
+
+Filing conventions in this repo were tribal knowledge — researchers
+filed into `.context/`, plans landed in `.designs/`, prompts ended
+up wherever. AGENTS.md tried to capture filing rules but couldn't
+keep up as new directories accreted. The resolver pair makes
+filing rules first-class: a machine-managed `RESOLVER.md` derives
+the filing table from disk scan, a context table bundles
+recurring-task doc loads, and `.resolver/evals.yml` proves the
+routing works (positive and negative cases). The audit half catches
+dark capabilities (directories not classified) and managed-region
+drift before they cause filing decisions to silently go wrong.
+
+## Scope boundaries
+
+- In: `resolver` primitive — `RESOLVER.md` at a repo-or-target root
+  with managed-region markers, sibling `.resolver/evals.yml`, and an
+  AGENTS.md pointer line. Audit dimensions cover Tier-1
+  deterministic checks (pointer presence, path resolution, marker
+  integrity, eval parsing), Tier-2 semantic dimensions (filing
+  coverage, context actionability, eval representativeness, brief
+  presence and content), and Tier-3 cross-artifact checks
+  (dark-capability scan, mtime staleness, eval execution).
+- Out: skill-dispatch routing (intent → which skill runs; handled by
+  SKILL.md `description`), per-skill `_shared/references/` wiring
+  hygiene, nested-resolver delegation rules beyond depth 1–2.
+
+## Planned artifacts
+
+- [x] `plugins/build/_shared/references/resolver-best-practices.md`
+- [x] `plugins/build/skills/build-resolver/SKILL.md`
+- [x] `plugins/build/skills/check-resolver/SKILL.md`
+- [x] `plugins/build/skills/check-resolver/references/audit-dimensions.md`
+- [x] `plugins/build/skills/check-resolver/references/repair-playbook.md`
+- [x] `plugins/build/skills/check-resolver/scripts/check_pointer.py`
+- [x] `plugins/build/skills/check-resolver/scripts/check_resolver.py`
+- [x] `plugins/build/skills/check-resolver/scripts/check_evals.py`
+- [x] `plugins/build/_shared/references/primitive-routing.md` registration
+
+## Planned handoffs
+
+- [x] `/build:check-skill-pair resolver` — pair-level integrity
+- [x] `/build:check-skill` on each half — per-SKILL.md quality
+- [x] `/build:check-python-script` on the three Tier-1 scripts
+
+## Decisions log
+
+- 2026-05-01 — retroactive brief authored to satisfy the new
+  `brief-presence-and-content` audit dimension introduced in PR
+  for issue #379. All checklists marked complete since the artifacts
+  predate this brief.

--- a/.briefs/skill-pair.brief.md
+++ b/.briefs/skill-pair.brief.md
@@ -1,0 +1,55 @@
+---
+name: skill-pair build brief
+description: Intent and scope for the (retroactive) build of skill-pair
+type: brief
+related:
+  - plugins/build/_shared/references/skill-pair-best-practices.md
+---
+
+## User ask (verbatim)
+
+(retroactive) — capture intent for the existing skill-pair primitive
+so its self-audit produces zero `warn` findings on the new
+`brief-presence-and-content` dimension.
+
+## So-what
+
+`skill-pair` is the meta-pair every other primitive pair in the
+toolkit derives from. Authors kept producing one half of a pair
+(scaffolder OR auditor) and forgetting the other, leaving dangling
+rubrics or unenforced principles. The skill-pair primitive locks
+both halves to a single distilled principles doc so creation and
+review never drift, and its registration in `primitive-routing.md`
+makes new pairs discoverable rather than grep-only.
+
+## Scope boundaries
+
+- In: `skill-pair` primitive (the build/check pair pattern + shared
+  principles doc + audit-dimensions + repair-playbook + routing-doc
+  registration).
+- Out: single-skill scaffolds (handled by `/build:build-skill`),
+  single-SKILL.md audits (handled by `/build:check-skill`),
+  Tier-1 deterministic scripts (delegated to script-builder skills
+  per Language Selection in `primitive-routing.md`).
+
+## Planned artifacts
+
+- [x] `plugins/build/_shared/references/skill-pair-best-practices.md`
+- [x] `plugins/build/skills/build-skill-pair/SKILL.md`
+- [x] `plugins/build/skills/check-skill-pair/SKILL.md`
+- [x] `plugins/build/skills/check-skill-pair/references/audit-dimensions.md`
+- [x] `plugins/build/skills/check-skill-pair/references/repair-playbook.md`
+- [x] `plugins/build/_shared/references/primitive-routing.md` registration
+
+## Planned handoffs
+
+- [x] `/build:check-skill-pair skill-pair` — pair-level integrity self-audit
+- [x] `/build:check-skill` on each half — per-SKILL.md quality
+- [x] `/build:check-python-script` on `audit_pair.py` — Tier-1 script audit
+
+## Decisions log
+
+- 2026-05-01 — retroactive brief authored to satisfy the new
+  `brief-presence-and-content` audit dimension introduced in PR
+  for issue #379. All checklists marked complete since the artifacts
+  predate this brief.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,49 @@ Pre-restructure releases used a single version. Post-restructure, each plugin
 
 ## [Unreleased]
 
+## [build-0.18.0] - 2026-05-02
+
+### Added
+
+- **`BRIEF.md` pattern for multi-artifact orchestrators (#379).** The
+  three multi-artifact `build/*` orchestrators — `build-skill-pair`,
+  `build-hook`, `build-resolver` — now write a per-build
+  `.briefs/<slug>.brief.md` at intake (Step 0) capturing user ask,
+  so-what, scope boundaries, and two checklists (planned artifacts,
+  planned handoffs). Mid-workflow re-reads counter the lossy-compression
+  drift toward generic rubrics. Paste-excerpt handoffs carry semantic
+  frame to leaf skills verbatim. A canonical anti-shortcut guard
+  appears in each orchestrator's Anti-Pattern Guards. The Review Gate
+  verifies the `Planned artifacts` checklist before accepting the
+  build.
+- **`brief-presence-and-content` audit dimension.** All three checker
+  counterparts (`check-skill-pair`, `check-hook`, `check-resolver`)
+  gain a new dimension covering both presence (deterministic — file
+  exists with the five required H2 sections) and content quality
+  (LLM judgment — so-what is non-generic, scope boundaries are
+  concrete). For `check-skill-pair`, `audit_pair.py` extends Tier-1
+  with the deterministic presence half; the SKILL.md body adds a
+  Brief-Content-Quality judgment pass. For `check-hook` and
+  `check-resolver`, the dimension lives entirely in the rubric and
+  the SKILL.md body. Severity is `warn` — briefs are throw-away;
+  missing briefs leave builds untraceable but do not break the pair.
+- **`brief-best-practices.md` shared reference.** New
+  `plugins/build/_shared/references/brief-best-practices.md`
+  documents brief format, paste-excerpt convention, slug-per-orchestrator
+  rules, update-don't-recreate semantics, and the anti-shortcut guard
+  rationale. Referenced by all three orchestrators and their checkers.
+- **`.briefs/` filing row in `RESOLVER.md`.** Registers the throw-away
+  brief artifact as a routable filing target inside the managed
+  region.
+
+### Changed
+
+- **`build-resolver` workflow steps renumbered.** Existing steps 0–8
+  shifted to 1–9 to accommodate the new Step 0 (Capture Brief).
+  Internal narration step references updated. External callers
+  reference resolver workflow by behavior, not step number, and are
+  unaffected.
+
 ## [wiki-0.4.0] - 2026-04-27
 
 ### Changed

--- a/RESOLVER.md
+++ b/RESOLVER.md
@@ -12,6 +12,7 @@ Routing table for filing new content and loading context. Machine-managed region
 | Design doc / RFC / architectural sketch | `.designs/` | `YYYY-MM-DD-<slug>.design.md` |
 | Research investigation (SIFT framework) | `.research/` | `YYYY-MM-DD-<slug>.research.md` |
 | Reusable prompt (skill-dev, maintenance, automation) | `.prompts/` | `<slug>.md` |
+| Build session brief (intent capture for multi-artifact `build/*` runs) | `.briefs/` | `<slug>.brief.md` |
 
 ## Context — what to load before acting
 

--- a/plugins/build/.claude-plugin/plugin.json
+++ b/plugins/build/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "build",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Skills for creating and refining Claude Code skills, rules, hooks, and subagents.",
   "author": {
     "name": "Brandon Beidel"

--- a/plugins/build/_shared/references/brief-best-practices.md
+++ b/plugins/build/_shared/references/brief-best-practices.md
@@ -1,0 +1,92 @@
+---
+name: Build Brief Best Practices
+description: Authoring guide for `.briefs/<slug>.brief.md` — the per-build intent artifact written by multi-artifact build/* orchestrators (build-skill-pair, build-hook, build-resolver). Defines format, paste-excerpt convention, slug rules, update-don't-recreate semantics, and the anti-shortcut guard rationale. Referenced by the three orchestrators and their checker counterparts.
+---
+
+# Build Brief Best Practices
+
+## What a Brief Is
+
+A build brief is a small markdown file written at the very start of a multi-artifact build workflow that captures *why* the build is happening, *what* it will produce, *how* it will hand off to leaf skills, and a running decisions log. It exists because long linear orchestrators (five artifacts in `build-skill-pair`, three in `build-resolver`) lossy-compress the original ask away by the final draft step — the rubric reads generic, the audit dimensions feel inherited from defaults, and a session resumed days later requires reconstructing the intent from git history. The brief is also where checklists live: `Planned artifacts` and `Planned handoffs` are checked off as work proceeds, giving the Review Gate a concrete completeness signal. Briefs are intentionally short-lived and throw-away — they exist to keep the active build coherent, not to accumulate as a project log. They live at `.briefs/<slug>.brief.md`, are not tracked by `wiki:lint`, and may be deleted once the build lands.
+
+## Anatomy
+
+The canonical brief format:
+
+```markdown
+---
+name: <primitive> build brief
+description: Intent and scope for the build of <primitive>
+type: brief
+related:
+  - <path to principles doc / produced artifacts>
+---
+
+## User ask (verbatim)
+<quote from intake — paste the user's words, not a summary>
+
+## So-what
+<one paragraph: why this primitive matters, what problem it solves,
+who benefits. Specific to this build — generic so-what is a smell.>
+
+## Scope boundaries
+- In: <what this build covers>
+- Out: <what it explicitly does not>
+
+## Planned artifacts
+- [ ] <path/to/artifact-1>
+- [ ] <path/to/artifact-2>
+
+## Planned handoffs
+- [ ] /build:build-bash-script — produce <name>.sh enforcing <dim>
+- [ ] /build:check-skill — audit <name> SKILL.md
+
+## Decisions log
+<appended as the workflow proceeds — date-stamped one-liners are fine>
+```
+
+The five required H2 sections are *User ask*, *So-what*, *Scope boundaries*, *Planned artifacts*, *Planned handoffs*. *Decisions log* is appended-to throughout the build; it's not a Review-Gate gate. No `status:` field — briefs do not have a draft/complete/superseded lifecycle. They are either present (build active or recent) or absent (build hasn't happened, or the brief was deleted post-landing).
+
+## Patterns That Work
+
+**One brief per primitive — update, don't recreate.** Re-running an orchestrator on an existing primitive reads `.briefs/<slug>.brief.md`, asks the user whether to update it (default yes) or abandon and regenerate (default no), and proceeds. The Decisions log is appended-to; planned-artifact and planned-handoff checkboxes can be reset if the scope materially changes. The filename does not carry a date prefix — that would imply a per-session lifecycle, but the contract is per-primitive.
+
+**Slug per orchestrator.** Each multi-artifact orchestrator owns a slug-derivation rule:
+
+| Orchestrator | Slug source | Example |
+|---|---|---|
+| `build-skill-pair` | primitive name (Intake #1) | `.briefs/terraform-module.brief.md` |
+| `build-hook` | hook name from enforcement goal | `.briefs/block-main-push.brief.md` |
+| `build-resolver` | `resolver` for root-scoped, target dir slug for nested | `.briefs/resolver.brief.md` |
+
+The slug is stable across re-runs so updates land in the same file. When an orchestrator can't derive a unique slug from intake (e.g., two hooks with the same enforcement goal), it asks the user to disambiguate before writing.
+
+**Paste excerpts at handoff, not pointers.** When an orchestrator hands off to a leaf skill (`/build:build-bash-script`, `/build:build-python-script`), it pastes the brief's *So-what* paragraph and the relevant audit-dimension or constraint text directly into the leaf skill's invocation prompt — verbatim. Leaf skills are not modified; they do not know briefs exist. Pointers ("see `.briefs/foo.brief.md`") fail because the leaf skill won't navigate; excerpts succeed because the semantic frame travels with the prompt.
+
+**Re-read the so-what before drafting.** Mid- and late-step instructions in each orchestrator say "re-read the brief's so-what before drafting the rubric" / "before writing the audit dimensions." This counters the lossy-compression failure mode where the rubric drifts toward generic by artifact 5 of 5.
+
+**Check off as you go; verify at Review Gate.** The two checklists (planned artifacts, planned handoffs) are checked off as each is produced. The Review Gate verifies both checklists are complete before accepting the build — an unchecked box is a Review-Gate fail, surfacing forgotten artifacts or skipped handoffs.
+
+## Anti-Patterns
+
+**Inlining a chained skill instead of invoking it.** Observed failure mode: rather than invoking `/build:build-bash-script` via the Skill tool, an orchestrator reads that skill's SKILL.md and writes a partial implementation directly. The shortcut bypasses the chained skill's rubric and leaves no audit trail that the proper skill was used. The anti-shortcut guard is the canonical mitigation:
+
+> "MUST invoke `/build:<chained-skill>` via the Skill tool. MUST NOT read its SKILL.md and inline a partial implementation. The shortcut bypasses the chained skill's rubric and leaves no audit trail."
+
+This bullet appears in each affected orchestrator's Anti-Pattern Guards section.
+
+**Generic so-what.** A so-what that could apply to any build of this primitive — "this codifies best practices for X" — fails the content-quality check. The so-what should name the actual reason this primitive is being built now: a specific gap, a specific user, a specific recurring problem. `check-*` skills audit this with LLM judgment.
+
+**Abandoned checklists.** Boxes left unchecked at end-of-build, especially `Planned handoffs`, mean the orchestrator either skipped a handoff or finished without verifying its own scope. The Review-Gate completeness check catches this; if the user wants to drop a planned item, they uncheck it explicitly with a `Decisions log` entry, not by ignoring it.
+
+**Pointer-only handoff.** "See `.briefs/foo.brief.md` for context" pasted into a leaf-skill invocation is treated by the leaf as ambient text it can ignore. Excerpts must be pasted verbatim — so-what + the specific dimension or constraint — for the semantic frame to actually arrive.
+
+**Treating briefs as long-lived docs.** Briefs are not project context. They do not appear in `wiki:lint` checks, do not need cross-references, and may be deleted after the build lands. Treating them as durable artifacts inverts the throw-away contract.
+
+## Safety & Maintenance
+
+Briefs are gitignored at the project's discretion or committed at the project's discretion — neither is required. A committed brief gives PR reviewers traceability from the produced artifacts back to intent; a gitignored brief avoids accumulating one-shot context in history. Either choice is valid. What is *not* valid is auto-deleting briefs from a hook or script — the user owns the lifecycle.
+
+When a brief becomes stale (the produced artifacts diverged from the planned-artifacts list, the so-what no longer matches the current build), the next orchestrator run that touches the same primitive will surface the drift at the "update or recreate?" prompt. There is no separate freshness check.
+
+The format is intentionally light. Adding fields (timing data, metric thresholds, owner annotations) is out of scope — briefs earn their keep by being short enough to read in 30 seconds. A brief that grows past one screen has accreted scope that belongs in a design doc or plan, not a brief.

--- a/plugins/build/pyproject.toml
+++ b/plugins/build/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "check"
-version = "0.17.0"
+version = "0.18.0"
 description = "Claude Code plugin for auditing Claude Code skills and rules for quality issues."
 requires-python = ">=3.9"
 dependencies = []

--- a/plugins/build/skills/build-hook/SKILL.md
+++ b/plugins/build/skills/build-hook/SKILL.md
@@ -11,6 +11,7 @@ user-invocable: true
 references:
   - ../../_shared/references/hook-best-practices.md
   - ../../_shared/references/primitive-routing.md
+  - ../../_shared/references/brief-best-practices.md
   - references/hook-testing.md
 license: MIT
 ---
@@ -22,9 +23,35 @@ gate deterministically, bypassing LLM judgment. See
 [hook-best-practices.md](../../_shared/references/hook-best-practices.md) for the
 rubric both halves of the pair share.
 
-**Workflow sequence:** 1. Route → 2. Scope Gate → 3. Elicit → 4. Draft →
-5. Safety Check → 6. Stop Hook Guard (conditional) → 7. Rule Overlap →
-8. Review Gate → 9. Save → 10. Test
+**Workflow sequence:** 0. Brief → 1. Route → 2. Scope Gate → 3. Elicit →
+4. Draft → 5. Safety Check → 6. Stop Hook Guard (conditional) →
+7. Rule Overlap → 8. Review Gate → 9. Save → 10. Test
+
+## 0. Brief
+
+Capture intent before any other action. Write
+`.briefs/<hook-name>.brief.md` from the user's intake. The slug is
+the hook name derived from the enforcement goal (e.g.,
+`block-main-push`, `redact-secrets-on-save`); pre-fill from
+`$ARGUMENTS` `[hook event] [enforcement goal]` if present, otherwise
+ask now. Format follows
+[brief-best-practices.md](../../_shared/references/brief-best-practices.md):
+five required H2 sections (*User ask*, *So-what*, *Scope boundaries*,
+*Planned artifacts*, *Planned handoffs*) plus an empty *Decisions log*.
+
+Pre-populate the two checklists from the planned workflow:
+
+- **Planned artifacts** — the two files produced by Step 9 Save:
+  hook script under `.claude/hooks/<name>.sh` and the `settings.json`
+  entry snippet (shown for manual application, not auto-patched).
+- **Planned handoffs** — `/build:check-hook` (audit). If a structured
+  payload requires non-trivial parsing past the trivial-glue
+  threshold, also `/build:check-bash-script` or
+  `/build:check-python-script` once the script is written.
+
+If `.briefs/<hook-name>.brief.md` already exists, read it and ask
+whether to update (default yes) or abandon and recreate (default no).
+Do not overwrite the brief silently.
 
 ## 1. Route
 
@@ -68,9 +95,16 @@ handler-type question. Otherwise ask one at a time:
 
 ## 4. Draft
 
+Re-read the brief's *So-what* and *Scope boundaries* before drafting.
+Drift toward generic "block X / enforce Y" framing in the script
+header or the settings entry comment is the lossy-compression
+failure mode the brief exists to counter.
+
 Produce two artifacts, referencing the Anatomy section of the principles
 doc for every shape decision (skeleton, matcher syntax, JSON output contract,
-settings.json entry, path-expansion variables).
+settings.json entry, path-expansion variables). Tick each item in
+*Planned artifacts* off in `.briefs/<hook-name>.brief.md` as it is
+drafted.
 
 **Artifact 1 — Hook script.** Start from the skeleton in
 [hook-best-practices.md §Anatomy §Script skeleton](../../_shared/references/hook-best-practices.md).
@@ -125,6 +159,13 @@ The user decides — overlap is often intentional.
 Present both artifacts — script and settings.json entry — and wait for
 explicit user approval before writing. If the user requests changes, revise
 and re-present. Proceed only on explicit approval.
+
+**Checklist verification.** Before accepting the build, read
+`.briefs/<hook-name>.brief.md` and confirm every item in *Planned
+artifacts* is checked off. Unchecked items are a Review-Gate fail —
+either the artifact was forgotten, or scope changed and the brief
+needs updating with a *Decisions log* entry justifying the drop.
+*Planned handoffs* may remain unchecked here; those land in Step 10.
 
 ## 9. Save
 
@@ -202,6 +243,14 @@ offers `/build:check-hook` to audit the configuration.
 3. **`async: true` with `exit 2`.** Async hooks run after execution regardless of exit code.
 4. **Writing files before the Review Gate.** Skipping the gate bypasses the only safety checkpoint.
 5. **Auto-patching `settings.json`.** Always show the snippet; let the user apply.
+6. **Inlining a chained skill instead of invoking it.** When a hook's
+   script grows past trivial glue and warrants `/build:check-bash-script`
+   or `/build:check-python-script`, MUST invoke the chained skill
+   via the Skill tool (paste the brief's *So-what* + the relevant
+   audit dimension into the prompt). MUST NOT read its SKILL.md and
+   inline a partial implementation. The shortcut bypasses the chained
+   skill's rubric and leaves no audit trail that the proper skill
+   was used.
 
 ## Key Instructions
 

--- a/plugins/build/skills/build-resolver/SKILL.md
+++ b/plugins/build/skills/build-resolver/SKILL.md
@@ -6,6 +6,7 @@ user-invocable: true
 references:
   - ../../_shared/references/resolver-best-practices.md
   - ../../_shared/references/primitive-routing.md
+  - ../../_shared/references/brief-best-practices.md
 license: MIT
 ---
 
@@ -15,7 +16,31 @@ Scaffold the three linked artifacts that make a resolver work: `RESOLVER.md` at 
 
 ## Workflow
 
-### 0. Verify Primitive
+### 0. Capture Brief
+
+Capture intent before any other workflow step. Write
+`.briefs/<slug>.brief.md` from the user's intake. The slug is
+`resolver` for a root-scoped resolver, or the target directory slug
+for a nested resolver (e.g., `plugins-resolver`). Format follows
+[brief-best-practices.md](../../_shared/references/brief-best-practices.md):
+five required H2 sections (*User ask*, *So-what*, *Scope boundaries*,
+*Planned artifacts*, *Planned handoffs*) plus an empty *Decisions log*.
+
+Pre-populate the two checklists from the planned workflow:
+
+- **Planned artifacts** — the three files produced by Step 8 Write:
+  `RESOLVER.md` at the resolver root, sibling `.resolver/evals.yml`,
+  and the AGENTS.md pointer line.
+- **Planned handoffs** — `/build:check-resolver` (in regenerate mode,
+  with `--run-evals`).
+
+If `.briefs/<slug>.brief.md` already exists, read it and ask whether
+to update (default yes) or abandon and recreate (default no). Update
+means: append to *Decisions log*, refresh checklists if scope
+materially changed, retain *User ask* and *So-what* unless the user
+explicitly revises them. Do not overwrite the brief silently.
+
+### 1. Verify Primitive
 
 A resolver is right when:
 - The repo has ≥3 tracked directories with filing conventions (each typically marked by a consistent naming pattern or shared frontmatter `type:`)
@@ -27,7 +52,7 @@ Redirect when:
 - The user wants skill-dispatch routing (intent → which skill runs) → that's handled by SKILL.md `description`; not a resolver concern
 - The user wants per-skill hygiene for `_shared/references/` wiring → separate problem; not this pair
 
-### 1. Detect Existing Resolver
+### 2. Detect Existing Resolver
 
 Walk up from the target directory looking for an existing `RESOLVER.md`. The first ancestor that has one becomes the **resolver root** for this run.
 
@@ -42,7 +67,7 @@ Walk up from the target directory looking for an existing `RESOLVER.md`. The fir
 
 Announce the mode, the resolver root, and what will change before proceeding. All subsequent steps operate scoped to the resolver root, not necessarily the repo root.
 
-### 2. Scan Resolver Root
+### 3. Scan Resolver Root
 
 Walk the resolver root's subtree (depth 1–2) and collect:
 
@@ -53,7 +78,12 @@ Walk the resolver root's subtree (depth 1–2) and collect:
 
 Report the scan summary: N directories detected, K tagged as filing candidates, M tagged ambient.
 
-### 3. Elicit Filing Table
+### 4. Elicit Filing Table
+
+Re-read the brief's *So-what* and *Scope boundaries* before
+elicitation. Filing rows that drift toward generic naming
+(`.misc/`, `.docs/`) rather than the repo's actual conventions are
+the lossy-compression failure mode the brief exists to counter.
 
 Present autodetected filing rows as proposed content. For each, show: content type (inferred from a sample of frontmatter `description` fields, or asked of the user), location (directory), naming pattern. Ask the user to confirm, correct, or extend.
 
@@ -61,7 +91,12 @@ For directories the scan could not classify, ask directly: "`.inbox/` has 4 file
 
 The filing table is the one machine-generated part of the managed region. Capture final decisions per row.
 
-### 4. Elicit Context Table
+### 5. Elicit Context Table
+
+Re-read the brief's *So-what* before eliciting context bundles.
+Generic task names ("when working on the project") are a smell;
+the brief should anchor the bundles to the *specific* recurring
+tasks named at intake.
 
 This is human-provided. Ask:
 
@@ -69,7 +104,7 @@ This is human-provided. Ask:
 
 Validate that each listed entry resolves to a file or directory. Directory entries are valid — the convention is to Glob the directory's naming pattern and read frontmatter to identify the right file. If a path doesn't resolve, flag and ask for a correction before writing.
 
-### 5. Seed Trigger Evals
+### 6. Seed Trigger Evals
 
 Propose 10–20 eval cases drawn from:
 - One positive case per filing row ("save this X" → expected location)
@@ -78,16 +113,23 @@ Propose 10–20 eval cases drawn from:
 
 Ask the user to confirm, edit, or add cases. A resolver shipped without evals is a decoration.
 
-### 6. Review Gate
+### 7. Review Gate
 
 Show the full proposed output:
 - `RESOLVER.md` contents (filing + context + out-of-scope inside markers, notes section outside)
 - `AGENTS.md` diff (one pointer line; placement proposed based on existing structure)
 - `.resolver/evals.yml` contents
 
+**Checklist verification.** Before accepting the build, read
+`.briefs/<slug>.brief.md` and confirm every item in *Planned
+artifacts* is checked off. Unchecked items are a Review-Gate fail —
+either the artifact was forgotten, or scope changed and the brief
+needs updating with a *Decisions log* entry justifying the drop.
+*Planned handoffs* may remain unchecked here; those land in Step 9.
+
 Iterate on feedback. Hold the write until the user approves.
 
-### 7. Write
+### 8. Write
 
 - Create `RESOLVER.md` at the resolver root
 - Create `.resolver/evals.yml` as a sibling under the resolver root (create `.resolver/` if missing) — co-located so the resolver and its evals move together
@@ -95,9 +137,9 @@ Iterate on feedback. Hold the write until the user approves.
 
 Report each file path.
 
-### 8. Hand Off
+### 9. Hand Off
 
-In **regenerate mode** (Step 1), run `/build:check-resolver --run-evals` automatically after writing — the managed region changed, so the seeded prompts must be re-proven against the new routing. Report the eval pass rate alongside the audit findings.
+In **regenerate mode** (Step 2), run `/build:check-resolver --run-evals` automatically after writing — the managed region changed, so the seeded prompts must be re-proven against the new routing. Report the eval pass rate alongside the audit findings. Paste the brief's *So-what* into the check-resolver invocation prompt verbatim, not as a `.briefs/<slug>.brief.md` pointer.
 
 In **fresh-scaffold mode**, offer: "Run `/build:check-resolver` against the new resolver?" Run it on approval; pass `--run-evals` only if the user asks. Evals failing on the first run means the seeded expectations don't match the filing/context shape — fix the evals, not the resolver.
 
@@ -106,27 +148,29 @@ In **fresh-scaffold mode**, offer: "Run `/build:check-resolver` against the new 
 <example>
 User: `/build:build-resolver`
 
-Step 2 scan: finds `.research/`, `.plans/`, `.designs/`, `.context/`, `.prompts/`, `plugins/build/_shared/references/`. Detects frontmatter `type:` patterns or consistent naming in four of these. Flags `.raw/` as ambient (no frontmatter pattern, no consistent naming).
+Step 0 captures a brief at `.briefs/resolver.brief.md` with the user's intake, planned-artifact and planned-handoff checklists.
 
-Step 3: proposes 6 filing rows; user confirms 5, drops `.prompts/` as out-of-scope.
+Step 3 scan: finds `.research/`, `.plans/`, `.designs/`, `.context/`, `.prompts/`, `plugins/build/_shared/references/`. Detects frontmatter `type:` patterns or consistent naming in four of these. Flags `.raw/` as ambient (no frontmatter pattern, no consistent naming).
 
-Step 4: user names three recurring tasks — "authoring a rule", "authoring a hook", "planning research" — with 2–3 doc paths each.
+Step 4: proposes 6 filing rows; user confirms 5, drops `.prompts/` as out-of-scope.
 
-Step 5: skill proposes 12 eval cases (5 positive filing, 3 positive context, 4 negative); user accepts 10, edits 2.
+Step 5: user names three recurring tasks — "authoring a rule", "authoring a hook", "planning research" — with 2–3 doc paths each.
 
-Step 6 Review Gate: presents all three artifacts. User approves.
+Step 6: skill proposes 12 eval cases (5 positive filing, 3 positive context, 4 negative); user accepts 10, edits 2.
 
-Step 7 writes:
+Step 7 Review Gate: presents all three artifacts plus brief-checklist verification. User approves.
+
+Step 8 writes:
 - `RESOLVER.md` (42 lines)
 - `.resolver/evals.yml` (35 lines)
 - `AGENTS.md` — inserts pointer line under existing "Context Navigation"
 
-Step 8: runs `/build:check-resolver`. All Tier-1 checks PASS; two Tier-2 WARN on thin context bundles ("authoring a rule" loads only one doc — consider adding primitive-routing.md). User applies WARN fix via repair loop.
+Step 9: runs `/build:check-resolver`. All Tier-1 checks PASS; two Tier-2 WARN on thin context bundles ("authoring a rule" loads only one doc — consider adding primitive-routing.md). User applies WARN fix via repair loop.
 </example>
 
 ## Key Instructions
 
-- Run the Step 0 primitive check — redirect if the repo doesn't cross the resolver threshold (≥3 tracked dirs with conventions, or ≥5 cross-skill reference docs)
+- Run the Step 1 primitive check — redirect if the repo doesn't cross the resolver threshold (≥3 tracked dirs with conventions, or ≥5 cross-skill reference docs)
 - Preserve human prose outside managed-region markers on regeneration — the managed region is disk-derived; everything else is author's
 - The filing table is generated from the disk scan, not invented — if the scan produces nothing for a directory, ask rather than fabricate
 - The context table is human-provided — do not synthesize task→doc bundles from model defaults; the user names recurring tasks
@@ -140,6 +184,14 @@ Step 8: runs `/build:check-resolver`. All Tier-1 checks PASS; two Tier-2 WARN on
 3. **Synthesizing context entries from model defaults.** Context bundles are repo-specific; the user must name the recurring tasks and confirm the doc set. Manufactured entries rot on the first regeneration.
 4. **Writing with zero eval cases.** Even 5 eval cases are better than 0; refuse to write `.resolver/evals.yml` empty.
 5. **Overwriting existing human prose.** On regenerate mode, verify the managed-region markers exist and that only the region between them changes. Abort if the file exists but markers are missing — ask the user to reconcile.
+6. **Inlining a chained skill instead of invoking it.** When handing off
+   to `/build:check-resolver` (regenerate mode auto-runs it; fresh-scaffold
+   mode offers it), MUST invoke the chained skill via the Skill tool.
+   MUST NOT read its SKILL.md and inline a partial implementation. The
+   shortcut bypasses the chained skill's rubric and leaves no audit
+   trail that the proper skill was used. Paste the brief's *So-what*
+   into the invocation prompt verbatim — leaf and chained skills do
+   not navigate to the brief.
 
 ## Handoff
 

--- a/plugins/build/skills/build-skill-pair/SKILL.md
+++ b/plugins/build/skills/build-skill-pair/SKILL.md
@@ -18,6 +18,7 @@ references:
   - ../../_shared/references/primitive-routing.md
   - ../../_shared/references/skill-pair-best-practices.md
   - ../../_shared/references/skill-locations.md
+  - ../../_shared/references/brief-best-practices.md
 license: MIT
 ---
 
@@ -29,7 +30,7 @@ point at the same principles doc so creation and review never drift.
 The distillation step — reconciling multiple inputs into one
 internally-consistent rubric — is where this skill earns its keep.
 
-**Workflow sequence:** 1. Route → 2. Target → 3. Scope Gate →
+**Workflow sequence:** 0. Brief → 1. Route → 2. Target → 3. Scope Gate →
 4. Intake → 5. Distill → 6. Draft → 7. Review Gate → 8. Save →
 9. Register → 10. Handoff
 
@@ -37,6 +38,35 @@ Throughout this skill, `<SKILL_ROOT>` and `<SHARED_REF_DIR>` are
 placeholders that resolve from the chosen target — see
 [skill-locations.md](../../_shared/references/skill-locations.md) for
 the prefix table.
+
+## 0. Brief
+
+Capture intent before any other action. Write
+`.briefs/<primitive>.brief.md` from the user's intake (the slug is the
+primitive name from Intake #1 — pre-fill from `$ARGUMENTS` if present,
+otherwise ask now). Format follows
+[brief-best-practices.md](../../_shared/references/brief-best-practices.md):
+five required H2 sections (*User ask*, *So-what*, *Scope boundaries*,
+*Planned artifacts*, *Planned handoffs*) plus an empty *Decisions log*
+appended-to throughout the workflow.
+
+Pre-populate the two checklists from the planned workflow:
+
+- **Planned artifacts** — the five files produced by Step 8 Save:
+  principles doc, both SKILL.mds, audit-dimensions.md,
+  repair-playbook.md (plus `primitive-routing.md` diff for plugin
+  target).
+- **Planned handoffs** — `/build:check-skill-pair`,
+  `/build:check-skill` on each half, and (conditional on the check
+  half needing Tier-1 scripts) `/build:build-bash-script` or
+  `/build:build-python-script` per *Language Selection* in
+  `primitive-routing.md`.
+
+If `.briefs/<primitive>.brief.md` already exists, read it and ask
+whether to update (default yes) or abandon and recreate (default no).
+Update means: append to *Decisions log*, refresh checklists if scope
+materially changed, retain *User ask* and *So-what* unless the user
+explicitly revises them. Do not overwrite the brief silently.
 
 ## 1. Route
 
@@ -140,6 +170,11 @@ and propose a placement; confirm with the user.
 
 ## 5. Distill
 
+Re-read the brief's *So-what* before drafting the rubric. The
+distilled doc must read as specific to the brief's intent — generic
+"best practices for X" framing is the lossy-compression failure mode
+the brief exists to counter.
+
 For each piece of input material from Intake #4: extract patterns
 *and the rationale behind each*. Patterns without rationale are
 cargo-culting; refuse to carry them into the rubric.
@@ -180,8 +215,14 @@ description: Authoring guide for <primitive> — ... Referenced by build-<primit
 
 ## 6. Draft (five artifacts)
 
+Re-read the brief's *So-what* and *Scope boundaries* before drafting
+the audit dimensions. Audit dimensions inherited from defaults
+(rather than from the principles distilled at intake) are the
+primary intra-skill drift symptom.
+
 Produce all five before the Review Gate — present them together so the
-user sees the whole pair.
+user sees the whole pair. Tick each item in *Planned artifacts* off
+in `.briefs/<primitive>.brief.md` as it is drafted.
 
 **Artifact 1 — Principles doc.** Output of Step 4.
 
@@ -217,6 +258,13 @@ diff to `primitive-routing.md`. Wait for explicit user approval before
 writing any file. If the user requests changes, revise and re-present
 — continue until the user approves or cancels. Proceed to Save only on
 explicit approval.
+
+**Checklist verification.** Before accepting the build, read
+`.briefs/<primitive>.brief.md` and confirm every item in *Planned
+artifacts* is checked off. Unchecked items are a Review-Gate fail —
+either the artifact was forgotten, or scope changed and the brief
+needs updating with a *Decisions log* entry justifying the drop.
+*Planned handoffs* may remain unchecked here; those land in Step 10.
 
 This gate exists because five new files (plus a routing-doc change in
 plugin mode) is a large commit to land silently. The user needs to
@@ -285,6 +333,15 @@ section — Python wins on interpretability — applies here too. This
 skill is meta-infrastructure; it does not get to bypass its own
 routing.
 
+**Paste-excerpt handoff.** When invoking
+`/build:build-bash-script` or `/build:build-python-script`, paste the
+brief's *So-what* paragraph and the specific audit dimension the
+script will enforce directly into the leaf skill's invocation prompt
+— verbatim, not as a `.briefs/<primitive>.brief.md` pointer. Leaf
+skills do not navigate to the brief; the semantic frame must travel
+with the prompt. Tick the corresponding item in *Planned handoffs*
+off as each leaf invocation completes.
+
 ## Example
 
 Invocation: `/build:build-skill-pair terraform-module`
@@ -323,6 +380,11 @@ Output: five files plus a routing-doc diff adding a paragraph under
 4. **Writing before Review Gate approval.** Five files plus a routing
    diff is a large drop. Present the whole shape first; write only
    after explicit approval.
+5. **Inlining a chained skill instead of invoking it.** MUST invoke
+   `/build:<chained-skill>` via the Skill tool. MUST NOT read its
+   SKILL.md and inline a partial implementation. The shortcut bypasses
+   the chained skill's rubric and leaves no audit trail that the
+   proper skill was used.
 
 ## Key Instructions
 

--- a/plugins/build/skills/check-hook/SKILL.md
+++ b/plugins/build/skills/check-hook/SKILL.md
@@ -10,6 +10,7 @@ argument-hint: "[settings.json path]"
 user-invocable: true
 references:
   - ../../_shared/references/hook-best-practices.md
+  - ../../_shared/references/brief-best-practices.md
   - references/audit-dimensions.md
   - references/repair-playbook.md
   - references/platform-limitations.md
@@ -23,7 +24,8 @@ Audit a project's Claude Code hooks configuration against the rubric in
 Read-only until the opt-in Repair Loop.
 
 **Workflow sequence:** 1. Scope → 2. Primitive Routing Scan →
-3. Judgment Checks → 4. Platform Scope → 5. Report → 6. Opt-In Repair Loop
+3. Judgment Checks → 3b. Brief-Quality Pass → 4. Platform Scope →
+5. Report → 6. Opt-In Repair Loop
 
 ## 1. Scope
 
@@ -62,6 +64,27 @@ authoritative.
 
 For each finding, capture: dimension name, offending hook / command / file,
 specific issue, severity (`fail` / `warn`).
+
+## 3b. Brief-Quality Pass
+
+For each hook script audited, look for `.briefs/<hook-name>.brief.md`
+at the repo root (the slug is the hook script's basename without
+`.sh`). Apply the `brief-presence-and-content` dimension from
+[audit-dimensions.md](references/audit-dimensions.md):
+
+- **Presence.** File exists with the five required H2 sections
+  (*User ask*, *So-what*, *Scope boundaries*, *Planned artifacts*,
+  *Planned handoffs*).
+- **Content quality.** *So-what* names a specific scenario the hook
+  prevents — a real near-miss, a class of mistakes the team kept
+  making — rather than reading as a category description.
+- **Scope concreteness.** *In* / *Out* lists carry concrete items,
+  not vague hedges.
+
+Each shortfall is a `warn` finding under the
+`brief-presence-and-content` dimension. Append to the findings set.
+Hooks built before the brief pattern existed will trip this; the
+repair playbook recommends a retroactive brief.
 
 ## 4. Platform Scope
 

--- a/plugins/build/skills/check-hook/references/audit-dimensions.md
+++ b/plugins/build/skills/check-hook/references/audit-dimensions.md
@@ -142,3 +142,11 @@ Each dimension enforces a specific section of
 **Fail:** Never — this dimension is always advisory.
 **Severity:** `warn`
 **Principles section:** §Safety & Maintenance (CLAUDE.md overlap)
+
+### brief-presence-and-content
+
+**What:** A `.briefs/<hook-name>.brief.md` exists at the repo root capturing the build's intent, carries the five required H2 sections (*User ask*, *So-what*, *Scope boundaries*, *Planned artifacts*, *Planned handoffs*), and the *So-what* paragraph names a specific enforcement gap rather than a category description.
+**Pass:** Brief file exists; all five required sections are present; *So-what* names a specific scenario the hook prevents (a real near-miss, a class of mistakes the team kept making) rather than reading as "deterministically enforces X"; *Scope boundaries* lists concrete in/out items.
+**Fail:** Brief is missing entirely; or one or more required sections are absent; or the *So-what* reads as a category description; or *Scope boundaries* is empty / vague.
+**Severity:** `warn` (presence and content). Briefs are throw-away — a missing brief does not break the hook, but it leaves the build untraceable to its original intent. Hooks built before the brief pattern existed will trip this; a retroactive brief is acceptable.
+**Principles section:** [brief-best-practices.md](../../../_shared/references/brief-best-practices.md) §What a Brief Is and §Anti-Patterns

--- a/plugins/build/skills/check-hook/references/repair-playbook.md
+++ b/plugins/build/skills/check-hook/references/repair-playbook.md
@@ -205,3 +205,9 @@ Remove committed `set -x` — uncomment locally only.
 - **Drop the hook:** if the advisory is sufficient and the hook generates false positives.
 
 Never auto-resolve. The user chooses.
+
+### brief-presence-and-content
+
+**Finding:** `.briefs/<hook-name>.brief.md` is missing, lacks one or more of the five required H2 sections, or the *So-what* reads as a category description rather than a specific intent statement.
+**Diagnosis:** The hook was scaffolded before the brief pattern existed, the orchestrator skipped Step 0, or the *So-what* drifted toward generic framing ("deterministically enforces X" rather than "the team kept pushing to main; this hook prevents the specific incident from 2026-04-22").
+**Fix:** for missing-or-incomplete-presence, write or extend `.briefs/<hook-name>.brief.md` per [brief-best-practices.md](../../../_shared/references/brief-best-practices.md). For generic *So-what*, ask the user for the specific scenario the hook prevents — a real near-miss, a class of mistakes the team kept making — and rewrite the paragraph anchored in those specifics. Briefs are throw-away; a retroactive brief authored after the fact is acceptable.

--- a/plugins/build/skills/check-resolver/SKILL.md
+++ b/plugins/build/skills/check-resolver/SKILL.md
@@ -5,6 +5,7 @@ argument-hint: "[target directory — defaults to CWD; walks up to the nearest R
 user-invocable: true
 references:
   - ../../_shared/references/resolver-best-practices.md
+  - ../../_shared/references/brief-best-practices.md
   - references/audit-dimensions.md
   - references/repair-playbook.md
 license: MIT
@@ -52,11 +53,12 @@ Rules with a FAIL finding from the first five rows are **excluded from Tier 2** 
 
 ### 3. Tier 2 — Semantic Dimensions (One LLM Call)
 
-Present the three judgment dimensions from [audit-dimensions.md](references/audit-dimensions.md) as a locked rubric in one call. Include `RESOLVER.md` verbatim, the output of the directory scan, and the `.resolver/evals.yml` contents.
+Present the four judgment dimensions from [audit-dimensions.md](references/audit-dimensions.md) as a locked rubric in one call. Include `RESOLVER.md` verbatim, the output of the directory scan, the `.resolver/evals.yml` contents, and (if present) the `.briefs/<slug>.brief.md` contents.
 
 1. **Filing Coverage** — Does the filing table reflect the directories that actually exist on disk? Flag dark capabilities (directories not in table and not in out-of-scope list).
 2. **Context Actionability** — Does each context row list at least one concrete doc path (not vague references)? Is the bundle size appropriate (1–4 docs)?
 3. **Eval Representativeness** — Do the evals cover both filing and context routing? Are there negative cases? Is coverage ≥1 case per filing row?
+4. **Brief Presence and Content** — Does `.briefs/<slug>.brief.md` exist with the five required H2 sections (*User ask*, *So-what*, *Scope boundaries*, *Planned artifacts*, *Planned handoffs*)? Is the *So-what* anchored in a specific filing/context drift rather than reading as a category description? Are scope boundaries concrete? Severity is WARN — briefs are throw-away; missing briefs leave the build untraceable but do not break the resolver.
 
 Output per dimension: `evidence → reasoning → verdict (WARN or PASS) → recommendation`. Default-closed on borderline evidence.
 
@@ -89,7 +91,7 @@ For each selected finding, draw the canonical repair from `repair-playbook.md`. 
 ## Key Instructions
 
 - Run Tier-1 first; exclude malformed resolvers from Tier 2
-- Present the three Tier-2 dimensions in a single locked-rubric call; per-dimension calls degrade agreement (RULERS, Hong et al. 2026)
+- Present the four Tier-2 dimensions in a single locked-rubric call; per-dimension calls degrade agreement (RULERS, Hong et al. 2026)
 - Include `RESOLVER.md` verbatim in the Tier-2 prompt — never summarize
 - Gate the dark-capabilities scan on depth — depth 1–2 is the sweet spot; deeper scans overwhelm with transient build outputs
 - Run evals only when `--run-evals` is passed; eval execution is slow and costs LLM calls, so keep it opt-in

--- a/plugins/build/skills/check-resolver/references/audit-dimensions.md
+++ b/plugins/build/skills/check-resolver/references/audit-dimensions.md
@@ -17,6 +17,7 @@ Handle deterministic checks (pointer presence, path resolution, YAML parse, mtim
   - [Dimension 1: Filing Coverage](#dimension-1-filing-coverage)
   - [Dimension 2: Context Actionability](#dimension-2-context-actionability)
   - [Dimension 3: Eval Representativeness](#dimension-3-eval-representativeness)
+  - [Dimension 4: Brief Presence and Content](#dimension-4-brief-presence-and-content)
 - [Tier 3: Cross-Artifact Checks](#tier-3-cross-artifact-checks)
 - [Evaluation Prompt Template](#evaluation-prompt-template)
 - [Output Format](#output-format)
@@ -55,7 +56,7 @@ Handle deterministic checks (pointer presence, path resolution, YAML parse, mtim
 
 ## Tier-2 — Semantic Dimensions
 
-Present all three dimensions as a locked rubric in a single call. Include `RESOLVER.md` verbatim, the directory scan output, and `.resolver/evals.yml`.
+Present all four dimensions as a locked rubric in a single call. Include `RESOLVER.md` verbatim, the directory scan output, `.resolver/evals.yml`, and (if present) `.briefs/<slug>.brief.md`.
 
 **Per-dimension calls are an anti-pattern** — per-criterion splits score 11.5 points lower (Hong et al., 2026, RULERS).
 
@@ -120,6 +121,31 @@ For each dimension: **verdict** (WARN, PASS, or N/A), **evidence**, **recommenda
 - Mix of filing and context cases proportional to the respective table sizes
 
 **Canonical Repair:** See `repair-playbook.md` → Dimension 3.
+
+---
+
+### Dimension 4: Brief Presence and Content
+
+*(principle — [brief-best-practices.md](../../../_shared/references/brief-best-practices.md))*
+
+**What it checks:** Does `.briefs/<slug>.brief.md` exist (slug = `resolver` for root-scoped, target dir slug for nested), with the five required H2 sections (*User ask*, *So-what*, *Scope boundaries*, *Planned artifacts*, *Planned handoffs*)? Does the *So-what* paragraph name a specific gap or recurring problem this resolver addresses, rather than reading as a category description? Are scope boundaries concrete?
+
+This dimension is **brief-presence-and-content** in cross-checker rubric vocabulary; it is included in the locked Tier-2 rubric so the same single LLM call evaluates filing, context, evals, and brief together (per RULERS — per-criterion splits cost calibration).
+
+**Fail signals (→ WARN):**
+- Brief is missing entirely (resolver was scaffolded before the brief pattern, or Step 0 was skipped)
+- One or more of the five required H2 sections is absent
+- *So-what* reads as a category description ("documents the resolver for this repo") rather than a specific intent (the recurring task that motivated dynamic context routing here)
+- *Scope boundaries* is empty or carries vague hedges
+
+**Pass signals:**
+- Brief file exists with all five required sections
+- *So-what* names a specific gap (e.g., "team kept filing research into `.context/` because the convention was undocumented") rather than a category description
+- *In* / *Out* lists carry concrete items (filing rows, context bundles, named recurring tasks) rather than "the usual"
+
+**Severity:** WARN (presence and content). Briefs are throw-away — a missing brief does not break the resolver, but it leaves the build untraceable.
+
+**Canonical Repair:** See `repair-playbook.md` → Dimension 4: Brief Presence and Content.
 
 ---
 
@@ -200,11 +226,18 @@ Criterion: >=1 case per filing row; >=15% negative cases; mix of filing and cont
 PASS anchor: 12 cases covering all 5 filing rows plus 3 context rows, with 2 negative cases
 FAIL anchor: 5 cases all positive filing, no context cases, no negative cases
 
+## Dimension 4: Brief Presence and Content
+Criterion: .briefs/<slug>.brief.md exists with five required H2s (User ask, So-what, Scope boundaries, Planned artifacts, Planned handoffs); So-what is non-generic; scope boundaries are concrete. N/A is acceptable when the brief is intentionally absent (e.g., a resolver pre-dating the brief pattern with no impending re-build).
+
+PASS anchor: brief present, So-what names a specific filing-convention drift the team kept hitting, scope boundaries list the affected directories
+FAIL anchor: brief missing; or brief present but So-what reads "documents the resolver for this repo" with empty scope boundaries
+
 ---
 
 <RESOLVER.md verbatim>
 <.resolver/evals.yml verbatim>
 <directory scan output>
+<.briefs/<slug>.brief.md verbatim, or "(missing)">
 
 ---
 

--- a/plugins/build/skills/check-resolver/references/repair-playbook.md
+++ b/plugins/build/skills/check-resolver/references/repair-playbook.md
@@ -136,9 +136,7 @@ Every FAIL and WARN finding maps to a canonical repair. Before applying, state t
 **CHANGE:** Add cases from the missing side in proportion to the table sizes
 **REASON:** Coverage gaps hide routing defects in the uncovered table.
 
----
-
-## Dimension 4: Brief Presence and Content
+### Dimension 4: Brief Presence and Content
 
 **Signal:** `.briefs/<slug>.brief.md` is missing.
 

--- a/plugins/build/skills/check-resolver/references/repair-playbook.md
+++ b/plugins/build/skills/check-resolver/references/repair-playbook.md
@@ -138,6 +138,29 @@ Every FAIL and WARN finding maps to a canonical repair. Before applying, state t
 
 ---
 
+## Dimension 4: Brief Presence and Content
+
+**Signal:** `.briefs/<slug>.brief.md` is missing.
+
+**CHANGE:** Write a brief at `.briefs/<slug>.brief.md` per [brief-best-practices.md](../../../_shared/references/brief-best-practices.md), with the five required H2 sections.
+**FROM:** No file at `.briefs/resolver.brief.md`; the resolver was scaffolded before the brief pattern existed.
+**TO:** A retroactive brief naming the specific filing/context drift the resolver was built to address. *Planned artifacts* and *Planned handoffs* checklists can be marked complete after the fact.
+**REASON:** Briefs make builds traceable to original intent; a retroactive brief is acceptable since briefs are throw-away.
+
+**Signal:** Brief present but *So-what* reads as a category description.
+
+**CHANGE:** Rewrite *So-what* anchored in the specific scenario.
+**FROM:** "Documents the routing table for this repository's filing conventions."
+**TO:** "Team members kept filing research investigations into `.context/` because the convention was undocumented; this resolver makes filing rules first-class so future investigations land in `.research/` automatically."
+**REASON:** Generic so-what defeats the brief's purpose — the build becomes untraceable to the actual problem it solved.
+
+**Signal:** Brief missing one or more required H2 sections.
+
+**CHANGE:** Add the missing section(s); pre-populate *Planned artifacts* and *Planned handoffs* from the existing resolver artifacts and prior `/build:check-resolver` invocations.
+**REASON:** The five required sections are the brief's structural contract; missing sections defeat the dimension-coverage check.
+
+---
+
 ## Tier-3 — Cross-Artifact
 
 ### Signal: dark capabilities — directory on disk not classified

--- a/plugins/build/skills/check-skill-pair/SKILL.md
+++ b/plugins/build/skills/check-skill-pair/SKILL.md
@@ -22,6 +22,7 @@ references:
   - ../../_shared/references/primitive-routing.md
   - ../../_shared/references/skill-pair-best-practices.md
   - ../../_shared/references/skill-locations.md
+  - ../../_shared/references/brief-best-practices.md
   - references/audit-dimensions.md
   - references/repair-playbook.md
 license: MIT
@@ -36,20 +37,25 @@ only surface when you look at the six artifacts *together*.
 
 The deterministic audit runs in one step via
 [`scripts/audit_pair.py`](scripts/audit_pair.py). It emits Tier-1
-existence findings (six artifact slots), Tier-2 content findings
-(required H2 sections in the principles doc, audit-dimensions vs
-repair-playbook coverage), and Tier-3
-cross-reference findings (shared principles path, check-half
-frontmatter refs, build→check handoff, routing registration, dogfood
-script info). A second pass layers one LLM-judgment check on top:
-**audit-dimensions required-fields** — each dimension entry should
-carry six fields (name, what, pass, fail, severity, principles-doc
-section), accepted either labeled (`**Pass:**`) or inferred
-("Passes when…"). This check is prose-heuristic and stays out of the
-script.
+existence findings (six artifact slots **plus** brief presence with
+required-section verification), Tier-2 content findings (required
+H2 sections in the principles doc, audit-dimensions vs
+repair-playbook coverage), and Tier-3 cross-reference findings
+(shared principles path, check-half frontmatter refs, build→check
+handoff, routing registration, dogfood script info). Two judgment
+passes layer LLM checks on top: **audit-dimensions required-fields**
+— each dimension entry should carry six fields (name, what, pass,
+fail, severity, principles-doc section), accepted either labeled
+(`**Pass:**`) or inferred ("Passes when…"); and
+**brief-content-quality** — when `.briefs/<primitive>.brief.md`
+exists, the *So-what* paragraph should name a specific gap / user /
+problem rather than read as a category description, and *Scope
+boundaries* should list concrete in/out items. Both judgment passes
+are prose-heuristic and stay out of the script.
 
 **Workflow sequence:** 1. Scope → 2. Target → 3. Run audit_pair.py →
-4. Required-Fields Pass → 5. Report → 6. Opt-In Repair Loop
+4. Required-Fields Pass → 4b. Brief-Content-Quality Pass →
+5. Report → 6. Opt-In Repair Loop
 
 `<SKILL_ROOT>` and `<SHARED_REF_DIR>` resolve from the chosen target
 — see [skill-locations.md](../../_shared/references/skill-locations.md)
@@ -120,6 +126,29 @@ there is nothing to read.
 
 Read the file once, iterate dimension entries (H3 headings), and
 append any findings to the Tier-1/2/3 set the script produced.
+
+## 4b. Brief-Content-Quality Pass
+
+Skip if Tier-1 flagged the brief as missing — there is nothing to
+read.
+
+Read `.briefs/<primitive>.brief.md` and judge two qualities:
+
+- **So-what is non-generic.** A paragraph that could apply to any
+  build of this primitive ("this codifies best practices for X",
+  "captures conventions for Y") fails. The *So-what* should name the
+  specific gap, user, or recurring problem this build addresses. A
+  retroactive brief authored after the fact is acceptable; what
+  matters is that the paragraph is anchored in specifics, not in
+  category framing.
+- **Scope boundaries are concrete.** *In* and *Out* lists should
+  carry concrete items (file paths, audit dimensions, named
+  workflows), not vague hedges ("the usual stuff", "anything
+  related to X"). Empty boundary lists are a fail.
+
+A brief failing either judgment is a `warn` finding under the
+`brief-presence-and-content` dimension. Append the finding to the
+Tier-1 set the script produced.
 
 ## 5. Report
 

--- a/plugins/build/skills/check-skill-pair/references/audit-dimensions.md
+++ b/plugins/build/skills/check-skill-pair/references/audit-dimensions.md
@@ -66,6 +66,14 @@ Severity:
 **Severity:** fail (both missing) / warn (one missing).
 **Principles section:** *Patterns That Work — Pair registered in `primitive-routing.md`*.
 
+### brief-presence-and-content
+
+**What it checks:** `.briefs/<primitive>.brief.md` exists at the repo root, carries the five required H2 sections (*User ask*, *So-what*, *Scope boundaries*, *Planned artifacts*, *Planned handoffs*), and the *So-what* paragraph reads as specific to this primitive's intent rather than generic. The presence half is deterministic (handled by `audit_pair.py`); the content-quality half (so-what genericness, scope-boundary concreteness) is LLM judgment, applied in the Required-Fields / Brief-Quality pass alongside the existing dimension-fields check.
+**Pass:** brief file exists, all five required sections are present, the *So-what* names a specific gap / user / problem rather than a category description, and *Scope boundaries* lists concrete in/out items rather than "the usual".
+**Warn:** brief is missing entirely; or one or more required sections are absent; or the *So-what* reads as a category description (e.g., "this codifies best practices for X") rather than a specific intent; or *Scope boundaries* is empty / vague.
+**Severity:** warn (presence and content). Briefs are throw-away — a missing brief does not break the pair, but it leaves the build untraceable to its original intent.
+**Principles section:** *What a Brief Is* and *Anti-Patterns* in [brief-best-practices.md](../../../../_shared/references/brief-best-practices.md).
+
 ## Tier-2: Content
 
 ### principles-doc-structure

--- a/plugins/build/skills/check-skill-pair/references/repair-playbook.md
+++ b/plugins/build/skills/check-skill-pair/references/repair-playbook.md
@@ -74,6 +74,26 @@ For*; if it is a variant of an existing class, extend the relevant
 sub-section (most commonly *Language Selection*). Show the diff and
 write on confirmation.
 
+### brief-presence-and-content
+
+**Finding:** `.briefs/<primitive>.brief.md` is missing, or carries
+fewer than the five required H2 sections (*User ask*, *So-what*,
+*Scope boundaries*, *Planned artifacts*, *Planned handoffs*), or
+the *So-what* reads as a category description rather than a specific
+intent statement.
+**Diagnosis:** the pair was scaffolded before the brief pattern
+existed, the orchestrator skipped Step 0, or the brief was written
+but the *So-what* drifted toward generic framing.
+**Fix:** for missing-or-incomplete-presence, write or extend
+`.briefs/<primitive>.brief.md` per
+[brief-best-practices.md](../../../_shared/references/brief-best-practices.md).
+For generic *So-what*, ask the user to name the specific gap, user,
+or recurring problem this primitive addresses; rewrite the paragraph
+to anchor in those specifics. Briefs are throw-away — a retroactive
+brief authored after the fact is acceptable; it does not need to
+reconstruct the original intake conversation, only capture what the
+build *should have* recorded.
+
 ## Tier-2: Content
 
 ### principles-doc-structure

--- a/plugins/build/skills/check-skill-pair/scripts/audit_pair.py
+++ b/plugins/build/skills/check-skill-pair/scripts/audit_pair.py
@@ -354,6 +354,54 @@ REQUIRED_H2_PREFIXES = [
     "Safety",
 ]
 
+REQUIRED_BRIEF_H2_PREFIXES = [
+    "User ask",
+    "So-what",
+    "Scope boundaries",
+    "Planned artifacts",
+    "Planned handoffs",
+]
+
+
+def tier1_brief_presence(primitive: str, root: Path) -> list[Finding]:
+    """Check `.briefs/<primitive>.brief.md` presence and required sections.
+
+    Briefs are throw-away intent artifacts written by multi-artifact
+    orchestrators at intake; missing or incomplete briefs are `warn`,
+    not `fail` — the pair still functions, but the build that produced
+    it lacked the intent-capture step.
+    """
+    brief_path = root / ".briefs" / f"{primitive}.brief.md"
+    rel = str(brief_path.relative_to(root)) if brief_path.is_relative_to(root) else str(
+        brief_path
+    )
+    findings: list[Finding] = []
+    text = read_text(brief_path)
+    if text is None:
+        findings.append(
+            Finding(
+                1,
+                "brief-presence-and-content",
+                rel,
+                "missing — multi-artifact builds should capture intent in a brief",
+                "warn",
+            )
+        )
+        return findings
+    h2s = extract_h2(text)
+    for required in REQUIRED_BRIEF_H2_PREFIXES:
+        if not any(h.startswith(required) for h in h2s):
+            findings.append(
+                Finding(
+                    1,
+                    "brief-presence-and-content",
+                    rel,
+                    f"missing required section: {required}",
+                    "warn",
+                )
+            )
+    return findings
+
 
 def tier2_content(paths: dict[str, Path], root: Path) -> list[Finding]:
     findings: list[Finding] = []
@@ -589,7 +637,8 @@ def audit(
         return [], True
     t2 = tier2_content(paths, root)
     t3 = tier3_cross_reference(primitive, paths, root, target)
-    return t1 + t2 + t3, False
+    brief = tier1_brief_presence(primitive, root)
+    return t1 + brief + t2 + t3, False
 
 
 def main(argv: list[str] | None = None) -> int:


### PR DESCRIPTION
Closes #379.

## Summary

- Adds a per-build `BRIEF.md` artifact pattern to the three multi-artifact `build/*` orchestrators (`build-skill-pair`, `build-hook`, `build-resolver`): Step 0 captures intent before any other workflow step, mid-workflow re-reads counter the lossy-compression failure mode, paste-excerpt handoffs carry semantic frame to leaf skills verbatim, an anti-shortcut guard discourages inlining chained skills, and a Review-Gate checklist verification confirms completeness before accepting the build.
- Adds matching `brief-presence-and-content` audit dimensions to all three checker counterparts (`check-skill-pair`, `check-hook`, `check-resolver`) covering both presence (deterministic — `audit_pair.py` extends Tier-1) and content quality (LLM judgment — so-what genericness, scope-boundary concreteness).
- Registers `.briefs/` as a filing target in `RESOLVER.md`'s managed region; documents the pattern in a new `brief-best-practices.md` shared reference; commits retroactive briefs for the three primitive pairs that pre-date the pattern as fixtures.

## Decisions

The three open questions from issue #379, resolved in the plan:

1. **Audit depth: both presence and content.** `audit_pair.py` checks file existence + five required H2 sections deterministically; SKILL.md adds an LLM-judgment pass for so-what / scope quality.
2. **Update existing brief on re-run** (no per-session dated files). Filename convention is `.briefs/<slug>.brief.md` — no date prefix, since one-brief-per-primitive matches the contract.
3. **No `status:` frontmatter field.** Briefs are throw-away; not tracked by `wiki:lint`.

## Test plan

- [x] `bash validate_plan.sh` on the plan — plan structure valid
- [x] All three orchestrator SKILL.mds carry the canonical anti-shortcut guard string (`MUST invoke`)
- [x] `brief-best-practices.md` exists with five required H2 sections
- [x] All three checker `audit-dimensions.md` files contain the new `brief-presence-and-content` dimension
- [x] No leaf-skill SKILL.md modifications (`build-bash-script`, `build-python-script` clean per `git diff main..HEAD`)
- [x] Self-audit on `skill-pair`, `hook`, `resolver` reports zero new `fail` findings (one pre-existing `dark-capability` orphan on resolver, unrelated to this work)
- [x] `ruff check plugins/` — all checks passed
- [x] `python3 -m pytest plugins/wiki/tests/` — 245 passed

## Out of scope

Per #379: leaf-skill changes, single-artifact orchestrators (`build-skill`, `build-subagent`, `build-makefile`, etc.), dos-style living-doc pattern, runtime hook enforcement of the anti-shortcut guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)