### PR TITLE
feat(build): help-skill primitive pair

### DIFF
--- a/.briefs/help-skill.brief.md
+++ b/.briefs/help-skill.brief.md
@@ -1,0 +1,98 @@
+---
+name: help-skill build brief
+description: Intent and scope for the build of the help-skill primitive pair (build-help-skill / check-help-skill)
+type: brief
+related:
+  - https://github.com/bcbeidel/toolkit/issues/378
+  - plugins/build/_shared/references/primitive-routing.md
+  - plugins/build/_shared/references/skill-best-practices.md
+  - plugins/build/_shared/references/readme-best-practices.md
+---
+
+## User ask (verbatim)
+
+> Per-plugin help skill primitive — scaffold via new build-help-skill /
+> check-help-skill pair. Give each toolkit plugin a `help` skill that orients
+> a caller (agent or human) to what's in the plugin and how the skills compose
+> — like `--help` for a CLI. Reachable as `/<plugin>:help` and as
+> auto-triggered context when an agent asks "what's in this plugin / which
+> skill fits". Build it as a primitive pair under `plugins/build/`, scaffolded
+> via the existing `/build:build-skill-pair` meta-skill, so the four plugin
+> instances stay consistent and auditable.
+
+(Source: GitHub issue #378, edited 2026-05-02 to use precise primitive names
+`build-help-skill` / `check-help-skill`.)
+
+## So-what
+
+Toolkit ships four plugins (`build`, `wiki`, `work`, `consider`) totalling 25+
+skills. An agent or human entering one of those plugins cold has no in-plugin
+landing page — they must grep `AGENTS.md`, scan `plugins/<x>/skills/`, or guess
+which skill description matches their task. The Reddit `task-router` pattern
+(global router skill + `UserPromptSubmit` hook reminding Claude to consult it)
+solves the *post-compaction* version of this drift but at ~500 tokens/prompt
+forever, with a hand-curated table that drifts from disk. A per-plugin
+`help` skill is the *pull* alternative: on-demand (no token tax), scoped
+(one description to triage, not 25), generated from disk (no drift), and
+doubles as human UX (`/<plugin>:help` is a readable index). The pair codifies
+the shape so all four plugin instances stay consistent and so future plugins
+inherit the convention without re-inventing it.
+
+## Scope boundaries
+
+- **In:** A primitive-pair (`build-help-skill` + `check-help-skill`) under
+  `plugins/build/`, sharing one distilled principles doc; produces a SKILL.md
+  at `plugins/<plugin>/skills/help/SKILL.md` with a synopsis, disk-derived
+  skill index, curated workflow chains, and entry-point pointers; auditor
+  enforces coverage / freshness / fidelity (Tier-1) plus workflow curation,
+  triage actionability, dual audience, scope discipline, and trigger quality
+  (Tier-2).
+- **Out:** A `UserPromptSubmit` hook that force-injects help every prompt
+  (separate issue if drift proves real). A *global* router skill spanning
+  plugins (per-plugin scoping is intentional; cross-plugin discovery lives
+  in `AGENTS.md`). Auto-generating common-workflow chains (judgment, keep
+  curated). Generating the four plugin `help` skills themselves (those
+  follow this pair via `/build:build-help-skill` runs — separate work).
+
+## Planned artifacts
+
+- [x] `plugins/build/_shared/references/help-skill-best-practices.md`
+- [x] `plugins/build/skills/build-help-skill/SKILL.md`
+- [x] `plugins/build/skills/check-help-skill/SKILL.md`
+- [x] `plugins/build/skills/check-help-skill/references/audit-dimensions.md`
+- [x] `plugins/build/skills/check-help-skill/references/repair-playbook.md`
+- [x] `plugins/build/_shared/references/primitive-routing.md` — append
+      paragraph + Routing Test branch + route lines
+
+## Planned handoffs
+
+- [x] `/build:check-skill-pair help-skill` — pair-level integrity audit
+      (clean after dropping `(WARN)` from playbook signal heading)
+- [x] `/build:check-skill plugins/build/skills/build-help-skill/SKILL.md`
+      (clean after fenced-block fix + D9 partition fix)
+- [x] `/build:check-skill plugins/build/skills/check-help-skill/SKILL.md`
+      (clean after fenced-block fix + D9 partition fix)
+- [x] `/build:build-python-script` — produced
+      `plugins/build/skills/build-help-skill/scripts/render_skill_table.py`
+      (renders skill-index table from sibling frontmatter, stdlib-only)
+- [x] `/build:check-python-script` (both scripts) — clean after
+      `ruff format`; all 9 Tier-2 dimensions PASS; one INFO-level
+      cross-entity duplication noted (acceptable per AGENTS.md
+      "build scripts have no Python package")
+- [x] `/build:build-python-script` (second invocation) — produced
+      `plugins/build/skills/check-help-skill/scripts/check_help_skill.py`
+      (~280 LOC; runs 19 Tier-1 deterministic checks, lint format,
+      stdlib-only)
+
+## Decisions log
+
+- 2026-05-02 — primitive name finalized as `help-skill` (not `help`); chosen
+  for parallelism with `build-readme` / `build-makefile` (named after artifact,
+  not verb-object) and to avoid collision with the generic concept of "help".
+- 2026-05-02 — routing-doc placement: **new top-level primitive class** under
+  *What Each Primitive Was Designed For*. Rationale: a help-skill is a
+  distinct artifact-typed sub-class of SKILL.md (like README is a sub-class
+  of "markdown at repo root"), with its own scope concerns (orientation,
+  triage, dual audience) that don't reduce to "a skill with these conventions."
+  Treating it as a variant of `skill` would underweight what makes it
+  distinct.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ Before filing new content or loading context beyond a skill's eager
 
 | Plugin | Path | Skills |
 |--------|------|--------|
-| `build` | `plugins/build/` | `build-skill`, `build-skill-pair`, `build-rule`, `build-hook`, `build-subagent`, `build-bash-script`, `build-python-script`, `build-makefile`, `build-pre-commit-config`, `build-github-workflow`, `build-readme`, `build-resolver`, `refine-prompt`, `check-skill`, `check-skill-pair`, `check-rule`, `check-hook`, `check-subagent`, `check-bash-script`, `check-python-script`, `check-makefile`, `check-pre-commit-config`, `check-github-workflow`, `check-readme`, `check-resolver`, `check-skill-chain` |
+| `build` | `plugins/build/` | `build-skill`, `build-skill-pair`, `build-help-skill`, `build-rule`, `build-hook`, `build-subagent`, `build-bash-script`, `build-python-script`, `build-makefile`, `build-pre-commit-config`, `build-github-workflow`, `build-readme`, `build-resolver`, `refine-prompt`, `check-skill`, `check-skill-pair`, `check-help-skill`, `check-rule`, `check-hook`, `check-subagent`, `check-bash-script`, `check-python-script`, `check-makefile`, `check-pre-commit-config`, `check-github-workflow`, `check-readme`, `check-resolver`, `check-skill-chain` |
 | `wiki` | `plugins/wiki/` | `setup`, `research`, `ingest`, `lint` |
 | `work` | `plugins/work/` | `scope-work`, `plan-work`, `start-work`, `verify-work`, `finish-work` |
 | `consider` | `plugins/consider/` | 16 mental models + meta |

