### PR TITLE
feat(build): mechanical-work partition — principle, build step, audit dimension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,35 @@ Pre-restructure releases used a single version. Post-restructure, each plugin
 
 ## [Unreleased]
 
+## [build-0.19.0] - 2026-05-02
+
+### Added
+
+- **Mechanical-Work Partition principle and audit dimension.** A
+  new authoring principle in `skill-best-practices.md` —
+  *Partition mechanical work from judgment* — instructs skill
+  authors to extract mechanical substeps (file existence, regex
+  match, count, schema validity, fixed-list lookup, exit-code
+  branching) into sibling scripts under `scripts/` and have the
+  SKILL.md reason over the script's output, rather than
+  performing the mechanical work in prose every invocation.
+- **`build-skill` Step 5 — Partition mechanical work from
+  judgment.** New step (between Conflict Check and Draft) walks
+  the intended step list, labels each substep as mechanical or
+  judgment, and proposes script extraction before drafting.
+  Existing Steps 5–9 renumbered to 6–10; example walkthrough
+  updated to demonstrate the partition. Cross-references updated
+  in failure modes, key instructions, and the improve sub-step
+  pointer.
+- **`check-skill` Tier-2 Dimension 9 — Mechanical-Work
+  Partition.** Tier-2 LLM rubric now runs nine dimensions in a
+  single locked-rubric call (was eight). Dimension 9 flags
+  inline-prose mechanical work as WARN; judgment-only skills
+  return PASS with verdict N/A. `audit-dimensions.md` and
+  `repair-playbook.md` gain mirrored entries; SKILL.md body and
+  Anti-Pattern Guards updated to reference all nine dimensions.
+  Locked-rubric single-call property preserved.
+
 ## [build-0.18.0] - 2026-05-02
 
 ### Added

