### PR TITLE
fix(security-scan): surface file paths and excerpts in PR audit report

### DIFF
--- a/.github/scripts/evaluate-findings.py
+++ b/.github/scripts/evaluate-findings.py
@@ -2,14 +2,14 @@
 """Evaluate skill-scanner findings and produce risk-summary.json.
 
 Step 1 of the split evaluator/comment-writer architecture. Reads scanner
-findings (rule_id, severity, analyzer, description per finding) and asks
-Claude for a 2-3 sentence narrative plus the top findings. Raw skill
-content is never passed to this step — only structured scanner metadata —
-so prompt injection from skill text cannot reach the LLM call.
+findings and asks Claude for a 2-3 sentence narrative. The LLM call
+receives only metadata (rule_id, severity, analyzer, description,
+category) — never file paths, snippets, or other raw skill content — so
+prompt injection from skill text cannot reach the LLM call.
 
-The output schema (risk-summary.json) must not contain skill_text,
-excerpt, snippet, or any raw skill content. The downstream comment-writer
-trusts that contract.
+The persisted risk-summary.json carries the full per-finding detail
+(file_path, line_number, snippet) for the deterministic comment renderer
+to use. The injection boundary is the LLM prompt, not the summary file.
 
 Example:
     FINDINGS_FILE=findings.json SUMMARY_FILE=risk-summary.json \\
@@ -35,6 +35,9 @@ EXIT_INTERRUPTED = 130
 SEVERITY_ORDER = {"CRITICAL": 4, "HIGH": 3, "MEDIUM": 2, "LOW": 1, "UNKNOWN": 0}
 DEFAULT_MODEL = "claude-opus-4-6"
 DEFAULT_POLICY_PATH = "policy/skill-scan-policy.yml"
+SNIPPET_MAX_CHARS = 200
+TITLE_MAX_CHARS = 200
+LLM_SAFE_FIELDS = ("rule_id", "severity", "analyzer", "description", "category")
 
 
 def policy_fingerprint(policy_file: Path) -> str:
@@ -70,10 +73,13 @@ def parse_simple_yaml_list(policy_file: Path, key: str) -> list[str]:
 
 
 def load_findings(findings_file: Path) -> tuple[list[dict], bool]:
-    """Load scanner findings and extract only structured metadata.
+    """Load scanner findings and extract structured fields.
 
-    Returns (findings, scan_failed). Raw skill content (skill_text,
-    excerpt, snippet, etc.) is discarded — never forwarded.
+    Returns (findings, scan_failed). Each finding carries metadata fields
+    (rule_id, severity, analyzer, description, category) plus locator
+    fields (skill_name, file_path, line_number, snippet). Locator fields
+    are persisted to risk-summary.json for the comment renderer; only
+    LLM_SAFE_FIELDS are passed to the LLM evaluator.
     """
     if not findings_file.exists():
         print(
@@ -90,17 +96,40 @@ def load_findings(findings_file: Path) -> tuple[list[dict], bool]:
 
     scan_failed = bool(data.get("scan_failed", False))
 
+    raw_findings: list[dict] = []
     if "results" in data:
-        raw_findings = [f for r in data["results"] for f in r.get("findings", [])]
+        for r in data["results"]:
+            skill_name = str(r.get("skill_name", "") or "")
+            for f in r.get("findings", []):
+                raw_findings.append({**f, "_skill_name": skill_name})
     else:
-        raw_findings = data.get("findings", [])
+        raw_findings = list(data.get("findings", []))
+
+    def _opt_str(value, limit: int) -> str | None:
+        if value is None:
+            return None
+        return str(value)[:limit]
+
+    def _opt_int(value) -> int | None:
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
 
     structured = [
         {
             "rule_id": str(f.get("rule_id", "UNKNOWN"))[:100],
             "severity": str(f.get("severity", "UNKNOWN")).upper(),
             "analyzer": str(f.get("analyzer", "unknown"))[:100],
+            "category": str(f.get("category", "uncategorized"))[:100],
+            "title": _opt_str(f.get("title"), TITLE_MAX_CHARS),
             "description": str(f.get("description", "No description"))[:500],
+            "skill_name": str(f.get("_skill_name", ""))[:200],
+            "file_path": _opt_str(f.get("file_path"), 300),
+            "line_number": _opt_int(f.get("line_number")),
+            "snippet": _opt_str(f.get("snippet"), SNIPPET_MAX_CHARS),
         }
         for f in raw_findings
     ]
@@ -161,7 +190,13 @@ def call_evaluator(
         for sev in ("CRITICAL", "HIGH", "MEDIUM", "LOW")
     }
 
-    sample = findings[:20]
+    # Redact locator fields (file_path, snippet, etc.) before sending
+    # to the LLM. Snippets contain raw skill content; passing them
+    # through here would re-open the prompt-injection surface.
+    sample = [
+        {k: f[k] for k in LLM_SAFE_FIELDS if k in f}
+        for f in findings[:20]
+    ]
 
     prompt = (
         f"Plugin: {plugin_name}\n"
@@ -250,6 +285,17 @@ def run(args: argparse.Namespace) -> int:
     summary["overall_severity"] = overall_severity
     summary["finding_count"] = len(findings)
     summary["findings"] = findings
+    summary["severity_counts"] = {
+        sev: sum(1 for f in findings if f["severity"] == sev)
+        for sev in ("CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO")
+    }
+    category_counts: dict[str, int] = {}
+    for f in findings:
+        cat = f.get("category") or "uncategorized"
+        category_counts[cat] = category_counts.get(cat, 0) + 1
+    summary["category_counts"] = dict(
+        sorted(category_counts.items(), key=lambda kv: (-kv[1], kv[0]))
+    )
     summary["scan_failed"] = scan_failed
     summary["policy_fingerprint"] = policy_fingerprint(policy_file)
     summary["scanner_version"] = scanner_version

--- a/.github/scripts/write-comment.py
+++ b/.github/scripts/write-comment.py
@@ -39,26 +39,85 @@ MERGE_BLOCKED_NOTICE = (
     "produce findings. Resolve the workflow error before merging."
 )
 
+DESC_CELL_MAX = 160
+EXCERPT_CELL_MAX = 100
+SEVERITY_ROWS = ("CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO")
+
 
 def _md_escape_cell(text: str) -> str:
     """Make a string safe to drop into a Markdown table cell on one line."""
     return str(text).replace("|", "\\|").replace("\r", " ").replace("\n", " ").strip()
 
 
+def _truncate(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 1)].rstrip() + "…"
+
+
+def _format_location(f: dict) -> str:
+    skill = f.get("skill_name") or ""
+    path = f.get("file_path") or ""
+    line = f.get("line_number")
+    parts: list[str] = []
+    if skill and path:
+        parts.append(f"{skill}/{path}")
+    elif path:
+        parts.append(path)
+    elif skill:
+        parts.append(skill)
+    else:
+        return "—"
+    if line is not None:
+        parts.append(f":{line}")
+    return "".join(parts)
+
+
+def render_severity_table(severity_counts: dict[str, int]) -> str:
+    rows = ["| Severity | Count |", "|---|---|"]
+    for sev in SEVERITY_ROWS:
+        rows.append(f"| {sev} | {severity_counts.get(sev, 0)} |")
+    return "\n".join(rows) + "\n"
+
+
+def render_category_table(category_counts: dict[str, int]) -> str:
+    if not category_counts:
+        return ""
+    rows = ["| Category | Count |", "|---|---|"]
+    rows.extend(
+        f"| {_md_escape_cell(cat)} | {count} |"
+        for cat, count in category_counts.items()
+    )
+    return "\n".join(rows) + "\n"
+
+
 def render_findings_table(findings: list[dict]) -> str:
     if not findings:
         return "_No findings._"
-    header = "| # | Severity | Analyzer | Rule | Description |\n|---|---|---|---|---|\n"
-    rows = [
-        "| {idx} | {sev} | {analyzer} | {rule} | {desc} |".format(
-            idx=i,
-            sev=_md_escape_cell(f.get("severity", "UNKNOWN")),
-            analyzer=_md_escape_cell(f.get("analyzer", "unknown")),
-            rule=_md_escape_cell(f.get("rule_id", "UNKNOWN")),
-            desc=_md_escape_cell(f.get("description", "")),
+    header = (
+        "| # | Severity | Category | Location | Rule | Description | Excerpt |\n"
+        "|---|---|---|---|---|---|---|\n"
+    )
+    rows = []
+    for i, f in enumerate(findings, start=1):
+        snippet = f.get("snippet") or ""
+        excerpt_cell = (
+            f"`{_md_escape_cell(_truncate(snippet, EXCERPT_CELL_MAX))}`"
+            if snippet
+            else "—"
         )
-        for i, f in enumerate(findings, start=1)
-    ]
+        desc_text = _truncate(f.get("description", ""), DESC_CELL_MAX)
+        rows.append(
+            "| {idx} | {sev} | {cat} | {loc} | {rule} | {desc} | {exc} |".format(
+                idx=i,
+                sev=_md_escape_cell(f.get("severity", "UNKNOWN")),
+                cat=_md_escape_cell(f.get("category", "uncategorized")),
+                loc=_md_escape_cell(_format_location(f)),
+                rule=_md_escape_cell(f.get("rule_id", "UNKNOWN")),
+                desc=_md_escape_cell(desc_text),
+                exc=excerpt_cell,
+            )
+        )
     return header + "\n".join(rows) + "\n"
 
 
@@ -86,6 +145,28 @@ def render_comment(plugin_name: str, summary: dict) -> str:
             f"Scan completed for {plugin_name}. {finding_count} finding(s) detected.",
         )
         parts.extend([narrative, ""])
+
+    severity_counts = summary.get("severity_counts") or {}
+    category_counts = summary.get("category_counts") or {}
+
+    if findings and not scan_failed:
+        parts.extend(
+            [
+                "### Severity breakdown",
+                "",
+                render_severity_table(severity_counts),
+                "",
+            ]
+        )
+        if category_counts:
+            parts.extend(
+                [
+                    "### Category breakdown",
+                    "",
+                    render_category_table(category_counts),
+                    "",
+                ]
+            )
 
     parts.extend(
         [

--- a/.github/workflows/skill-audit-report.yml
+++ b/.github/workflows/skill-audit-report.yml
@@ -147,7 +147,32 @@ jobs:
             printf 'head_sha=%s\n' "${head_sha}"
             printf 'gate_ok=%s\n' "${overall_gate_ok}"
           } >>"$GITHUB_OUTPUT"
-          printf '%s\n' "${summary_lines[@]}" >scan-output/check-summary.md
+
+          # Build the check-run summary: per-plugin tally lines first, then
+          # the rendered audit comment(s) embedded so the PR-page check view
+          # carries actionable detail (paths, severity, excerpts) rather
+          # than just a count. Truncate per GitHub's 65k summary cap.
+          {
+            printf '%s\n' "${summary_lines[@]}"
+            printf '\n'
+            for artifact_dir in scan-artifacts/*/; do
+              [ -d "${artifact_dir}" ] || continue
+              plugin="$(jq -r '.plugin' "${artifact_dir}context.json" 2>/dev/null || true)"
+              [ -n "${plugin}" ] || continue
+              comment="scan-output/${plugin}/audit-comment.md"
+              [ -f "${comment}" ] || continue
+              printf -- '---\n\n'
+              cat "${comment}"
+              printf '\n'
+            done
+          } >scan-output/check-summary.md
+          # Hard-cap to GitHub's check-run summary limit (65535 chars).
+          if [ "$(wc -c <scan-output/check-summary.md)" -gt 65000 ]; then
+            head -c 64500 scan-output/check-summary.md >scan-output/check-summary.trim
+            printf '\n\n_… output truncated; see PR comment(s) for the full report._\n' \
+              >>scan-output/check-summary.trim
+            mv scan-output/check-summary.trim scan-output/check-summary.md
+          fi
 
           if [[ "${overall_gate_ok}" -eq 0 ]]; then
             printf '\none or more plugins failed the severity gate.\n'


### PR DESCRIPTION
## Summary

Closes #391. The Skill Security Audit check-run summary previously carried only a per-plugin tally (e.g. `❌ build — high (120 finding(s))`), forcing PR authors to re-run the scanner locally to know which file or rule fired. The scanner already emits `file_path`, `line_number`, `snippet`, and `category` per finding — `evaluate-findings.py` was stripping them as part of the LLM-redaction stage.

This PR moves the redaction boundary from "the file" to "the LLM prompt": the persisted `risk-summary.json` now carries full per-finding detail, while the prompt sample sent to Anthropic is reduced to `LLM_SAFE_FIELDS` (`rule_id`, `severity`, `analyzer`, `description`, `category`). The injection contract is preserved.

- `evaluate-findings.py` — pass `id`/`category`/`title`/`file_path`/`line_number`/`snippet`/`skill_name` through to `risk-summary.json`; redact only at the LLM call site; add `severity_counts` (incl. INFO) and `category_counts` to the summary.
- `write-comment.py` — render severity + category breakdown tables; expand the findings table with `Location` and `Excerpt` columns; pipe-escape and length-cap excerpts.
- `skill-audit-report.yml` — embed the rendered audit comment(s) into `check-summary.md` so the PR-page check view shows the table, with a 65k-char hard cap for the GitHub Checks API.

## Verification

End-to-end smoke test against the actual PR #382 artifact (120 findings):

- LLM prompt confirmed clean: no `file_path`, `snippet`, or `skill_name` substrings.
- Rendered comment: 35.7k chars (well under both the GH comment and check-summary 65k limits).
- Severity counts reconcile: 5 CRITICAL + 12 HIGH + 28 MEDIUM + 48 LOW + 27 INFO = 120.
- 8 categories surfaced (skill_discovery_abuse=33, command_injection=29, policy_violation=27, …).
- 118/120 findings carry `file_path`; 93/120 carry `snippet`; 37/120 carry `line_number` (LLM analyzer often omits line).

## Deferred to follow-ups

- **Step 5 — inline GitHub Checks-API annotations on the diff.** Worth doing, but only ~31% of findings carry a `line_number`, so most would still render only in the table. Better as a focused follow-up that thinks about path-joining and the `null line` fallback.
- **Step 7 — net-new vs. inherited delta marker.** Needs a base-branch scan or a changed-files heuristic. Bigger design call; separate issue.

## Test plan

- [ ] CI runs `Skill Security Audit Scan` + `Skill Security Audit Report` on this PR
- [ ] Confirm the PR comment renders Severity / Category / Findings tables with Location + Excerpt columns
- [ ] Confirm the `Skill Security Audit Report` check-run summary on the PR page contains the rendered tables (not just the one-line tally)
- [ ] Confirm gate behavior unchanged (this PR should pass — only `.github/scripts/` and `.github/workflows/` changed; no `plugins/**` paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)