--- a/plugins/build/.claude-plugin/plugin.json
+++ b/plugins/build/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "build",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Skills for creating and refining Claude Code skills, rules, hooks, and subagents.",
   "author": {
     "name": "Brandon Beidel"

--- a/plugins/build/_shared/references/help-skill-best-practices.md
+++ b/plugins/build/_shared/references/help-skill-best-practices.md
@@ -1,0 +1,227 @@
+---
+name: Help-Skill Best Practices
+description: Authoring guide for help-skills — a SKILL.md at plugins/<plugin>/skills/help/ that orients agents and humans to a plugin's contents, reachable as /<plugin>:help and as auto-triggered context. Covers what a help-skill is for, the canonical anatomy, patterns that keep the index honest, anti-patterns that fail dual audience, and the safety posture. Referenced by build-help-skill and check-help-skill.
+---
+
+# Help-Skill Best Practices
+
+## What a Good Help-Skill Does
+
+A help-skill is the **front door of a plugin** — the markdown a caller
+loads when they want to know what a plugin contains and which of its
+skills fits the task in hand. It is not a generic skill; it is a
+specialized SKILL.md whose subject is *the plugin itself*. Two
+audiences read it: a human typing `/<plugin>:help` who wants a readable
+index, and an agent that has matched the trigger "what's in this
+plugin / which skill fits" and needs triage scaffolding to route into
+the right sibling skill.
+
+A help-skill earns its place when a plugin contains enough skills that
+discovery by grep or by skimming `<plugin>/skills/` is slow, and the
+skill descriptions alone don't communicate *how the skills compose*.
+Five or more sibling skills is the rough threshold; below that, the
+caller can read the directory directly. A help-skill is the *pull*
+alternative to a `UserPromptSubmit` hook that injects a global routing
+table on every prompt — on-demand, no token tax, scoped to one plugin,
+generated from disk so the index can't drift.
+
+A help-skill is not a top-level repository README (that is for a
+stranger arriving from a search result; the help-skill caller has
+already chosen the plugin), not a CLI tool's `--help` output (it is
+markdown for an LLM, not text for a terminal), not a global
+cross-plugin router (per-plugin scoping is intentional), and not a
+substitute for `AGENTS.md` (which carries cross-plugin context).
+
+## Anatomy
+
+```markdown
+---
+name: help                          ← always literal "help" — directory and slug
+description: Use when the caller asks "what's in the <plugin> plugin",
+  "list <plugin> skills", "how do I use <plugin>", or wants to see
+  which <plugin> skill fits a task.
+version: 1.0.0
+owner: <plugin>-plugin
+license: MIT
+references:
+  - ../../_shared/references/help-skill-best-practices.md
+---
+
+# /<plugin>:help
+
+One-sentence synopsis of what the plugin does.
+
+## Skills in this plugin
+
+<!-- generated: do not edit by hand; regenerate from disk -->
+| Skill | Triggers on |
+|---|---|
+| `<sibling-1>` | <description first ~12 words> |
+| `<sibling-2>` | <description first ~12 words> |
+<!-- /generated -->
+
+## Common workflows
+
+- **<Workflow name>** — `<skill-a>` → `<skill-b>` → `<skill-c>`.
+  <One sentence: when this chain applies.>
+
+## Where to look next
+
+- [AGENTS.md](../../../../AGENTS.md) — cross-plugin context
+- [RESOLVER.md](../../../../RESOLVER.md) — filing and context routing
+- [`<plugin>/README.md`](../../README.md) — plugin install / contributing
+```
+
+Load-bearing pieces: the literal `name: help` (the slug is fixed —
+Claude Code's `/<plugin>:<slug>` invocation depends on it); the
+description tuned to "what's in the plugin" / "list skills" / "how do I
+use it" triggers; a one-sentence plugin synopsis; a disk-derived skill
+table inside a generated-region marker; one or more curated workflow
+chains; pointers to `AGENTS.md`, `RESOLVER.md`, and the plugin README.
+
+## Patterns That Work
+
+**Generate the skill table from sibling frontmatter.** The table is
+the most-read part of the document and the most likely to drift. A
+small generator that walks `<plugin>/skills/*/SKILL.md`, reads each
+`name` and `description`, and emits the table inside a managed region
+makes drift structurally impossible. Hand-editing the table inside the
+managed region is the failure mode the marker exists to flag.
+
+**Use `name: help` literally — the slug is fixed.** Claude Code
+resolves `/<plugin>:help` by looking for a skill named `help` inside
+the plugin's `skills/` directory. Renaming the slug breaks the
+discoverable invocation. The directory basename, the frontmatter
+`name`, and the slash-command suffix all carry the same string.
+
+**Lead the description with the caller's situation, not the skill's
+function.** *"Use when the caller asks 'what's in the build plugin' or
+'list build skills'"* retrieves; *"Surfaces an index of plugin skills"*
+does not. The router reads the description; the description must read
+like a trigger condition.
+
+**One-sentence synopsis below the H1 is the most-read line.** It
+answers *what does this plugin do* in one breath. Same role as a
+README's one-sentence description — but scoped to the plugin, not the
+project.
+
+**Curate workflow chains; do not auto-generate them.** A workflow
+chain like `scope-work → plan-work → start-work → verify-work` carries
+judgment about how skills compose. That judgment cannot be derived
+from frontmatter. List two or three chains the plugin's authors
+actually expect callers to follow; resist the urge to enumerate every
+permutation.
+
+**Trigger description must not collide with sibling-skill triggers.**
+The help-skill fires on "what's in this plugin / list skills / how do
+I use it" — meta-questions about the plugin. If its description
+overlaps with a sibling skill's description (e.g., both fire on "build
+a skill"), the router picks one arbitrarily and the caller gets the
+wrong skill half the time. The help-skill description must read
+unambiguously as *a question about the plugin*, not *a task the plugin
+performs*.
+
+**Keep the body short.** Under 150 lines is the target — a help-skill
+is an index, not documentation. If the curated workflows or the
+"where to look next" section grow past a screen, the content belongs
+in `AGENTS.md` or a docs site, not in the help-skill.
+
+**Pointers, not duplications.** The "where to look next" section links
+to `AGENTS.md`, `RESOLVER.md`, and the plugin README. It does not
+duplicate their content. Two copies drift; one canonical source plus a
+link does not.
+
+**Relative paths, parents-up to repo root.** From
+`plugins/<plugin>/skills/help/SKILL.md`, the repo root is four
+directories up. Use `../../../../AGENTS.md`, `../../../../RESOLVER.md`,
+and `../../README.md` for the plugin README. Absolute paths break
+under fork or relocation; relative paths survive.
+
+## Anti-Patterns
+
+**Hand-curated skill table.** A table that lives inside the help-skill
+as authored prose drifts the moment a sibling skill is added,
+removed, or renamed. The next caller sees an incorrect index and
+either follows it (and lands on a missing skill) or ignores it (and
+the help-skill provides no value). Use a generated region; never
+hand-edit between the markers.
+
+**Description that fires on the plugin's own workflows.** A
+help-skill whose description says *"Use when the user wants to build,
+check, or audit a skill"* (in the `build` plugin) competes with every
+sibling skill in the same plugin. The router has no way to choose
+correctly and the help-skill effectively replaces routing with chaos.
+
+**Architectural prose in the help-skill body.** Sections explaining
+"why this plugin exists", "design philosophy", or "how plugins
+compose" belong in `AGENTS.md` or a project-level design doc. The
+help-skill is an index; long-form rationale dilutes the orientation.
+
+**Workflow chains that include skills not in this plugin.** Cross-
+plugin chains (e.g., `scope-work` → `build-skill` spanning `work` and
+`build`) belong in `AGENTS.md`'s plugin-composition section, not in a
+single plugin's help-skill. The per-plugin scoping is what keeps the
+help-skill bounded.
+
+**Skipping the synopsis.** A help-skill that opens with "## Skills in
+this plugin" with no one-sentence synopsis above it skips the
+most-read line. The caller reads the H1 and then needs to translate
+"how does this plugin's skill set add up to a value proposition?"
+themselves — exactly the question the synopsis exists to answer.
+
+**Slug other than `help`.** Renaming to `index`, `overview`, `menu`,
+or `<plugin>-help` defeats `/<plugin>:help` as a discoverable
+invocation. Callers and `AGENTS.md`'s "Plugin Structure" table both
+key on the literal slug.
+
+**Including the help-skill in its own table.** The generator must
+exclude `help` from the rendered table — listing the help-skill in its
+own index is recursive, useless, and confuses callers about whether
+to invoke the help-skill from itself.
+
+**Embedded executable content.** Help-skills are pure orientation
+markdown; they do not need scripts or destructive commands. A
+help-skill with `## Steps` running `rm` or `curl` is the wrong
+primitive — that's a workflow skill misnamed as help.
+
+## Safety & Maintenance
+
+A help-skill is version-controlled, auto-loaded, and trusted by Claude
+as instructions — same trust posture as any other SKILL.md. The
+blast-radius surface is smaller (no destructive operations) but the
+information-leak surface is the same.
+
+- **No embedded secrets, internal hostnames, or credentials** —
+  audited deterministically, same rule as every SKILL.md.
+- **No instructions to disable security posture** — TLS, SELinux,
+  firewall.
+- **No `curl … | bash` invitations** — help-skills should not be
+  pointing callers at supply-chain installers; if a workflow needs an
+  installer, that workflow's own skill is where it lives.
+
+**Maintenance posture.** The skill-table managed region must
+regenerate every time a sibling skill is added, removed, or has its
+description changed. The generator is the contract; manual edits are
+a bug. Curated workflow chains do *not* auto-update — they are
+human-maintained judgment, and a sibling skill added without
+revisiting them produces a stale chain. Plugin maintainers re-read
+the workflows section on every plugin version bump and confirm it
+still reflects how skills are expected to compose.
+
+When a sibling skill is removed, the generator re-emits the table
+without it — but a curated workflow chain that referenced the removed
+skill becomes a broken pointer. Tier-1 freshness checks catch this:
+every skill name in `## Common workflows` must resolve to a sibling
+SKILL.md on disk.
+
+---
+
+**Diagnostic when a help-skill underperforms.** Not invoked when a
+caller asks "what's in this plugin"? The description is capability-
+shaped instead of trigger-shaped — rewrite leading with "Use when the
+caller asks…". Invoked but caller still picks the wrong sibling
+skill? The triage scaffolding is too sparse — add a "common
+workflows" entry that names the skill chain for the caller's task.
+Skill table out of date? The managed region was hand-edited or the
+generator wasn't re-run — re-run the generator and audit for manual
+edits inside the markers.

--- a/plugins/build/_shared/references/primitive-routing.md
+++ b/plugins/build/_shared/references/primitive-routing.md
@@ -56,6 +56,8 @@ Route: `/build:build-subagent` scaffolds a `.claude/agents/<name>.md` definition
 
 **Resolvers** exist for repos whose dynamic context — where to file new content and which docs to load before recurring tasks — has outgrown AGENTS.md alone. A resolver is a root-level `RESOLVER.md` with two machine-managed tables (filing and context) plus a one-line AGENTS.md pointer and a `.resolver/evals.yml` sidecar; the managed region regenerates from disk conventions, and evals prove the routing. Not a skill-dispatch resolver (that's handled by the `description` field on each SKILL.md), not a shared-reference linter (that's authoring-time hygiene, a separate concern). Route: `/build:build-resolver` to scaffold or regenerate the three artifacts; `/build:check-resolver` to audit the pointer, managed region, path resolution, filing coverage, context actionability, eval representativeness, dark capabilities, and staleness against the rubric in [resolver-best-practices.md](resolver-best-practices.md).
 
+**Help-skills** exist as a per-plugin orientation surface — the SKILL.md a caller loads when they ask "what's in this plugin / which skill fits". A help-skill is a specialized SKILL.md whose subject is the plugin itself: a one-sentence synopsis, a disk-derived index of sibling skills inside a managed region, two or three curated workflow chains showing how skills compose, and pointers to AGENTS.md / RESOLVER.md / the plugin README. Reachable as `/<plugin>:help` and as auto-triggered context when an agent matches the meta-trigger. It is the *pull* alternative to a `UserPromptSubmit` hook that injects a global routing table on every prompt — on-demand, no token tax, scoped to one plugin, drift-resistant by construction. Not a generic SKILL.md (route to `/build:build-skill`), not a top-level repo README (route to `/build:build-readme`), not a global cross-plugin router (per-plugin scoping is intentional). Route: `/build:build-help-skill <plugin>` to scaffold a help-skill for a plugin; `/build:check-help-skill <path>` to audit one against coverage, freshness, frontmatter fidelity, plus five judgment dimensions and a cross-entity trigger-collision check, per the rubric in [help-skill-best-practices.md](help-skill-best-practices.md).
+
 ## Routing Test
 
 Two questions route most decisions:
@@ -71,6 +73,7 @@ If neither resolves it:
 - The artifact is a project's top-level `README.md` → **README**
 - YAML file under `.github/workflows/` that fires on repository events → **GitHub Actions workflow**
 - Root-level routing table for filing new content and loading context doc bundles → **Resolver**
+- Per-plugin orientation surface listing sibling skills and curated workflows → **Help-skill**
 
 ## When You've Chosen the Wrong Primitive
 

--- a/plugins/build/pyproject.toml
+++ b/plugins/build/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "check"
-version = "0.19.0"
+version = "0.20.0"
 description = "Claude Code plugin for auditing Claude Code skills and rules for quality issues."
 requires-python = ">=3.9"
 dependencies = []

--- a/plugins/build/skills/build-help-skill/SKILL.md
+++ b/plugins/build/skills/build-help-skill/SKILL.md
@@ -1,0 +1,300 @@
+---
+name: build-help-skill
+description: >-
+  Use when the user wants to "create a help skill", "scaffold a help
+  skill for the X plugin", "add a /<plugin>:help command", "build a
+  plugin index skill", or wants to give a plugin an orientation
+  surface that lists its skills and common workflows. Produces a
+  SKILL.md at plugins/<plugin>/skills/help/SKILL.md.
+argument-hint: "[plugin name]"
+user-invocable: true
+version: 1.0.0
+owner: build-plugin
+license: MIT
+references:
+  - ../../_shared/references/help-skill-best-practices.md
+  - ../../_shared/references/primitive-routing.md
+  - ../../_shared/references/skill-best-practices.md
+  - scripts/render_skill_table.py
+---
+
+# /build:build-help-skill
+
+Scaffold a `help` skill for a Claude Code plugin — the SKILL.md a
+caller loads when they ask "what's in this plugin / which skill
+fits". A help-skill is a specialized SKILL.md whose subject is the
+plugin itself: a one-sentence synopsis, a disk-derived index of
+sibling skills, two or three curated workflow chains, and pointers
+to `AGENTS.md` / `RESOLVER.md` / the plugin README.
+
+Authoring principles — what makes a help-skill load-bearing, the
+canonical anatomy, the patterns that keep the index honest — live in
+[help-skill-best-practices.md](../../_shared/references/help-skill-best-practices.md).
+This skill is the workflow; the principles doc is the rubric.
+
+## When to use
+
+- The user says "create/build/scaffold a help skill" or "add a
+  `/<plugin>:help` command"
+- A plugin has grown to 5+ sibling skills and discovery by grep is
+  slow
+- The user wants a plugin to have an orientation surface that lists
+  its skills and shows how they compose
+- The user passes a plugin name (e.g., `build`, `wiki`, `work`) and
+  wants its help-skill scaffolded
+
+## Prerequisites
+
+- Working directory is a toolkit checkout (or a repo with the same
+  `plugins/<plugin>/skills/<name>/SKILL.md` shape)
+- Write access to `plugins/<plugin>/skills/help/`
+- The target plugin already exists at `plugins/<plugin>/` with at
+  least 2 sibling skills (a help-skill for a plugin with one skill
+  is more cost than benefit)
+- `/build:check-help-skill` available for the post-write audit step
+
+## Steps
+
+1. **Verify the primitive.** Confirm the user wants a *help-skill* —
+   a plugin-orientation SKILL.md — and not a generic skill (route to
+   `/build:build-skill`), a top-level README (route to
+   `/build:build-readme`), or a global router skill (out of scope —
+   per-plugin scoping is intentional). Full decision matrix in
+   [primitive-routing.md](../../_shared/references/primitive-routing.md).
+
+2. **Resolve the plugin.** Read `$ARGUMENTS`. If it names a plugin
+   (e.g., `build`, `wiki`, `work`, `consider`), confirm
+   `plugins/<plugin>/.claude-plugin/plugin.json` exists. If empty or
+   ambiguous, list the plugins in `plugins/` and ask which one. If
+   the named plugin does not exist, stop — do not scaffold a help-
+   skill for a plugin that hasn't been created.
+
+3. **Scope-gate.**
+   - **Existing help-skill.** If `plugins/<plugin>/skills/help/`
+     already exists, stop. Offer to revise the existing help-skill
+     instead — run `/build:check-help-skill` and iterate from
+     findings.
+   - **Plugin too small.** If the plugin has fewer than 2 sibling
+     skills, surface the threshold and ask the user to confirm. A
+     help-skill for a one-skill plugin is overhead with no payoff.
+   - **Slug collision.** If a sibling skill is already named `help`
+     anywhere in the plugin, stop — the slug is fixed and a
+     collision is a configuration error to resolve before
+     scaffolding.
+
+4. **Elicit the synopsis and workflows.** Ask, one question at a
+   time, three things:
+   - **Synopsis** — one sentence answering "what does this plugin
+     do" (e.g., for `work`: *"Plan, execute, and verify multi-step
+     coding work."*).
+   - **Common workflows** — two to three curated chains of skill
+     composition. Each chain is a bulleted entry: workflow name →
+     `skill-a` → `skill-b` → `skill-c`, plus one sentence on when
+     the chain applies. Pre-fill suggestions by reading sibling
+     skill descriptions and proposing chains the user can accept,
+     edit, or reject. Do not auto-generate without confirmation —
+     workflow curation is judgment.
+   - **Where-to-look-next pointers** — confirm the three default
+     pointers (`AGENTS.md`, `RESOLVER.md`, plugin `README.md`) and
+     ask if any plugin-specific docs (e.g., a design doc, a
+     research note) belong there too.
+
+5. **Read sibling skills via the renderer script.** Run
+   `scripts/render_skill_table.py <plugin> --format json` to parse
+   each sibling SKILL.md's frontmatter (name + description) into a
+   structured list. The script excludes `help` and `_shared/`
+   automatically. The LLM reasons over the script's JSON output, not
+   raw SKILL.md files — this is the deterministic substrate that
+   the rest of the workflow composes against. The same script
+   renders the markdown table in Step 7.
+
+6. **Pick the trigger discipline.** Draft the description with the
+   help-skill's distinguishing trigger shape: *"Use when the caller
+   asks 'what's in the `<plugin>` plugin', 'list `<plugin>` skills',
+   'how do I use `<plugin>`', or wants to see which `<plugin>` skill
+   fits a task."* Then check it against every sibling skill's
+   description for trigger collision. If any sibling fires on
+   "what's in this plugin" or "list skills" — flag the collision,
+   show both descriptions, and ask the user which to narrow. The
+   router cannot disambiguate two skills that match the same trigger.
+
+7. **Draft the SKILL.md.** Follow the anatomy in
+   [help-skill-best-practices.md](../../_shared/references/help-skill-best-practices.md).
+   Required frontmatter: `name: help` (literal — the slug is fixed),
+   `description` (from Step 6), `version: 1.0.0`, `owner:
+   <plugin>-plugin`, `license: MIT`, `references:` pointing at
+   `../../_shared/references/help-skill-best-practices.md`. Required
+   body: H1 `# /<plugin>:help`, the one-sentence synopsis from Step 4,
+   a `## Skills in this plugin` section wrapping a managed-region
+   marker pair (`<!-- generated: do not edit by hand; regenerate
+   from disk -->` and `<!-- /generated -->`) around the table
+   produced by `scripts/render_skill_table.py <plugin>` (re-run for
+   the markdown form), a `## Common workflows` section with the
+   curated chains from Step 4, and a `## Where to look next`
+   section with the pointers from Step 4. Body length under 150
+   lines.
+
+8. **Present for approval.** Before writing, narrate the design
+   choices in 3–6 bullets. Cover the synopsis (and why it differs
+   from `AGENTS.md`'s framing of the plugin), the trigger-collision
+   check from Step 6 (which sibling descriptions were closest, and
+   how the help-skill description was differentiated), the curated
+   workflows (which chains were chosen and why), and any pointers
+   beyond the three defaults. The reader should be able to disagree
+   with any choice. Iterate on feedback. Hold the write until the
+   user approves.
+
+9. **Write.** Create
+   `plugins/<plugin>/skills/help/` if it doesn't exist. Write
+   `SKILL.md` to that directory. Then invoke
+   `/build:check-help-skill` on the newly written file — surface any
+   findings and offer the repair loop before moving on.
+
+10. **Update plugin manifest.** If
+    `plugins/<plugin>/.claude-plugin/plugin.json` enumerates skills
+    (some plugins do, some don't), add `help` to the list. If the
+    plugin's `AGENTS.md` table or top-level `AGENTS.md` "Plugin
+    Structure" table lists skills per plugin, add `help` there too.
+    Surface the diff before writing — table edits are easy to get
+    wrong.
+
+## Failure modes
+
+- **Plugin does not exist.** Step 2 stops the workflow. Recovery:
+  ask the user to scaffold the plugin first, or to pick a different
+  plugin.
+- **Trigger collision with a sibling skill.** Step 6 surfaces the
+  collision. Recovery: narrow either the help-skill description or
+  the sibling description before drafting; do not write a help-
+  skill that will fight its own siblings for routing.
+- **Existing help-skill at scope.** Step 3 stops the workflow.
+  Recovery: offer to revise the existing help-skill via
+  `/build:check-help-skill` and the repair loop, not to scaffold
+  over it.
+- **User declines the draft at the approval gate.** Expected.
+  Recovery: capture the specific objection, revise the draft, and
+  re-present.
+- **`check-help-skill` findings block the write.** After Step 9, if
+  `/build:check-help-skill` surfaces FAIL findings, apply the
+  canonical repair from `repair-playbook.md` and re-audit until
+  only WARNs remain (or until the user explicitly accepts a FAIL).
+
+## Examples
+
+<example>
+Invocation:
+
+```bash
+/build:build-help-skill work
+```
+
+Step 1 — Primitive confirmed (plugin orientation surface).
+
+Step 2 — Plugin resolves to `plugins/work/`. Confirmed via
+`plugin.json`.
+
+Step 3 — No existing `plugins/work/skills/help/`. Plugin has 5
+sibling skills (above the 2-skill threshold). No `help` slug
+collision.
+
+Step 4 — Elicits:
+- Synopsis: *"Plan, execute, and verify multi-step coding work."*
+- Workflows:
+  - **Build new feature** — `scope-work` → `plan-work` →
+    `start-work` → `verify-work`. *Use when starting from
+    requirements; produces a design doc, plan, and validated code.*
+  - **Fix a bug** — `scope-work` → `start-work` → `verify-work`.
+    *Use when the bug is well-understood and a full plan is
+    overkill; skips planning to keep the loop tight.*
+- Pointers: defaults plus `plugins/work/CONTRIBUTING.md`.
+
+Step 5 — Reads 5 sibling SKILL.mds; extracts name + description for
+each.
+
+Step 6 — Trigger description drafted: *"Use when the caller asks
+'what's in the work plugin', 'list work skills', 'how do I use
+work', or wants to see which work skill fits a task."* Cross-checked
+against siblings — no collision (siblings fire on "scope/plan/start/
+verify work", not on meta-questions about the plugin).
+
+Step 7 — Drafts SKILL.md with the managed-region table built from
+sibling frontmatter.
+
+Step 8 — Narrates the synopsis choice (concise, action-oriented; not
+a duplicate of AGENTS.md's framing), the trigger differentiation,
+the workflow curation. User approves.
+
+Step 9 — Writes `plugins/work/skills/help/SKILL.md`. Invokes
+`/build:check-help-skill plugins/work/skills/help/SKILL.md` — 0
+findings.
+
+Step 10 — Updates `plugins/work/.claude-plugin/plugin.json` and the
+top-level `AGENTS.md` "Plugin Structure" table to list `help`.
+Surfaces both diffs before writing.
+</example>
+
+## Key Instructions
+
+- Use the literal slug `help` — directory `help/`, frontmatter `name:
+  help`, slash command `/<plugin>:help`. The slug is not negotiable;
+  Claude Code's invocation depends on it.
+- Generate the skill-index table from sibling SKILL.md frontmatter,
+  inside a managed region. Hand-curated tables drift; the
+  managed-region marker is what `check-help-skill` audits for hand
+  edits.
+- Curate workflow chains — do not auto-generate. The chains carry
+  judgment about how skills compose; the user must confirm each one.
+- Run the trigger-collision check (Step 6) before drafting. A
+  help-skill that fights its siblings for routing is worse than no
+  help-skill at all.
+- Hold the write until the user approves the draft (Step 8 gate).
+- After writing, run `/build:check-help-skill` — this skill must
+  produce help-skills that pass the deterministic checks.
+
+## Anti-Pattern Guards
+
+1. **Hand-curated skill table.** A table without managed-region
+   markers, or content edited inside the markers, drifts on every
+   sibling change. Principle: *Generate the skill table from sibling
+   frontmatter.*
+2. **Slug other than `help`.** `index`, `overview`, `menu`, or
+   `<plugin>-help` all break `/<plugin>:help` as a discoverable
+   invocation. Principle: *Use `name: help` literally — the slug is
+   fixed.*
+3. **Capability-shaped description.** "Surfaces an index of plugin
+   skills" does not retrieve. Lead with "Use when the caller
+   asks…". Principle: *Lead the description with the caller's
+   situation.*
+4. **Trigger collision with sibling skills.** The Step 6 check
+   exists for this — running it after the draft is too late.
+   Principle: *Trigger description must not collide with sibling-
+   skill triggers.*
+5. **Architectural prose in the body.** Long-form rationale belongs
+   in `AGENTS.md`. Principle: *Pointers, not duplications.*
+6. **Cross-plugin workflow chains.** Chains spanning two plugins
+   belong in `AGENTS.md`. Principle: *Workflow chains scoped to
+   this plugin only.*
+7. **Listing the help-skill in its own table.** Recursive and
+   useless. The generator must exclude `name == "help"`.
+8. **Writing before approval.** Always present the draft and narrate
+   choices first; the user must explicitly approve before SKILL.md
+   is written.
+9. **Inlining a chained skill instead of invoking it.** MUST invoke
+   `/build:check-help-skill` via the Skill tool after the write.
+   MUST NOT read its SKILL.md and inline a partial audit. The
+   shortcut bypasses the chained skill's rubric and leaves no audit
+   trail that the proper skill was used.
+
+## Handoff
+
+**Receives:** Plugin name (resolves to `plugins/<plugin>/`), or no
+argument (prompts for intake).
+
+**Produces:** `plugins/<plugin>/skills/help/SKILL.md`, plus optional
+edits to `plugin.json` and the top-level `AGENTS.md` plugin table.
+
+**Chainable to:** `/build:check-help-skill <path>` (audits the
+just-built help-skill against the rubric — coverage, freshness,
+fidelity, trigger quality, dual audience, scope discipline);
+`/build:check-skill <path>` (catches generic SKILL.md structural
+issues this skill's draft step missed).

--- a/plugins/build/skills/build-help-skill/scripts/render_skill_table.py
+++ b/plugins/build/skills/build-help-skill/scripts/render_skill_table.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Render a help-skill's skill-index table from sibling SKILL.md frontmatter.
+
+Walks a plugin's skills/ directory, parses each sibling SKILL.md's YAML
+frontmatter (name + description), and emits either a markdown table
+suitable for embedding inside a help-skill's managed region, or a JSON
+list of {name, description, triggers} entries. The skill named ``help``
+is always excluded.
+
+Examples:
+    ./render_skill_table.py build
+    ./render_skill_table.py --skills-dir plugins/work/skills
+    ./render_skill_table.py work --format json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+EXIT_USAGE = 2
+EXIT_INTERRUPTED = 130
+TRIGGER_WORD_LIMIT = 12
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[3]
+PLUGINS_DIR = PLUGIN_ROOT.parent
+
+
+def get_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Render a help-skill's skill-index table from sibling SKILL.md frontmatter."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "plugin", nargs="?", help="Plugin name (resolves to plugins/<plugin>/skills/)."
+    )
+    parser.add_argument(
+        "--skills-dir",
+        type=Path,
+        help="Explicit skills directory; overrides positional plugin.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("markdown", "json"),
+        default="markdown",
+        help="Output format.",
+    )
+    parser.add_argument(
+        "--word-limit",
+        type=int,
+        default=TRIGGER_WORD_LIMIT,
+        help="Word cap for the triggers cell.",
+    )
+    return parser
+
+
+def resolve_skills_dir(args: argparse.Namespace) -> Path:
+    if args.skills_dir:
+        return args.skills_dir
+    if not args.plugin:
+        raise ValueError("either a plugin name or --skills-dir is required")
+    return PLUGINS_DIR / args.plugin / "skills"
+
+
+def parse_frontmatter(text: str) -> dict[str, str]:
+    """Parse a minimal subset of YAML frontmatter into a flat str->str dict.
+
+    Handles scalar lines (``name: foo``) and folded/literal block scalars
+    (``description: >-`` followed by indented continuation lines). Lists,
+    nested mappings, and quoted multi-line strings are out of scope —
+    unknown structures are skipped.
+    """
+    if not text.startswith("---\n"):
+        return {}
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return {}
+    body = text[4:end]
+    out: dict[str, str] = {}
+    lines = body.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        m = re.match(r"^([A-Za-z][A-Za-z0-9_-]*):\s*(.*)$", line)
+        if not m:
+            i += 1
+            continue
+        key, val = m.group(1), m.group(2).strip()
+        if val in (">-", ">", "|", "|-"):
+            chunks: list[str] = []
+            i += 1
+            while i < len(lines) and (
+                lines[i].startswith("  ") or not lines[i].strip()
+            ):
+                if lines[i].strip():
+                    chunks.append(lines[i].strip())
+                i += 1
+            out[key] = " ".join(chunks)
+            continue
+        out[key] = val.strip("\"'")
+        i += 1
+    return out
+
+
+def first_n_words(s: str, n: int) -> str:
+    words = s.split()
+    if len(words) <= n:
+        return s.strip()
+    return " ".join(words[:n]) + "…"
+
+
+def collect_siblings(skills_dir: Path, word_limit: int) -> list[dict[str, str]]:
+    if not skills_dir.is_dir():
+        raise FileNotFoundError(f"skills directory does not exist: {skills_dir}")
+    entries: list[dict[str, str]] = []
+    for child in sorted(skills_dir.iterdir()):
+        if not child.is_dir() or child.name.startswith("_") or child.name == "help":
+            continue
+        skill_md = child / "SKILL.md"
+        if not skill_md.is_file():
+            continue
+        fm = parse_frontmatter(skill_md.read_text(encoding="utf-8"))
+        name = fm.get("name", child.name)
+        description = fm.get("description", "")
+        entries.append(
+            {
+                "name": name,
+                "description": description,
+                "triggers": first_n_words(description, word_limit),
+            }
+        )
+    return entries
+
+
+def render_markdown(entries: list[dict[str, str]]) -> str:
+    lines = ["| Skill | Triggers on |", "|---|---|"]
+    for e in entries:
+        triggers = e["triggers"].replace("|", "\\|")
+        lines.append(f"| `{e['name']}` | {triggers} |")
+    return "\n".join(lines) + "\n"
+
+
+def render_json(entries: list[dict[str, str]]) -> str:
+    return json.dumps(entries, indent=2) + "\n"
+
+
+def run(args: argparse.Namespace) -> int:
+    skills_dir = resolve_skills_dir(args)
+    entries = collect_siblings(skills_dir, args.word_limit)
+    if args.format == "json":
+        sys.stdout.write(render_json(entries))
+    else:
+        sys.stdout.write(render_markdown(entries))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = get_parser().parse_args(argv)
+    try:
+        return run(args)
+    except KeyboardInterrupt:
+        return EXIT_INTERRUPTED
+    except (FileNotFoundError, ValueError) as err:
+        print(f"error: {err}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/build/skills/check-help-skill/SKILL.md
+++ b/plugins/build/skills/check-help-skill/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: check-help-skill
+description: >-
+  Use when the user wants to "audit a help skill", "check the
+  /<plugin>:help command", "review my plugin index", "verify my
+  help-skill is up to date", or "is the skill table in this help-skill
+  current". Audits a plugins/<plugin>/skills/help/SKILL.md against the
+  help-skill rubric — coverage, freshness, frontmatter fidelity, plus
+  five judgment dimensions.
+argument-hint: "[path to help-skill SKILL.md, or plugin name]"
+user-invocable: true
+version: 1.0.0
+owner: build-plugin
+license: MIT
+references:
+  - ../../_shared/references/help-skill-best-practices.md
+  - ../../_shared/references/skill-best-practices.md
+  - references/audit-dimensions.md
+  - references/repair-playbook.md
+  - scripts/check_help_skill.py
+---
+
+# /build:check-help-skill
+
+Audit a help-skill — the SKILL.md at
+`plugins/<plugin>/skills/help/SKILL.md` — against the rubric. The
+audit runs in three tiers: deterministic checks (skill-index
+coverage, freshness, frontmatter fidelity, line count, slug, secret
+patterns); judgment checks (workflow curation, triage scaffolding,
+dual audience, scope discipline, trigger quality); and a cross-
+entity check (trigger collision against sibling skills).
+
+The full check inventory lives in
+[audit-dimensions.md](references/audit-dimensions.md). Repair
+recipes live in [repair-playbook.md](references/repair-playbook.md).
+The principles audited come from
+[help-skill-best-practices.md](../../_shared/references/help-skill-best-practices.md).
+
+## When to use
+
+- The user says "audit / check / review / lint a help-skill"
+- The user passes a path to a help-skill SKILL.md or names a plugin
+  whose help-skill should be audited
+- After `/build:build-help-skill` writes a new help-skill (the build
+  step chains to this skill automatically)
+- A sibling skill in the plugin was added, removed, or renamed —
+  drift check
+- A plugin version bump — confirm the help-skill still reflects the
+  plugin's shape
+
+## Prerequisites
+
+- Working directory contains a checkout with the target plugin
+- Read access to `plugins/<plugin>/skills/help/SKILL.md` and to
+  every sibling `plugins/<plugin>/skills/*/SKILL.md`
+- `$ARGUMENTS` either names the help-skill path or names the plugin
+  (resolves to `plugins/<plugin>/skills/help/SKILL.md`)
+
+## Steps
+
+1. **Resolve the target.** Read `$ARGUMENTS`. If it ends in
+   `SKILL.md`, treat as the path. If it names a plugin (e.g.,
+   `work`), resolve to `plugins/<plugin>/skills/help/SKILL.md`. If
+   the file does not exist, stop — there is nothing to audit. If
+   the path resolves to a SKILL.md whose `name` is not `help`, stop
+   and route to `/build:check-skill` — this auditor is for help-
+   skills only.
+
+2. **Run Tier-1 deterministic checks.** Invoke
+   `scripts/check_help_skill.py <plugin-or-path>` and capture
+   stdout. The script enforces the audit-dimensions.md Tier-1
+   inventory — slug fidelity, frontmatter shape, line count,
+   secret/TLS/pipe-to-shell patterns, synopsis presence,
+   managed-region presence, skill-index coverage and
+   no-self-listing, description fidelity, workflow section
+   presence and freshness, pointer resolution — and emits findings
+   in lint format with severities (FAIL / WARN / INFO). The LLM
+   reasons over the script's output, not the raw SKILL.md. Exit 0
+   indicates clean / WARN-only / INFO-only; exit 1 indicates at
+   least one FAIL.
+
+3. **FAIL gate.** Any FAIL finding excludes the file from Tier-2
+   judgment — fix the structural issue before evaluating quality.
+   The exclusion list: `slug-mismatch`, `secret`, `managed-region-
+   missing`, `skill-index-coverage` (rows for skills that don't
+   exist on disk), `pointer-broken-fail` (broken pointer to
+   AGENTS.md / RESOLVER.md / plugin README, which are load-bearing
+   navigation). Other FAILs may be present at this point but are
+   surfaced and continue.
+
+4. **Run Tier-2 judgment checks.** One LLM evaluation per file
+   covering all five dimensions: workflow curation (at least one
+   composed chain, not just a flat list); triage scaffolding (task
+   → skill mapping is actionable, not just a description echo);
+   dual audience (readable for both human typing `/<plugin>:help`
+   and agent looking up routing); scope discipline (does not
+   duplicate AGENTS.md or README content); trigger quality
+   (description fires on meta-questions about the plugin, not on
+   the plugin's own workflows). Each dimension returns
+   PASS / WARN / FAIL with one-sentence rationale, citing the
+   source principle.
+
+5. **Run Tier-3 cross-entity check.** For each sibling skill in the
+   plugin, compare its `description` against the help-skill's
+   `description` for trigger collision. Heuristic: shared
+   trigger-phrase tokens above a threshold flag as INFO; an
+   identical "Use when the user/caller asks…" phrasing across two
+   skills flags as WARN. The router cannot disambiguate two skills
+   that match the same trigger — surface every collision so the
+   user can narrow either side.
+
+6. **Report.** Emit findings in the lint-style format used across
+   the toolkit's check-* skills: severity, ID, location (line:col
+   when applicable), one-line message, source principle. Group by
+   tier. End with a summary count and the `/build:check-help-skill
+   --repair` invitation.
+
+7. **Opt-in repair loop.** If the user opts in (`y` / specific
+   finding IDs), apply canonical repairs from
+   [repair-playbook.md](references/repair-playbook.md) one finding
+   at a time, with explicit confirmation per fix. Re-run Tier-1
+   after each fix to verify it landed cleanly. Tier-2 dimensions
+   are coaching — surface them but do not auto-repair without
+   explicit per-finding approval.
+
+## Failure modes
+
+- **Target file missing.** Step 1 stops the workflow. Recovery:
+  scaffold via `/build:build-help-skill <plugin>` first, or correct
+  the path argument.
+- **Target is not a help-skill.** Step 1 routes to
+  `/build:check-skill`. Recovery: re-invoke the appropriate
+  auditor.
+- **Sibling skills unreadable.** If `plugins/<plugin>/skills/*/
+  SKILL.md` cannot be parsed (malformed frontmatter), Tier-1
+  coverage and fidelity checks emit `tool-degraded` INFO findings
+  and continue. Recovery: fix the malformed sibling first; the
+  help-skill audit is downstream.
+- **Tier-2 LLM call fails.** Surface the failure as an INFO
+  finding; Tier-1 results stand. Recovery: re-run the audit; do not
+  block on transient model failures.
+- **Repair playbook lacks a recipe for a finding.** A
+  finding-without-recipe is a gap in the playbook itself, not a
+  failure of the auditor. Surface to the user; the recipe should be
+  added to `repair-playbook.md` in a follow-up.
+
+## Examples
+
+<example>
+Invocation:
+
+```bash
+/build:check-help-skill work
+```
+
+Step 1 — Resolves to `plugins/work/skills/help/SKILL.md`. File
+exists. `name: help`. Proceed.
+
+Step 2 — Tier-1: 0 FAIL, 1 WARN, 0 INFO.
+- WARN `description-fidelity` — table row for `plan-work` reads
+  *"Plan a multi-step task"* but the current
+  `plugins/work/skills/plan-work/SKILL.md` description starts *"Use
+  when the user has a spec or requirements for a multi-step
+  task…"*. Source: *Description fidelity — entries reflect actual
+  frontmatter*.
+
+Step 3 — No FAIL exclusion; proceed to Tier-2.
+
+Step 4 — Tier-2: 5 PASS.
+
+Step 5 — Tier-3: no trigger collisions.
+
+Step 6 — Reports 1 WARN. Invites repair.
+
+Step 7 — User accepts the repair. Playbook recipe regenerates the
+managed region from sibling frontmatter; re-runs Tier-1; finding
+clears. Reports clean.
+</example>
+
+## Key Instructions
+
+- Run Tier-1 before Tier-2; FAIL findings exclude the file from
+  judgment evaluation. Audit cleanly is the contract.
+- Cite the source principle for every finding — every dimension in
+  `audit-dimensions.md` names the
+  `help-skill-best-practices.md` section it enforces.
+- Tier-3 trigger-collision check is what makes this auditor
+  load-bearing — a help-skill in isolation looks fine; a help-skill
+  that fights its siblings only fails when the router has to choose.
+- Repair is opt-in and per-finding; never apply playbook recipes
+  without explicit user confirmation.
+
+## Anti-Pattern Guards
+
+1. **Skipping the trigger-collision check.** A help-skill that
+   parses cleanly but collides with siblings will misroute callers
+   silently. Tier-3 is the load-bearing dimension; running only
+   Tier-1 + Tier-2 leaves the highest-value defect undetected.
+2. **Auto-repairing Tier-2 findings.** Judgment dimensions (workflow
+   curation, dual audience, scope discipline) need user input.
+   Auto-applying playbook recipes without confirmation produces
+   plausible but wrong rewrites.
+3. **Treating description-fidelity as deterministic-equivalent.**
+   The check compares the table's trigger column to the sibling's
+   current description; minor wording differences are expected
+   (truncation to ~12 words). The check fires on *substantive*
+   drift (a sibling description changed and the table did not).
+   Reporting trivial wording deltas as FAIL produces noise.
+4. **Inlining a chained skill instead of invoking it.** MUST invoke
+   `/build:check-skill` via the Skill tool when Step 1 routes off-
+   target. MUST NOT inline a partial check-skill audit. The
+   shortcut bypasses the chained skill's rubric.
+
+## Handoff
+
+**Receives:** Path to a help-skill SKILL.md or a plugin name.
+
+**Produces:** A finding report (FAIL / WARN / INFO with source
+principle citations) and an opt-in repair loop. Does not write to
+disk unless the user opts in to repair.
+
+**Chainable to:** `/build:check-skill <path>` (catches generic
+SKILL.md structural issues outside the help-skill rubric);
+`/build:check-skill-pair help-skill` (audits pair-level integrity —
+principles doc present, audit/playbook coverage, routing
+registration); `/build:build-help-skill <plugin>` (when the target
+file does not exist).

--- a/plugins/build/skills/check-help-skill/references/audit-dimensions.md
+++ b/plugins/build/skills/check-help-skill/references/audit-dimensions.md
@@ -1,0 +1,169 @@
+---
+name: Audit Dimensions — Help-Skill
+description: The complete check inventory for check-help-skill — Tier-1 deterministic checks, Tier-2 judgment dimensions, and Tier-3 cross-entity trigger-collision check. Every dimension cites its source principle in help-skill-best-practices.md. Referenced by the check-help-skill workflow and the repair playbook.
+---
+
+# Audit Dimensions
+
+The check-help-skill audit runs in three tiers. This document is the
+inventory: every deterministic check Tier-1 emits, every judgment
+dimension Tier-2 evaluates, and the cross-entity collision check
+Tier-3 runs. Every dimension cites the source principle from
+[help-skill-best-practices.md](../../../_shared/references/help-skill-best-practices.md)
+that it audits.
+
+## Tier-1 — Deterministic Checks
+
+Each check has an ID, severity, and the source principle it enforces.
+Tier-1 is implemented as scripts (Python, per *Language Selection* in
+`primitive-routing.md` — frontmatter parsing is structured-data work,
+testable against `pytest`); scaffolding the scripts is a follow-on
+handoff to `/build:build-python-script`. Until the scripts land, the
+check-help-skill SKILL.md performs Tier-1 inline against the
+inventory below.
+
+| Check ID | What | Severity | Source principle |
+|---|---|---|---|
+| `slug-mismatch` | Frontmatter `name` is the literal string `help`, and the directory basename is `help` | FAIL | Use `name: help` literally — the slug is fixed |
+| `frontmatter-shape` | Required frontmatter keys present: `name`, `description`, `version`, `owner`, `license`, `references:` (with at least the help-skill-best-practices.md path) | WARN | Anatomy — required frontmatter |
+| `frontmatter-invented-key` | No top-level frontmatter keys outside the documented set (cross-checked against `skill-best-practices.md`) | WARN | Invent no keys the skill spec does not sanction |
+| `body-line-count` | Body length ≤150 lines target, ≤200 lines hard ceiling | WARN | Keep the body short |
+| `secret` | No API keys, tokens, credentials, internal hostnames, or private URLs in the file | FAIL | No embedded secrets |
+| `tls-disable` | No instructions to disable TLS verification, SELinux, or firewalls | FAIL | No instructions to disable security posture |
+| `pipe-to-shell` | No `curl ... \| bash` / `wget ... \| sh` / `iex (iwr ...)` invocations | FAIL | No `curl … \| bash` invitations |
+| `synopsis-present` | A one-sentence synopsis appears below the H1, before the first H2 | WARN | One-sentence synopsis below the H1 is the most-read line |
+| `managed-region-present` | The skill-index section contains a matching pair of `<!-- generated: ... -->` and `<!-- /generated -->` markers wrapping a markdown table | FAIL | Generate the skill table from sibling frontmatter |
+| `managed-region-tampered` | Content inside the managed region matches a regeneration from current sibling frontmatter (no hand edits) | WARN | Hand-editing the table inside the managed region is the failure mode the marker exists to flag |
+| `skill-index-coverage` | Every sibling skill at `plugins/<plugin>/skills/*/SKILL.md` (excluding `help`) appears as a row in the skill-index table; no rows for non-existent skills | FAIL | The skill table is the most-read part of the document and the most likely to drift |
+| `skill-index-no-self` | The `help` skill does not appear in its own table | WARN | The generator must exclude `help` |
+| `description-fidelity` | Each table row's trigger text matches the first ~12 words of the corresponding sibling skill's current `description` (substantive drift, not whitespace) | WARN | Description fidelity — entries reflect actual frontmatter |
+| `workflow-section-present` | A `## Common workflows` section exists with at least one curated chain | WARN | Curate workflow chains; do not auto-generate |
+| `workflow-freshness` | Every skill name referenced in `## Common workflows` resolves to a sibling SKILL.md on disk | WARN | A curated workflow chain that referenced the removed skill becomes a broken pointer |
+| `workflow-chain-cross-plugin` | Workflow chains reference only skills inside this plugin (no cross-plugin compositions) | WARN | Workflow chains scoped to this plugin only |
+| `pointer-resolution` | Every relative link in `## Where to look next` resolves to a file on disk | WARN | Pointers, not duplications — but pointers must work |
+| `pointer-broken-fail` | Pointers to load-bearing navigation (AGENTS.md, RESOLVER.md, plugin README) resolve | FAIL | Pointers to canonical navigation are load-bearing |
+| `description-trigger-shape` | The `description` frontmatter leads with "Use when" and includes at least one concrete trigger phrase ("what's in", "list skills", "how do I use", "which skill fits") | WARN | Lead the description with the caller's situation, not the skill's function |
+
+**FAIL exclusions from Tier-2.** Any `slug-mismatch`, `secret`,
+`tls-disable`, `pipe-to-shell`, `managed-region-missing`,
+`skill-index-coverage` (rows for skills that don't exist on disk), or
+`pointer-broken-fail` finding excludes the file from Tier-2.
+Structural failures must be repaired before judgment evaluation runs.
+
+**Missing-tool degradation.** Tier-1 inline (until the Python helper
+scripts land) reads sibling SKILL.md files via the Read tool. If a
+sibling file cannot be parsed, the affected check (coverage,
+fidelity) emits `tool-degraded` INFO and continues; the help-skill
+audit is downstream of sibling validity.
+
+## Tier-2 — Judgment Dimensions
+
+One LLM evaluation per file. All five dimensions run every time. A
+dimension that doesn't apply returns PASS silently. Findings carry
+WARN severity unless explicitly noted — judgment-level drift is
+coaching, not blocking.
+
+### D1 Workflow Curation
+
+**Source principle:** *Curate workflow chains; do not auto-generate
+them. List two or three chains the plugin's authors actually expect
+callers to follow.*
+
+**Judges:** Does `## Common workflows` contain at least one
+*composed* chain (skill-a → skill-b → skill-c), not just a flat list
+of skills? Are the chains specific to actual user tasks, or are they
+abstract enumerations? Does each chain include a one-sentence "when
+this chain applies" qualifier? A workflows section that is just a
+re-listing of the skill table FAILs this dimension.
+
+### D2 Triage Scaffolding
+
+**Source principle:** *Triage scaffolding — task → skill mapping is
+actionable.*
+
+**Judges:** Can a caller with a specific task ("I want to fix a bug
+in this codebase", "I want to plan a feature") read the help-skill
+and unambiguously identify which sibling skill to invoke next? Or
+does the help-skill list skills without scaffolding the choice
+between them? A help-skill that names siblings without telling the
+caller how to choose between them WARNs this dimension.
+
+### D3 Dual Audience
+
+**Source principle:** *Two audiences read it: a human typing
+`/<plugin>:help` who wants a readable index, and an agent that has
+matched the trigger and needs triage scaffolding.*
+
+**Judges:** Does the document read cleanly for both audiences? A
+help-skill written purely for an LLM (terse, abbreviated, optimized
+for token cost) will fail the human-readability check; a help-skill
+written purely for human reading (long-form, narrative, marketing-
+flavored) will fail the agent-routing check. The pass criterion is
+both — short, scannable, with the right amount of context to route
+without requiring the reader to load adjacent files.
+
+### D4 Scope Discipline
+
+**Source principles:** *Pointers, not duplications.* *Architectural
+prose in the help-skill body* (anti-pattern). *Keep the body short.*
+
+**Judges:** Does the help-skill stay inside its scope (synopsis,
+index, workflows, pointers) without spilling into AGENTS.md
+territory (architectural prose, design philosophy, plugin-
+composition rationale) or README territory (install instructions,
+contributing guidelines, license text)? A help-skill that grows a
+"Why this plugin exists" section or an "Installation" section WARNs
+this dimension; the content belongs elsewhere.
+
+### D5 Trigger Quality
+
+**Source principle:** *Lead the description with the caller's
+situation, not the skill's function.* *Trigger description must not
+collide with sibling-skill triggers.*
+
+**Judges:** Does the `description` frontmatter retrieve on
+*meta-questions about the plugin* ("what's in this plugin", "list
+skills", "how do I use it", "which skill fits") and not on *the
+plugin's own workflows* (e.g., for the `build` plugin, not on "build
+a skill" — that fires the actual sibling)? A description shaped like
+"Use when the user wants to use the X plugin's features" is too
+generic and competes with siblings. A description shaped like "Use
+when the caller asks 'what's in the X plugin' or 'list X skills'" is
+specific to the help-skill's role.
+
+This dimension overlaps with Tier-3 cross-entity collision but is
+distinct: Tier-2 judges the description in isolation (does it read
+as a meta-trigger?), Tier-3 measures collision against actual
+siblings.
+
+## Tier-3 — Cross-Entity Trigger Collision
+
+### trigger-collision
+
+**Source principle:** *Trigger description must not collide with
+sibling-skill triggers. The router cannot disambiguate two skills
+that match the same trigger.*
+
+**Severity:** WARN (INFO when only token-overlap heuristic fires;
+WARN when identical trigger-phrase heuristic fires).
+
+**Method.** For every sibling skill in the plugin, compare its
+`description` against the help-skill's `description`. Two heuristics:
+
+- **Token overlap.** Tokenize both descriptions; flag pairs whose
+  shared trigger-phrase tokens (verbs + nouns from "Use when…"
+  clauses) exceed a threshold. Severity: INFO if 3+ shared trigger
+  tokens, WARN if 5+.
+- **Identical trigger phrasing.** Flag pairs where both descriptions
+  contain the same exact trigger phrase (e.g., both fire on "list
+  skills"). Severity: WARN.
+
+**Output.** For each collision, surface both descriptions and the
+shared tokens. The user resolves by narrowing either side; the
+auditor does not pick a winner automatically.
+
+**Why this tier exists.** A help-skill in isolation can pass Tier-1
+and Tier-2 cleanly while being fundamentally broken — when the
+router is presented with the help-skill alongside its siblings, it
+cannot pick correctly. This is the load-bearing check. Skipping
+Tier-3 leaves the highest-value defect undetected.

--- a/plugins/build/skills/check-help-skill/references/repair-playbook.md
+++ b/plugins/build/skills/check-help-skill/references/repair-playbook.md
@@ -1,0 +1,489 @@
+---
+name: Repair Playbook — Help-Skill
+description: One repair recipe per Tier-1 finding type plus one per Tier-2 dimension plus one per Tier-3 collision. Each recipe is Signal → CHANGE → FROM → TO → REASON. Applied during the check-help-skill opt-in repair loop with per-finding confirmation.
+---
+
+# Repair Playbook
+
+Per-finding repair recipes for check-help-skill. Every Tier-1 finding
+ID, every Tier-2 dimension, and the Tier-3 collision finding has a
+recipe here. Apply one at a time, with explicit user confirmation,
+re-running the producing check after each fix.
+
+## Format
+
+- **Signal** — the finding ID or dimension name
+- **CHANGE** — what to modify, in one sentence
+- **FROM** — concrete non-compliant example
+- **TO** — compliant replacement
+- **REASON** — why, tied to source principle
+
+---
+
+## Tier-1 — Slug & Frontmatter
+
+### Signal: `slug-mismatch`
+
+**CHANGE** Set frontmatter `name` to the literal string `help` and
+ensure the directory basename is also `help`. Move the file if the
+directory is named anything else.
+
+**FROM**
+```yaml
+---
+name: build-index
+---
+```
+**TO**
+```yaml
+---
+name: help
+---
+```
+**REASON** `/<plugin>:help` resolves on the literal slug `help`.
+Renaming defeats discoverable invocation.
+
+### Signal: `frontmatter-shape`
+
+**CHANGE** Add the missing required frontmatter keys: `name`,
+`description`, `version`, `owner`, `license`, `references:`.
+
+**FROM**
+```yaml
+---
+name: help
+description: Plugin index
+---
+```
+**TO**
+```yaml
+---
+name: help
+description: Use when the caller asks "what's in the build plugin"…
+version: 1.0.0
+owner: build-plugin
+license: MIT
+references:
+  - ../../_shared/references/help-skill-best-practices.md
+---
+```
+**REASON** Required frontmatter is the cache-busting and ownership
+signal consumers rely on.
+
+### Signal: `frontmatter-invented-key`
+
+**CHANGE** Remove the unsanctioned frontmatter key. If the
+information is load-bearing, move it to the body.
+
+**FROM**
+```yaml
+---
+plugin-tier: core
+---
+```
+**TO** *(remove the key entirely)*
+
+**REASON** Unknown frontmatter keys are silently ignored by Claude
+Code; including them implies a contract that does not exist.
+
+---
+
+## Tier-1 — Body Structure
+
+### Signal: `body-line-count`
+
+**CHANGE** Trim the body. Move long-form rationale to AGENTS.md or
+the plugin README; tighten workflow descriptions to one sentence
+each.
+
+**FROM** *body length 280 lines, with multi-paragraph workflow
+narratives*
+
+**TO** *body length under 150 lines, one-sentence workflow
+qualifiers*
+
+**REASON** A help-skill is an index, not documentation. Length
+dilutes the orientation.
+
+### Signal: `synopsis-present`
+
+**CHANGE** Add a single-sentence synopsis below the H1, before the
+first H2.
+
+**FROM**
+```markdown
+# /build:help
+
+## Skills in this plugin
+```
+**TO**
+```markdown
+# /build:help
+
+Author and audit Claude Code primitives — skills, hooks, rules,
+subagents, and scripts.
+
+## Skills in this plugin
+```
+**REASON** The synopsis is the most-read line. Skipping it forces
+the caller to translate the skill table into a value proposition.
+
+---
+
+## Tier-1 — Skill Index
+
+### Signal: `managed-region-present`
+
+**CHANGE** Wrap the skill table in
+`<!-- generated: do not edit by hand; regenerate from disk -->` and
+`<!-- /generated -->` markers.
+
+**FROM**
+```markdown
+## Skills in this plugin
+
+| Skill | Triggers on |
+|---|---|
+| build-skill | … |
+```
+**TO**
+```markdown
+## Skills in this plugin
+
+<!-- generated: do not edit by hand; regenerate from disk -->
+| Skill | Triggers on |
+|---|---|
+| build-skill | … |
+<!-- /generated -->
+```
+**REASON** The marker is what the auditor uses to detect hand edits;
+without it, drift becomes invisible.
+
+### Signal: `managed-region-tampered`
+
+**CHANGE** Regenerate the table inside the managed region from
+sibling SKILL.md frontmatter; discard hand edits.
+
+**FROM** *manually polished trigger column with prose embellishment*
+
+**TO** *table regenerated from each sibling's `description` first
+~12 words, no embellishment*
+
+**REASON** Hand-editing the managed region is what the marker
+exists to forbid. Drift is structurally impossible only when the
+generator is the source of truth.
+
+### Signal: `skill-index-coverage`
+
+**CHANGE** Regenerate the table from `plugins/<plugin>/skills/*/`
+directory listing. Add rows for any sibling skill missing from the
+table; remove rows for skills that no longer exist on disk.
+
+**FROM** *table missing the recently added `check-skill-pair` row;
+table contains a row for `build-deprecated` that no longer exists*
+
+**TO** *table includes `check-skill-pair`; row for `build-
+deprecated` removed*
+
+**REASON** The skill table is the most-read and most-drift-prone
+part of the document. Coverage drift is what the help-skill is
+specifically supposed to prevent.
+
+### Signal: `skill-index-no-self`
+
+**CHANGE** Remove the `help` row from the skill-index table.
+
+**FROM**
+```
+| help | Use when the caller asks… |
+```
+**TO** *(row removed)*
+
+**REASON** Listing the help-skill in its own table is recursive and
+confusing; the generator must exclude `name == "help"`.
+
+### Signal: `description-fidelity`
+
+**CHANGE** Regenerate the trigger column for the affected row from
+the sibling skill's current `description` (first ~12 words). Do not
+hand-polish.
+
+**FROM**
+```
+| plan-work | Plan a multi-step task |
+```
+*(but `plan-work`'s current description starts: "Use when the user
+has a spec or requirements for a multi-step task…")*
+
+**TO**
+```
+| plan-work | Use when the user has a spec or requirements for… |
+```
+**REASON** The table is the disk-derived view of sibling
+descriptions. Drift means the index lies about what siblings do.
+
+---
+
+## Tier-1 — Workflows & Pointers
+
+### Signal: `workflow-section-present`
+
+**CHANGE** Add a `## Common workflows` section with at least one
+curated chain. Do not auto-generate; ask the user.
+
+**FROM** *no workflows section*
+
+**TO**
+```markdown
+## Common workflows
+
+- **Build new feature** — `scope-work` → `plan-work` → `start-work`
+  → `verify-work`. *Use when starting from requirements.*
+```
+**REASON** A help-skill without curated workflows is a flat index;
+triage scaffolding is what differentiates it from the directory
+listing.
+
+### Signal: `workflow-freshness`
+
+**CHANGE** Either remove the broken skill reference from the
+workflow chain, or update the chain to use a current sibling.
+
+**FROM**
+```
+- **X** — `scope-work` → `plan-work` → `legacy-runner`.
+```
+*(but `legacy-runner` no longer exists at
+`plugins/work/skills/legacy-runner/`)*
+
+**TO**
+```
+- **X** — `scope-work` → `plan-work` → `start-work`.
+```
+**REASON** A workflow chain that references a removed skill is a
+broken pointer — followers land on nothing.
+
+### Signal: `workflow-chain-cross-plugin`
+
+**CHANGE** Either narrow the chain to in-plugin skills or move the
+cross-plugin chain to AGENTS.md's plugin-composition section.
+
+**FROM**
+```
+- **X** — `scope-work` (work) → `build-skill` (build).
+```
+**TO**
+```
+- **X** — `scope-work` → `plan-work` → `start-work`.
+```
+*(and add the cross-plugin chain to AGENTS.md if useful)*
+
+**REASON** Per-plugin scoping is intentional. Cross-plugin
+discovery lives in AGENTS.md; mixing it into a help-skill blurs the
+boundary.
+
+### Signal: `pointer-resolution`
+
+**CHANGE** Fix the broken relative link.
+
+**FROM**
+```markdown
+- [AGENTS.md](../../AGENTS.md)
+```
+*(file is actually 4 directories up, not 2)*
+
+**TO**
+```markdown
+- [AGENTS.md](../../../../AGENTS.md)
+```
+**REASON** From `plugins/<plugin>/skills/help/SKILL.md`, the repo
+root is four directories up.
+
+### Signal: `pointer-broken-fail`
+
+**CHANGE** Same as `pointer-resolution`. The FAIL severity reflects
+that AGENTS.md / RESOLVER.md / the plugin README are load-bearing
+navigation.
+
+**REASON** A help-skill whose pointer to AGENTS.md is broken sends
+callers nowhere; the pointer's job is to be the off-ramp to broader
+context.
+
+---
+
+## Tier-1 — Description Shape
+
+### Signal: `description-trigger-shape`
+
+**CHANGE** Rewrite the `description` to lead with "Use when" and
+include concrete trigger phrases.
+
+**FROM**
+```yaml
+description: Plugin index for the build plugin.
+```
+**TO**
+```yaml
+description: >-
+  Use when the caller asks "what's in the build plugin", "list
+  build skills", "how do I use build", or wants to see which build
+  skill fits a task.
+```
+**REASON** Capability-shaped descriptions do not retrieve. The
+router reads the description as a trigger condition.
+
+---
+
+## Tier-1 — Safety
+
+### Signal: `secret`
+
+**CHANGE** Remove the secret. Help-skills should not contain
+credentials of any kind.
+
+**FROM**
+```
+api_key: sk-proj-abc123def456
+```
+**TO** *(removed; replace with reference to env var if context
+requires)*
+
+**REASON** A help-skill is committed and trusted by Claude as
+instructions; embedded secrets are a breach.
+
+### Signal: `tls-disable`
+
+**CHANGE** Remove the security-weakening instruction. Document the
+real fix or file a bug.
+
+**REASON** Security-weakening guidance outlives the issue that
+prompted it.
+
+### Signal: `pipe-to-shell`
+
+**CHANGE** Remove the `curl … | bash` invocation. If installer
+guidance is needed, link to a workflow skill instead.
+
+**REASON** Help-skills are orientation surfaces; supply-chain
+installers belong inside workflow skills with explicit safety
+gates.
+
+---
+
+## Tier-2 — Judgment Dimensions
+
+### Signal: D1 Workflow Curation (FAIL)
+
+**CHANGE** Replace the flat list with at least one composed chain
+showing how skills compose. Add a one-sentence "when this chain
+applies" qualifier per chain.
+
+**FROM**
+```markdown
+## Common workflows
+- scope-work
+- plan-work
+- start-work
+```
+**TO**
+```markdown
+## Common workflows
+- **Build new feature** — `scope-work` → `plan-work` → `start-work`
+  → `verify-work`. *Use when starting from requirements.*
+```
+**REASON** A help-skill without composed chains is just a re-
+listing of the skill table.
+
+### Signal: D2 Triage Scaffolding (WARN)
+
+**CHANGE** Add a "task → skill" mapping cue per workflow chain.
+Name the user task, not just the skill name.
+
+**FROM**
+```
+- **scope-work** — explores requirements
+```
+**TO**
+```
+- **When you have requirements but don't know how to break them
+  down** — start with `scope-work`, then `plan-work`.
+```
+**REASON** Triage scaffolds the choice; description echo doesn't.
+
+### Signal: D3 Dual Audience (WARN)
+
+**CHANGE** Add scannable structure (bullets, tables) for human
+readers and concrete trigger phrases for agent routing. Trim
+narrative prose; keep imperatives.
+
+**REASON** A help-skill that reads as a marketing page fails the
+agent; one that reads as token-optimized telegraph fails the
+human. Both audiences must scan it cleanly.
+
+### Signal: D4 Scope Discipline (WARN)
+
+**CHANGE** Move architectural / install / contributing prose out
+of the help-skill. Replace with a pointer to AGENTS.md / README /
+CONTRIBUTING.
+
+**FROM**
+```markdown
+## Why this plugin exists
+This plugin codifies the conventions we've evolved over…
+```
+**TO**
+```markdown
+## Where to look next
+- [AGENTS.md](../../../../AGENTS.md) — plugin composition rationale
+```
+**REASON** Pointers, not duplications. Two copies drift.
+
+### Signal: D5 Trigger Quality (WARN)
+
+**CHANGE** Rewrite the description to fire on meta-questions about
+the plugin, not on the plugin's own workflows.
+
+**FROM**
+```yaml
+description: Use when the user wants to build, audit, or work with
+  Claude Code primitives.
+```
+**TO**
+```yaml
+description: >-
+  Use when the caller asks "what's in the build plugin", "list
+  build skills", or "which build skill fits this task".
+```
+**REASON** A description shaped like sibling triggers competes for
+routing. The help-skill's distinct trigger is meta-questions about
+the plugin.
+
+---
+
+## Tier-3 — Cross-Entity Collision
+
+### Signal: trigger-collision
+
+**CHANGE** Narrow either the help-skill description or the
+colliding sibling description so the trigger sets are disjoint.
+Choose based on which side is "wider" — the help-skill's trigger
+should be meta-questions only; siblings' triggers should be the
+specific tasks they perform.
+
+**FROM**
+- help-skill description: *"Use when the user wants to use the
+  build plugin."*
+- sibling `build-skill` description: *"Use when the user wants to
+  build, scaffold, or create a skill."*
+- shared trigger phrase: "use the build plugin" overlaps with
+  "build" tasks.
+
+**TO**
+- help-skill description: *"Use when the caller asks 'what's in the
+  build plugin' or 'list build skills'."*
+- sibling description unchanged.
+
+**REASON** The router picks one arbitrarily when two skills match
+the same trigger. The help-skill is the one to narrow because its
+distinct value is meta-trigger; siblings own their workflow
+triggers.

--- a/plugins/build/skills/check-help-skill/scripts/check_help_skill.py
+++ b/plugins/build/skills/check-help-skill/scripts/check_help_skill.py
@@ -1,0 +1,543 @@
+#!/usr/bin/env python3
+"""Run Tier-1 deterministic checks against a help-skill SKILL.md.
+
+Walks the help-skill against the audit-dimensions.md Tier-1 inventory
+and emits lint-format findings: SEVERITY  <path> — <check-id>: <message>.
+
+Exit codes:
+    0 — clean / WARN-only / INFO-only
+    1 — at least one FAIL finding
+    2 — usage error
+
+Examples:
+    ./check_help_skill.py work
+    ./check_help_skill.py plugins/work/skills/help/SKILL.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+EXIT_USAGE = 2
+EXIT_INTERRUPTED = 130
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[3]
+PLUGINS_DIR = PLUGIN_ROOT.parent
+RENDER_SCRIPT = (
+    PLUGIN_ROOT / "skills" / "build-help-skill" / "scripts" / "render_skill_table.py"
+)
+
+REQUIRED_FRONTMATTER_KEYS = (
+    "name",
+    "description",
+    "version",
+    "owner",
+    "license",
+    "references",
+)
+SANCTIONED_FRONTMATTER_KEYS = frozenset(
+    {
+        "name",
+        "description",
+        "version",
+        "owner",
+        "license",
+        "references",
+        "argument-hint",
+        "user-invocable",
+        "disable-model-invocation",
+        "when_to_use",
+        "paths",
+        "allowed-tools",
+        "context",
+        "agent",
+        "model",
+        "effort",
+        "hooks",
+        "tested_with",
+    }
+)
+
+SECRET_PATTERNS = [
+    r"sk-[a-zA-Z0-9]{20,}",
+    r"AKIA[0-9A-Z]{16}",
+    r"ghp_[A-Za-z0-9]{20,}",
+    r"-----BEGIN (?:RSA |OPENSSH |EC )?PRIVATE KEY-----",
+    r"(?i)password\s*[:=]\s*[\"']?[^\s\"']{8,}",
+]
+TLS_DISABLE_PATTERNS = [
+    r"(?i)(?:disable|turn\s+off|skip)\s+(?:tls|ssl|certificate|cert)\s+(?:verif|validation|check)",
+    r"--insecure\b",
+    r"--no-check-certificate\b",
+    r"verify\s*=\s*False",
+]
+PIPE_TO_SHELL_PATTERNS = [
+    r"curl\s+[^|\n]*\|\s*(?:sh|bash|zsh)\b",
+    r"wget\s+[^|\n]*\|\s*(?:sh|bash|zsh)\b",
+    r"iex\s*\(\s*iwr",
+]
+TRIGGER_PHRASE_PATTERNS = [
+    r"what['’]s in",
+    r"list\s+\S+\s+skills",
+    r"list\s+skills",
+    r"how do i use",
+    r"which\s+\S+\s+skill",
+]
+LOAD_BEARING_POINTERS = ("AGENTS.md", "RESOLVER.md", "README.md")
+
+BODY_LINE_TARGET = 150
+BODY_LINE_HARD = 200
+WORD_LIMIT = 12
+DRIFT_PREFIX_WORDS = 6
+
+Finding = tuple[str, str, str]
+
+
+def get_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Run Tier-1 deterministic checks against a help-skill SKILL.md.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument("target", help="Plugin name or path to a help-skill SKILL.md.")
+    return p
+
+
+def resolve_target(arg: str) -> Path:
+    candidate = Path(arg)
+    if candidate.suffix == ".md" or candidate.name == "SKILL.md":
+        return candidate.resolve()
+    return (PLUGINS_DIR / arg / "skills" / "help" / "SKILL.md").resolve()
+
+
+def split_frontmatter_body(text: str) -> tuple[str, str]:
+    if not text.startswith("---\n"):
+        return "", text
+    lines = text.splitlines(keepends=True)
+    for i in range(1, len(lines)):
+        if lines[i].rstrip("\n") == "---":
+            return "".join(lines[1:i]), "".join(lines[i + 1 :])
+    return "", text
+
+
+def parse_frontmatter(yaml_text: str) -> dict[str, str]:
+    out: dict[str, str] = {}
+    lines = yaml_text.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        m = re.match(r"^([A-Za-z][A-Za-z0-9_-]*):\s*(.*)$", line)
+        if not m:
+            i += 1
+            continue
+        key, val = m.group(1), m.group(2).strip()
+        if val in (">-", ">", "|", "|-"):
+            chunks: list[str] = []
+            i += 1
+            while i < len(lines) and (
+                lines[i].startswith("  ") or not lines[i].strip()
+            ):
+                if lines[i].strip():
+                    chunks.append(lines[i].strip())
+                i += 1
+            out[key] = " ".join(chunks)
+            continue
+        out[key] = val.strip("\"'")
+        i += 1
+    return out
+
+
+def first_n_words(s: str, n: int) -> str:
+    words = s.split()
+    return " ".join(words[:n]) if words else ""
+
+
+def get_siblings(plugin: str) -> list[dict[str, str]]:
+    if not RENDER_SCRIPT.is_file():
+        return []
+    result = subprocess.run(
+        [sys.executable, str(RENDER_SCRIPT), plugin, "--format", "json"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return []
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return []
+
+
+def check_slug(path: Path, fm: dict[str, str]) -> list[Finding]:
+    out: list[Finding] = []
+    if fm.get("name") != "help":
+        out.append(
+            (
+                "FAIL",
+                "slug-mismatch",
+                f"frontmatter name is {fm.get('name')!r}, expected 'help'",
+            )
+        )
+    if path.parent.name != "help":
+        out.append(
+            (
+                "FAIL",
+                "slug-mismatch",
+                f"directory basename is {path.parent.name!r}, expected 'help'",
+            )
+        )
+    return out
+
+
+def check_frontmatter_shape(fm: dict[str, str]) -> list[Finding]:
+    missing = [k for k in REQUIRED_FRONTMATTER_KEYS if k not in fm]
+    return (
+        [("WARN", "frontmatter-shape", f"missing required keys: {', '.join(missing)}")]
+        if missing
+        else []
+    )
+
+
+def check_frontmatter_invented_key(fm: dict[str, str]) -> list[Finding]:
+    invented = sorted(set(fm.keys()) - SANCTIONED_FRONTMATTER_KEYS)
+    return (
+        [
+            (
+                "WARN",
+                "frontmatter-invented-key",
+                f"unsanctioned keys: {', '.join(invented)}",
+            )
+        ]
+        if invented
+        else []
+    )
+
+
+def check_body_line_count(body: str) -> list[Finding]:
+    n = len(body.splitlines())
+    if n > BODY_LINE_HARD:
+        return [
+            (
+                "WARN",
+                "body-line-count",
+                f"body length {n} exceeds {BODY_LINE_HARD}-line hard ceiling",
+            )
+        ]
+    if n > BODY_LINE_TARGET:
+        return [
+            (
+                "WARN",
+                "body-line-count",
+                f"body length {n} exceeds {BODY_LINE_TARGET}-line target",
+            )
+        ]
+    return []
+
+
+def check_patterns(
+    text: str, patterns: list[str], severity: str, check_id: str, label: str
+) -> list[Finding]:
+    return [
+        (severity, check_id, f"{label}: pattern {pat!r}")
+        for pat in patterns
+        if re.search(pat, text)
+    ]
+
+
+def check_synopsis_present(body: str) -> list[Finding]:
+    lines = body.splitlines()
+    h1, h2 = None, None
+    for i, line in enumerate(lines):
+        if h1 is None and line.startswith("# "):
+            h1 = i
+        elif h1 is not None and line.startswith("## "):
+            h2 = i
+            break
+    if h1 is None:
+        return [("WARN", "synopsis-present", "no H1 found in body")]
+    if h2 is None:
+        return [("WARN", "synopsis-present", "no H2 found after H1")]
+    if not "\n".join(lines[h1 + 1 : h2]).strip():
+        return [("WARN", "synopsis-present", "no synopsis between H1 and first H2")]
+    return []
+
+
+def check_managed_region(body: str) -> tuple[list[Finding], str | None]:
+    o = re.search(r"<!--\s*generated[^>]*-->", body)
+    c = re.search(r"<!--\s*/generated\s*-->", body)
+    if not o or not c or o.start() >= c.start():
+        return (
+            [
+                (
+                    "FAIL",
+                    "managed-region-present",
+                    "missing or out-of-order <!-- generated --> markers",
+                )
+            ],
+            None,
+        )
+    region = body[o.end() : c.start()].strip()
+    if "|" not in region:
+        return (
+            [
+                (
+                    "FAIL",
+                    "managed-region-present",
+                    "managed region contains no markdown table",
+                )
+            ],
+            None,
+        )
+    return ([], region)
+
+
+def parse_table_rows(region: str) -> list[tuple[str, str]]:
+    rows: list[tuple[str, str]] = []
+    for line in region.splitlines():
+        if not line.startswith("|"):
+            continue
+        parts = [p.strip() for p in line.strip("|").split("|")]
+        if len(parts) < 2 or all(set(p) <= set("- :") for p in parts):
+            continue
+        if parts[0].lower() in ("skill", "skill name"):
+            continue
+        name = parts[0].strip("`").strip()
+        if name:
+            rows.append((name, parts[1]))
+    return rows
+
+
+def check_skill_index_coverage(
+    rows: list[tuple[str, str]], siblings: list[dict[str, str]]
+) -> list[Finding]:
+    out: list[Finding] = []
+    sib = {s["name"] for s in siblings}
+    tab = {n for n, _ in rows}
+    missing = sib - tab
+    extra = tab - sib - {"help"}
+    if missing:
+        out.append(
+            (
+                "FAIL",
+                "skill-index-coverage",
+                f"siblings missing from table: {', '.join(sorted(missing))}",
+            )
+        )
+    if extra:
+        out.append(
+            (
+                "FAIL",
+                "skill-index-coverage",
+                f"table rows for non-existent skills: {', '.join(sorted(extra))}",
+            )
+        )
+    return out
+
+
+def check_skill_index_no_self(rows: list[tuple[str, str]]) -> list[Finding]:
+    return (
+        [("WARN", "skill-index-no-self", "table contains a row for 'help'")]
+        if any(name == "help" for name, _ in rows)
+        else []
+    )
+
+
+def check_description_fidelity(
+    rows: list[tuple[str, str]], siblings: list[dict[str, str]]
+) -> list[Finding]:
+    out: list[Finding] = []
+    by_name = {s["name"]: s for s in siblings}
+    for name, triggers in rows:
+        sib = by_name.get(name)
+        if not sib:
+            continue
+        expected = first_n_words(sib["description"], DRIFT_PREFIX_WORDS).lower()
+        observed = first_n_words(
+            triggers.replace("…", "").replace("\\|", "|"), DRIFT_PREFIX_WORDS
+        ).lower()
+        if expected and expected != observed:
+            out.append(
+                (
+                    "WARN",
+                    "description-fidelity",
+                    f"row '{name}' triggers do not match sibling description prefix",
+                )
+            )
+    return out
+
+
+def find_section(body: str, heading: str) -> str | None:
+    m = re.search(
+        rf"^##\s+{re.escape(heading)}\s*$(.*?)(?=^##\s+|\Z)", body, re.M | re.S
+    )
+    return m.group(1) if m else None
+
+
+def check_workflow_section_present(text: str | None) -> list[Finding]:
+    if text is None:
+        return [
+            (
+                "WARN",
+                "workflow-section-present",
+                "no '## Common workflows' section found",
+            )
+        ]
+    if not re.search(r"`[^`]+`\s*(?:→|->)\s*`", text):
+        return [
+            (
+                "WARN",
+                "workflow-section-present",
+                "workflows section has no composed chain (skill -> skill)",
+            )
+        ]
+    return []
+
+
+def check_workflow_freshness(
+    text: str | None, plugin_skills_dir: Path
+) -> list[Finding]:
+    if text is None:
+        return []
+    on_disk = (
+        {p.name for p in plugin_skills_dir.iterdir() if p.is_dir()}
+        if plugin_skills_dir.is_dir()
+        else set()
+    )
+    referenced = set(re.findall(r"`([a-z][a-z0-9-]*)`", text))
+    out: list[Finding] = []
+    for name in sorted(referenced - on_disk):
+        if "." in name or "/" in name:
+            continue
+        out.append(
+            (
+                "WARN",
+                "workflow-freshness",
+                f"workflow references skill '{name}' that does not exist in plugin",
+            )
+        )
+    return out
+
+
+def check_pointer_resolution(body: str, skill_md: Path) -> list[Finding]:
+    text = find_section(body, "Where to look next")
+    if text is None:
+        return [
+            ("WARN", "pointer-resolution", "no '## Where to look next' section found")
+        ]
+    out: list[Finding] = []
+    for m in re.finditer(r"\[([^\]]+)\]\(([^)]+)\)", text):
+        label, link = m.group(1), m.group(2)
+        if link.startswith(("http://", "https://", "#", "mailto:")):
+            continue
+        target = (skill_md.parent / link).resolve()
+        if not target.exists():
+            is_load_bearing = any(
+                p in link or p in label for p in LOAD_BEARING_POINTERS
+            )
+            sev = "FAIL" if is_load_bearing else "WARN"
+            cid = "pointer-broken-fail" if is_load_bearing else "pointer-resolution"
+            out.append((sev, cid, f"broken link [{label}]({link})"))
+    return out
+
+
+def check_description_trigger_shape(fm: dict[str, str]) -> list[Finding]:
+    desc = fm.get("description", "").lower()
+    if not desc:
+        return []
+    out: list[Finding] = []
+    if not desc.lstrip().startswith("use when"):
+        out.append(
+            (
+                "WARN",
+                "description-trigger-shape",
+                "description does not lead with 'Use when'",
+            )
+        )
+    if not any(re.search(p, desc) for p in TRIGGER_PHRASE_PATTERNS):
+        out.append(
+            (
+                "WARN",
+                "description-trigger-shape",
+                "description has no help-skill trigger phrase "
+                "(what's in / list skills / how do I use / which skill)",
+            )
+        )
+    return out
+
+
+def render_findings(path: Path, findings: list[Finding]) -> str:
+    order = {"FAIL": 0, "WARN": 1, "INFO": 2}
+    findings.sort(key=lambda f: (order.get(f[0], 99), f[1], f[2]))
+    counts = {"FAIL": 0, "WARN": 0, "INFO": 0}
+    for sev, _, _ in findings:
+        counts[sev] = counts.get(sev, 0) + 1
+    lines = [f"{sev}  {path} — {cid}: {msg}" for sev, cid, msg in findings]
+    if findings:
+        lines.append("")
+    lines.append(f"{counts['FAIL']} fail, {counts['WARN']} warn, {counts['INFO']} info")
+    return "\n".join(lines) + "\n"
+
+
+def run(args: argparse.Namespace) -> int:
+    skill_md = resolve_target(args.target)
+    if not skill_md.is_file():
+        raise FileNotFoundError(f"help-skill not found: {skill_md}")
+    text = skill_md.read_text(encoding="utf-8")
+    yaml_text, body = split_frontmatter_body(text)
+    fm = parse_frontmatter(yaml_text)
+    plugin = skill_md.parents[2].name
+    plugin_skills_dir = skill_md.parents[1]
+
+    findings: list[Finding] = []
+    findings += check_slug(skill_md, fm)
+    findings += check_frontmatter_shape(fm)
+    findings += check_frontmatter_invented_key(fm)
+    findings += check_body_line_count(body)
+    findings += check_patterns(
+        text, SECRET_PATTERNS, "FAIL", "secret", "secret-like pattern"
+    )
+    findings += check_patterns(
+        text, TLS_DISABLE_PATTERNS, "FAIL", "tls-disable", "TLS-disable pattern"
+    )
+    findings += check_patterns(
+        text, PIPE_TO_SHELL_PATTERNS, "FAIL", "pipe-to-shell", "pipe-to-shell installer"
+    )
+    findings += check_synopsis_present(body)
+    region_findings, region = check_managed_region(body)
+    findings += region_findings
+
+    siblings = get_siblings(plugin)
+    if region is not None:
+        rows = parse_table_rows(region)
+        findings += check_skill_index_coverage(rows, siblings)
+        findings += check_skill_index_no_self(rows)
+        findings += check_description_fidelity(rows, siblings)
+
+    workflow_text = find_section(body, "Common workflows")
+    findings += check_workflow_section_present(workflow_text)
+    findings += check_workflow_freshness(workflow_text, plugin_skills_dir)
+    findings += check_pointer_resolution(body, skill_md)
+    findings += check_description_trigger_shape(fm)
+
+    sys.stdout.write(render_findings(skill_md, findings))
+    return 1 if any(f[0] == "FAIL" for f in findings) else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = get_parser().parse_args(argv)
+    try:
+        return run(args)
+    except KeyboardInterrupt:
+        return EXIT_INTERRUPTED
+    except (FileNotFoundError, ValueError) as err:
+        print(f"error: {err}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/build/skills/check-help-skill/scripts/check_help_skill.py
+++ b/plugins/build/skills/check-help-skill/scripts/check_help_skill.py
@@ -243,7 +243,7 @@ def check_patterns(
     text: str, patterns: list[str], severity: str, check_id: str, label: str
 ) -> list[Finding]:
     return [
-        (severity, check_id, f"{label}: pattern {pat!r}")
+        (severity, check_id, f"{label} matched")
         for pat in patterns
         if re.search(pat, text)
     ]


### PR DESCRIPTION
## Summary

Adds `build-help-skill` / `check-help-skill` — a primitive pair for authoring per-plugin orientation skills reachable as `/<plugin>:help`.

A help-skill is a specialized SKILL.md whose subject is the plugin itself: a one-sentence synopsis, a disk-derived index of sibling skills inside a managed region, two or three curated workflow chains, and pointers to `AGENTS.md` / `RESOLVER.md` / the plugin README.

It's the *pull* alternative to the Reddit `task-router` + `UserPromptSubmit` pattern: on-demand (no token tax), scoped per plugin (one description to triage, not 25), generated from disk so the index can't drift, and doubles as human UX.

Closes #378.

## What ships

- **Rubric:** `plugins/build/_shared/references/help-skill-best-practices.md` — distilled from `skill-best-practices.md`, `readme-best-practices.md`, `AGENTS.md` document standards, and CLI `--help` conventions.
- **Build half:** `build-help-skill/SKILL.md` + `scripts/render_skill_table.py` (stdlib-only, emits the managed-region table from sibling frontmatter).
- **Check half:** `check-help-skill/SKILL.md` + `scripts/check_help_skill.py` (~280 LOC, 19 Tier-1 deterministic checks).
- **Audit dimensions** + **repair playbook** covering Tier-1 (19 checks), five Tier-2 judgment dimensions (workflow curation, triage scaffolding, dual audience, scope discipline, trigger quality), and a Tier-3 cross-entity trigger-collision check.
- **Registration:** new paragraph in `primitive-routing.md` "What Each Primitive Was Designed For" + Routing Test bullet.
- **Plugin manifest:** `AGENTS.md` plugin-table update; `build` plugin version bump `0.19.0` → `0.20.0` (MINOR per CONTRIBUTING — two new skills).

## Audit state

- `/build:check-skill-pair help-skill` — 0 fail, 0 warn, 0 info
- `/build:check-skill` on both halves — 0 findings each
- `/build:check-python-script` on both helper scripts — clean (ruff `format` + `check` pass)

## Test plan

- [ ] After merge, run `/build:build-help-skill build` and verify `/build:help` renders cleanly.
- [ ] Run `/build:check-help-skill build` against the just-built help-skill.
- [ ] Repeat for `wiki`, `work`, `consider`.
- [ ] Confirm `/<plugin>:help` is invocable as a slash command.

## Out of scope (separate issues)

- A `UserPromptSubmit` hook that force-injects help on every prompt (defer per #378).
- A global cross-plugin router skill (per-plugin scoping is intentional; cross-plugin discovery is in `AGENTS.md`).
- Generating common-workflow chains automatically (judgment, kept curated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)