--- a/plugins/build/.claude-plugin/plugin.json
+++ b/plugins/build/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "build",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Skills for creating and refining Claude Code skills, rules, hooks, and subagents.",
   "author": {
     "name": "Brandon Beidel"

--- a/plugins/build/_shared/references/skill-best-practices.md
+++ b/plugins/build/_shared/references/skill-best-practices.md
@@ -55,6 +55,8 @@ Load-bearing elements: the frontmatter identity (`name`, `description`, `version
 
 **Write Steps as a numbered sequence of atomic actions.** Ordered list starting at 1, one action per step, imperative voice addressed to the agent. Keep conditional nesting shallow; deeper branching usually means a second skill. No commentary or rationale inside the step body — reasoning lives in surrounding prose.
 
+**Partition mechanical work from judgment.** For each step, ask whether the work is *mechanical* (file existence, regex match, count, schema validity, fixed-list lookup, exit-code branching) or *judgment* (is this well-scoped, does this read well, does the description retrieve). Mechanical work belongs in a sibling script under `scripts/` that the SKILL.md invokes — the LLM reasons over the script's output, not the raw input. Doing mechanical work in prose is slower, less reliable per invocation, and pays the token cost every call. The toolkit's own audit skills (check-skill, check-resolver, check-rule) follow this partition: Tier-1 deterministic scripts feed Tier-2 LLM judgment. Apply the same shape to any skill whose workflow has a deterministic substrate, and note explicitly when the workflow is judgment-only.
+
 **State preconditions once, check them early.** List tools, env vars, versions, and assumed state in `## Prerequisites`, and verify the critical ones in step 1. Assumed state is the biggest source of silent failure.
 
 **Declare inputs, outputs, and their shapes.** Name parameters the skill consumes, artifacts it produces, and environment variables it reads. Implicit contracts invite guessing.

--- a/plugins/build/pyproject.toml
+++ b/plugins/build/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "check"
-version = "0.18.0"
+version = "0.19.0"
 description = "Claude Code plugin for auditing Claude Code skills and rules for quality issues."
 requires-python = ">=3.9"
 dependencies = []

--- a/plugins/build/skills/build-skill/SKILL.md
+++ b/plugins/build/skills/build-skill/SKILL.md
@@ -61,7 +61,7 @@ This skill is the workflow; the principles doc is the rubric.
 
 2. **Capture intent.** Read `$ARGUMENTS`. Parse one of: a name + intent
    phrase (use the name, capture the trigger from the rest); a path to
-   an existing `SKILL.md` (route to the Improve sub-step at Step 8);
+   an existing `SKILL.md` (route to the Improve sub-step at Step 9);
    or empty (prompt the user). If the current conversation already
    contains a workflow the user wants to capture, extract the intent
    from the conversation — the tools invoked, the step sequence, the
@@ -84,7 +84,20 @@ This skill is the workflow; the principles doc is the rubric.
    `[existing skill]`. Merge, replace, or narrow the scope?" Routing
    ambiguity forces Claude to pick arbitrarily.
 
-5. **Draft the skill.** Follow the anatomy in
+5. **Partition mechanical work from judgment.** Walk the intended
+   step list and label each substep as *mechanical* (file exists,
+   regex match, count, schema valid, fixed-list lookup, exit-code
+   branching) or *judgment* (is this well-scoped, does this read
+   well, does the description retrieve). For each mechanical
+   substep, propose extracting it to a sibling under `scripts/` and
+   invoking it from `SKILL.md` so the LLM reasons over the script's
+   output, not raw input — `skill-best-practices.md` covers the
+   rationale. Show the user the partition and the proposed scripts
+   before drafting. If the workflow is judgment-only with no
+   mechanical substrate, say so explicitly and move on; do not
+   invent scripts to fill the slot.
+
+6. **Draft the skill.** Follow the anatomy in
    [skill-best-practices.md](../../_shared/references/skill-best-practices.md).
    Required frontmatter: `name`, `description`, `version`, `owner`.
    Required body sections: `## When to use`, `## Prerequisites`,
@@ -101,23 +114,24 @@ This skill is the workflow; the principles doc is the rubric.
    platform-owned and rejected at load time. First ~5K tokens survive
    Claude Code compaction — lead with load-bearing content.
 
-6. **Present for approval.** Before writing, narrate the design
+7. **Present for approval.** Before writing, narrate the design
    choices in 3–6 bullets. Cover the frontmatter choices and why any
    non-default field is set; the structure choices (ordering, where
-   gates sit); and what was skipped and why (often more educational
-   than what was used). A reader who doesn't know skill authoring
-   should be able to follow the narration and disagree with any
-   choice. Iterate on feedback. Hold the write until the user
-   approves.
+   gates sit); the partition outcome from Step 5 (which substeps
+   became scripts and why, or that the workflow is judgment-only);
+   and what was skipped and why (often more educational than what
+   was used). A reader who doesn't know skill authoring should be
+   able to follow the narration and disagree with any choice.
+   Iterate on feedback. Hold the write until the user approves.
 
-7. **Write.** Create the skill directory if it doesn't exist. Write
+8. **Write.** Create the skill directory if it doesn't exist. Write
    `SKILL.md` to the full path from Step 3. Copy any bundled files
    (scripts, references) the draft names. Report the path. Claude
    Code picks up the new skill on next load. Then invoke
    `/build:check-skill` on the new skill — surface any findings and
    offer the repair loop before moving on.
 
-8. **Improve (alternate path from Step 2).** When Step 2 resolves to
+9. **Improve (alternate path from Step 2).** When Step 2 resolves to
    an existing `SKILL.md`, read it; run `/build:check-skill`; collect
    findings; ask the user which to address (y / n /
    comma-separated); apply canonical repairs from the playbook; show
@@ -127,11 +141,11 @@ This skill is the workflow; the principles doc is the rubric.
    appearing, try a different framing rather than tightening
    constraints with ALL-CAPS directives.
 
-9. **Package and present (optional).** Only when the `present_files`
-   tool is available (Claude.ai / Copilot / Cowork — see
-   [platform-notes.md](references/platform-notes.md)), package the
-   skill with `python -m scripts.package_skill <path/to/skill-folder>`
-   and direct the user to the resulting `.skill` file.
+10. **Package and present (optional).** Only when the `present_files`
+    tool is available (Claude.ai / Copilot / Cowork — see
+    [platform-notes.md](references/platform-notes.md)), package the
+    skill with `python -m scripts.package_skill <path/to/skill-folder>`
+    and direct the user to the resulting `.skill` file.
 
 ## Failure modes
 
@@ -146,7 +160,7 @@ This skill is the workflow; the principles doc is the rubric.
 - **User declines the draft at the approval gate.** Expected.
   Recovery: capture the specific objection, revise the draft, and
   re-present; do not write until the objection is addressed.
-- **check-skill findings block the write.** After Step 7, if
+- **check-skill findings block the write.** After Step 8, if
   `/build:check-skill` surfaces FAIL findings on the new skill,
   apply the canonical repair from `repair-playbook.md` and re-audit
   until only WARNs remain (or until the user explicitly accepts a
@@ -176,17 +190,26 @@ Step 3 — Scope: `.claude/` exists in the repo → project scope →
 
 Step 4 — No existing `process-pdfs` skill; no description collision.
 
-Step 5 — Drafts `SKILL.md` with required frontmatter (`name: process-pdfs`,
-`description: Use when…`, `version: 0.1.0`, `owner: <team>`) and
-required body sections.
+Step 5 — Partition: PDF detection (file extension + magic-byte check)
+and the `pdftotext` invocation are mechanical → extract to
+`scripts/extract_text.py` (input path → stdout text + exit code).
+Output sanity-check (is the text non-empty, are page breaks plausible)
+is judgment → keep inline. Narrates the partition before drafting.
 
-Step 6 — Narrates:
+Step 6 — Drafts `SKILL.md` with required frontmatter (`name: process-pdfs`,
+`description: Use when…`, `version: 0.1.0`, `owner: <team>`) and
+required body sections; Steps invoke `scripts/extract_text.py` for the
+mechanical work.
+
+Step 7 — Narrates:
 > - `name: process-pdfs` — gerund form, improves trigger match for "processing PDFs"
 > - Prerequisites names `pdftotext` (poppler) and a sample tests directory — cross-checked against Steps
+> - Partition: detection + extraction in `scripts/extract_text.py`; output sanity-check inline
 > - No `disable-model-invocation` — this is read-only; auto-triggering is safe
 > - Skipped `context: fork` — the user will want to see tool calls while iterating
 
-Step 7 — On approval, writes `.claude/skills/process-pdfs/SKILL.md`.
+Step 8 — On approval, writes `.claude/skills/process-pdfs/SKILL.md`
+and `.claude/skills/process-pdfs/scripts/extract_text.py`.
 Runs `/build:check-skill` — 0 findings. Reports the path.
 </example>
 
@@ -201,7 +224,7 @@ Runs `/build:check-skill` — 0 findings. Reports the path.
   (`/build:check-skill`'s Tier-1 flags unknown structural shapes)
 - Lead with load-bearing content in the first ~5K tokens —
   compaction-safe window
-- Hold the write until the user approves the draft (Step 6 gate)
+- Hold the write until the user approves the draft (Step 7 gate)
 - After writing, run `/build:check-skill` — this skill must produce
   skills that pass the deterministic checks
 

--- a/plugins/build/skills/check-skill/SKILL.md
+++ b/plugins/build/skills/check-skill/SKILL.md
@@ -21,7 +21,7 @@ license: MIT
 
 Evaluate the quality of an existing Claude Code skill. Three tiers,
 in order: deterministic format checks (no LLM), per-skill semantic
-checks (eight always-on dimensions in a single locked-rubric call),
+checks (nine always-on dimensions in a single locked-rubric call),
 then cross-skill description collision detection.
 
 This skill evaluates the skills themselves — not files against skills.
@@ -102,20 +102,21 @@ doc changes, the dimensions should follow.
    Safety Gating; hedge WARNs inform D4 Clarity and Consistency).
 
 4. **Run Tier-2 semantic checks.** For each structurally valid
-   skill, one locked-rubric LLM call assesses all eight always-on
+   skill, one locked-rubric LLM call assesses all nine always-on
    dimensions in
    [audit-dimensions.md](references/audit-dimensions.md):
    (1) Description Retrieval Signal, (2) Trigger Conditions,
    (3) Step Discipline, (4) Clarity and Consistency,
    (5) Prerequisites and Contract, (6) Failure Handling,
-   (7) Safety Gating, (8) Example Realism. Include the full
-   `SKILL.md` body verbatim — never summarize. Present all eight
-   dimensions in one call; per-dimension calls degrade agreement by
-   ~11.5 points (RULERS, Hong et al. 2026). Dimensions that don't
-   apply return PASS silently (e.g., Safety Gating on a read-only
-   skill). Output per dimension: evidence → reasoning → verdict
-   (WARN / PASS / N/A) → recommendation. Default-closed: borderline
-   evidence surfaces as WARN, not PASS.
+   (7) Safety Gating, (8) Example Realism, (9) Mechanical-Work
+   Partition. Include the full `SKILL.md` body verbatim — never
+   summarize. Present all nine dimensions in one call; per-dimension
+   calls degrade agreement by ~11.5 points (RULERS, Hong et al.
+   2026). Dimensions that don't apply return PASS silently (e.g.,
+   Safety Gating on a read-only skill; Mechanical-Work Partition on
+   a judgment-only skill). Output per dimension: evidence →
+   reasoning → verdict (WARN / PASS / N/A) → recommendation.
+   Default-closed: borderline evidence surfaces as WARN, not PASS.
 
 5. **Run Tier-3 description-collision detection.** Compare
    descriptions across the skill collection and flag pairs whose
@@ -220,9 +221,9 @@ WARN  plugins/build/skills/foo/SKILL.md — Description collides with baz/SKILL.
   as expensive LLM calls
 - Feed Tier-1 WARN signals (destructive-cmd hits, hedge hits) as
   context into the Tier-2 prompt — they inform the evaluator for
-  D7 Safety Gating and D4 Clarity, not the dimension set (all eight
+  D7 Safety Gating and D4 Clarity, not the dimension set (all nine
   dimensions always run)
-- Present all eight Tier-2 dimensions as a single locked-rubric
+- Present all nine Tier-2 dimensions as a single locked-rubric
   call per skill — per-dimension calls degrade agreement by ~11.5
   points (RULERS, Hong et al. 2026)
 - Include the full SKILL.md body verbatim in every LLM evaluation
@@ -247,7 +248,7 @@ WARN  plugins/build/skills/foo/SKILL.md — Description collides with baz/SKILL.
    — every Recommendation names the specific change, drawn from
    `repair-playbook.md`.
 6. **Trigger-gating Tier-2 dimensions** — don't skip dimensions
-   based on whether the skill "opts into" a shape; run all eight
+   based on whether the skill "opts into" a shape; run all nine
    always. Dimensions that don't apply return PASS silently.
 
 ## Handoff

--- a/plugins/build/skills/check-skill/references/audit-dimensions.md
+++ b/plugins/build/skills/check-skill/references/audit-dimensions.md
@@ -1,6 +1,6 @@
 ---
 name: Audit Skill Dimensions
-description: Evaluation criteria for auditing a Claude Code SKILL.md — Tier-1 deterministic format checks, Tier-2 eight-dimension semantic rubric mirroring the authoring principles, and Tier-3 cross-skill conflict detection.
+description: Evaluation criteria for auditing a Claude Code SKILL.md — Tier-1 deterministic format checks, Tier-2 nine-dimension semantic rubric mirroring the authoring principles, and Tier-3 cross-skill conflict detection.
 ---
 
 # Audit Skill Dimensions
@@ -32,6 +32,7 @@ dimension follows.
   - [Dimension 6: Failure Handling](#dimension-6-failure-handling)
   - [Dimension 7: Safety Gating](#dimension-7-safety-gating)
   - [Dimension 8: Example Realism](#dimension-8-example-realism)
+  - [Dimension 9: Mechanical-Work Partition](#dimension-9-mechanical-work-partition)
 - [Evaluation Prompt Template](#evaluation-prompt-template)
 - [Tier 3: Cross-Skill Description Collision](#tier-3-cross-skill-description-collision)
 - [Output Format](#output-format)
@@ -94,7 +95,7 @@ excluded from Tier 2.
 
 ## Tier 2: Semantic Dimensions (One LLM Call per Skill)
 
-Present all eight dimensions as a locked rubric in a single call per
+Present all nine dimensions as a locked rubric in a single call per
 skill. Include the full SKILL.md body verbatim — never summarize.
 
 **Per-dimension calls are an anti-pattern.** Per-criterion separate calls
@@ -290,6 +291,29 @@ verdict "N/A".
 
 ---
 
+### Dimension 9: Mechanical-Work Partition
+
+*(principle — [Partition mechanical work from judgment](../../../_shared/references/skill-best-practices.md))*
+
+**What it checks:** Whether mechanical substeps (file existence, regex match, count, schema validity, fixed-list lookup, exit-code branching) are extracted to sibling scripts the SKILL.md invokes — or kept inline as prose the LLM has to re-derive on every invocation.
+
+**Scope:** Only WARN when the prose describes mechanical work the LLM is expected to perform without script support. Judgment-only skills (rubric application, scope decisions, narrative writing) return PASS with verdict "N/A".
+
+**Fail signals (→ WARN):**
+- A step instructs the LLM to perform a check that is purely mechanical: "Verify the file exists", "Count the occurrences of X", "Validate the YAML matches schema Y", "Check whether all entries appear in the registered list" — with no sibling script invoked
+- A step asks the LLM to parse, extract, or compare structured data the script could feed it as already-parsed output
+- The skill bundles no `scripts/` sibling but contains multiple mechanical-shaped steps
+- The skill describes pattern-matching against a fixed regex, fixed list, or known schema as if it were judgment
+
+**Pass signals:**
+- Mechanical substeps invoke sibling scripts under `scripts/` and the LLM reasons over the script's output (text, JSON, exit code)
+- The skill is judgment-only (rubric application, narrative writing, scope decisions) and no extraction applies
+- Inline mechanical work is acknowledged with a one-line reason (e.g., a single trivial check whose script would add maintenance burden disproportionate to the cost)
+
+**Canonical Repair:** See `repair-playbook.md` → Dimension 9.
+
+---
+
 ## Evaluation Prompt Template
 
 Use this skeleton for every Tier-2 LLM call. Criterion statements and
@@ -297,7 +321,7 @@ anchor examples come from the rubric above — do not generate them
 per-audit.
 
 ```
-You are auditing a Claude Code SKILL.md file. Evaluate all eight
+You are auditing a Claude Code SKILL.md file. Evaluate all nine
 dimensions below in a single response.
 
 Tier-1 signals for this skill (use as context, not as dimension gating):
@@ -371,6 +395,16 @@ identifiers, show side effects, and avoid synthetic placeholders?
 PASS anchor: example with real file paths, realistic parameters, and visible outputs/side effects
 FAIL anchor: `foo`/`bar`/`Widget` placeholders, `"example"` strings, no side effect shown
 
+## Dimension 9: Mechanical-Work Partition
+Criterion: Are mechanical substeps (file existence, regex match,
+count, schema validity, fixed-list lookup, exit-code branching)
+extracted to sibling scripts the SKILL.md invokes, with the LLM
+reasoning over the script's output? (Returns N/A when the workflow
+is judgment-only.)
+
+PASS anchor: a step invokes `scripts/extract.py` and the LLM reasons over its JSON output; or the skill is judgment-only (rubric application, narrative writing) and no extraction applies
+FAIL anchor: prose like "Verify the file exists at <path>" or "Count the entries in the registry" with no sibling script — the LLM is expected to re-derive the mechanical work on every invocation
+
 ---
 
 <skill file verbatim>
@@ -435,7 +469,8 @@ Sort order: FAIL findings first, WARN findings second, HINT last; within
 each severity, Tier-1 deterministic findings first, then Tier-2
 dimensions in numerical order (Description Retrieval → Trigger
 Conditions → Step Discipline → Clarity → Prerequisites → Failure
-Handling → Safety Gating → Example Realism), then Tier-3 collisions;
+Handling → Safety Gating → Example Realism → Mechanical-Work
+Partition), then Tier-3 collisions;
 ties break alphabetically by file path.
 
 Final summary line: `N skills audited, M findings (X fail, Y warn)` or

--- a/plugins/build/skills/check-skill/references/repair-playbook.md
+++ b/plugins/build/skills/check-skill/references/repair-playbook.md
@@ -41,6 +41,7 @@ before applying.
   - [Dimension 6: Failure Handling](#dimension-6-failure-handling)
   - [Dimension 7: Safety Gating](#dimension-7-safety-gating)
   - [Dimension 8: Example Realism](#dimension-8-example-realism)
+  - [Dimension 9: Mechanical-Work Partition](#dimension-9-mechanical-work-partition)
 - [Tier 3: Description Collisions](#tier-3-description-collisions)
 
 ---
@@ -397,6 +398,26 @@ bash
 ```
 ```
 **REASON:** Domain-specific identifiers let the evaluator (human or Claude) recognize the context and apply the skill the way they would to new cases. Synthetic placeholders defeat the point of the example.
+
+### Dimension 9: Mechanical-Work Partition
+
+**Signal:** Mechanical substeps (file existence, regex match, count, schema validity, fixed-list lookup, exit-code branching) live as inline prose the LLM is expected to perform every invocation, with no sibling script invoked.
+
+**CHANGE:** Extract the mechanical work to a script under `scripts/` and have the SKILL.md invoke it. The LLM reasons over the script's output (text, JSON, exit code). Keep judgment substeps (does this read well, is the scope right) inline.
+**FROM:**
+```markdown
+## Steps
+1. Read every `*.md` file under `references/`.
+2. For each file, parse the frontmatter and verify `name` is set, `version` matches `^\d+\.\d+\.\d+$`, and `description` is under 1024 chars.
+3. Report any failures.
+```
+**TO:**
+```markdown
+## Steps
+1. Run `python scripts/audit_frontmatter.py references/` — emits one JSON object per file with `path`, `name`, `version_ok`, `description_len`, and `failures: []`.
+2. Read the script's output. For each entry with non-empty `failures`, decide whether the failure is repair-now or repair-later based on severity, then report the partition to the user.
+```
+**REASON:** Mechanical work in prose is slower per invocation, less reliable run-to-run, and pays the token cost every call. The toolkit's own check-* skills follow this partition — Tier-1 deterministic scripts feed Tier-2 LLM judgment. Apply the same shape to any skill whose work has a deterministic substrate; judgment-only skills (rubric application, scope decisions) skip this repair.
 
 ---
 


### PR DESCRIPTION
## Summary

Surfaces an explicit determinism path inside skill authoring. Today, `build-skill` biases toward producing reasoning-only skills — there's no step that asks the LLM to identify mechanical substeps and propose extracting them into scripts. The toolkit's design principle ("Structure in code, quality in skills") is *modeled* by the existing `check-*` skills but isn't *taught* by `build-skill` to produce future skills. This PR closes that gap on three sides.

- **Authoring principle.** New principle in `skill-best-practices.md` — *Partition mechanical work from judgment* — names the partition (file existence, regex match, count, schema validity, fixed-list lookup, exit-code branching go in scripts; rubric/scope/narrative judgment stays inline) and cites the toolkit's own check-* skills as the reference shape.
- **Build step.** `build-skill` gets a new Step 5 between Conflict Check and Draft. It walks the intended step list, labels each substep mechanical vs. judgment, and proposes script extraction before drafting. Steps 5–9 renumber to 6–10; the example walkthrough demonstrates the partition. Cross-references in failure modes, key instructions, and the improve-path pointer are updated.
- **Audit dimension.** `check-skill`'s Tier-2 rubric grows from 8 to 9 dimensions in a single locked-rubric call (RULERS single-call property preserved). New Dimension 9 — Mechanical-Work Partition — flags inline-prose mechanical work as WARN; judgment-only skills (rubric application, narrative writing, scope decisions) return PASS with verdict N/A. Mirrored entries in `audit-dimensions.md` and `repair-playbook.md`.

## Changes

- `plugins/build/_shared/references/skill-best-practices.md` — new authoring principle
- `plugins/build/skills/build-skill/SKILL.md` — new Step 5; renumber 5–9 → 6–10; example update; cross-ref updates
- `plugins/build/skills/check-skill/SKILL.md` — Tier-2 description updated to 9 dimensions; Anti-Pattern Guard #6 updated
- `plugins/build/skills/check-skill/references/audit-dimensions.md` — TOC, Dimension 9 entry, prompt-template anchor, sort-order update
- `plugins/build/skills/check-skill/references/repair-playbook.md` — Dimension 9 canonical repair with FROM/TO example
- `plugins/build/.claude-plugin/plugin.json` + `plugins/build/pyproject.toml`: 0.18.0 → 0.19.0 (Minor — behavioral change to existing skills)
- `CHANGELOG.md` — `[build-0.19.0]` entry

## Test plan

- [ ] `build-skill/SKILL.md` body stays under the 300-line warn (currently 269)
- [ ] No "eight" / "Dimension 8" references remain in `check-skill` artifacts (where Dimension 9 is the new tail)
- [ ] Run `/build:check-skill` against `build-skill` itself to confirm the renumbered steps and new Step 5 don't trigger unexpected findings
- [ ] Run `/build:check-skill` against `check-skill` itself to confirm the new Dimension 9 description doesn't trigger Tier-1 line-length / hedge findings
- [ ] Spot-check a known judgment-only skill (e.g., `consider/*`) audits as PASS / N/A on Dimension 9, not WARN
- [ ] Spot-check a known script-backed skill (e.g., `check-skill` itself) audits as PASS on Dimension 9

🤖 Generated with [Claude Code](https://claude.com/claude-code)