### PR TITLE
feat(security-scan): pre-commit hook + check-skill scanner integration (no LLM by default)

### DIFF
--- a/.github/scripts/precommit-scan-skills.sh
+++ b/.github/scripts/precommit-scan-skills.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# precommit-scan-skills.sh — run cisco-ai-skill-scanner against the
+# skill directories that contain staged changes. Static analyzers only
+# (no --use-llm), so the hook is fast, deterministic, and does not need
+# an API key.
+#
+# Pre-commit framework passes the staged file list as positional args.
+# This script maps each file to its parent skill directory
+# (plugins/<plugin>/skills/<skill>/), dedupes, and scans each one.
+#
+# Usage (direct):
+#   ./precommit-scan-skills.sh plugins/build/skills/check-skill/SKILL.md ...
+#
+# Usage (via pre-commit framework): wired through .pre-commit-config.yaml
+# with files: '^plugins/[^/]+/skills/[^/]+/'.
+#
+# Dependencies: skill-scanner (cisco-ai-skill-scanner==2.0.9), bash 4.0+.
+#
+# Exit codes:
+#   0   no in-scope files, or scan clean (no HIGH+ findings)
+#   1   one or more skills have HIGH or CRITICAL findings
+#   2   scanner not installed or other misconfiguration
+
+set -euo pipefail
+
+PROGNAME="$(basename "${0}")"
+readonly PROGNAME
+
+# Regex matching a path inside a skill directory. Capture group 1 is the
+# skill directory itself (plugins/<plugin>/skills/<skill>).
+readonly SKILL_PATH_RE='^(plugins/[^/]+/skills/[^/]+)/'
+
+die() {
+  printf '%s: error: %s\n' "${PROGNAME}" "$*" >&2
+  exit 2
+}
+
+extract_skill_dirs() {
+  local file
+  for file in "$@"; do
+    if [[ "${file}" =~ ${SKILL_PATH_RE} ]]; then
+      printf '%s\n' "${BASH_REMATCH[1]}"
+    fi
+  done | sort -u
+}
+
+scan_one() {
+  local skill_dir="$1"
+  if [[ ! -d "${skill_dir}" ]]; then
+    # Skill was deleted in this commit; nothing to scan.
+    return 0
+  fi
+  printf '\n=== Scanning %s ===\n' "${skill_dir}"
+  skill-scanner scan "${skill_dir}" \
+    --format summary \
+    --fail-on-severity high
+}
+
+main() {
+  if ! command -v skill-scanner >/dev/null 2>&1; then
+    die "skill-scanner not found on PATH. Install with: pip install cisco-ai-skill-scanner==2.0.9"
+  fi
+
+  local skill_dirs
+  skill_dirs="$(extract_skill_dirs "$@")"
+
+  if [[ -z "${skill_dirs}" ]]; then
+    return 0
+  fi
+
+  local failed=0
+  local skill_dir
+  while IFS= read -r skill_dir; do
+    if ! scan_one "${skill_dir}"; then
+      failed=1
+    fi
+  done <<<"${skill_dirs}"
+
+  if [[ "${failed}" -ne 0 ]]; then
+    printf '\n%s: HIGH or CRITICAL findings detected.\n' "${PROGNAME}" >&2
+    printf 'Fix the findings, or bypass intentionally with: git commit --no-verify\n' >&2
+    exit 1
+  fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+# Pre-commit hooks for toolkit. Bootstrap once per clone:
+#   pip install pre-commit
+#   pre-commit install
+#
+# Run on demand without committing:
+#   pre-commit run --all-files
+#   pre-commit run skill-security-scan --all-files
+repos:
+  - repo: local
+    hooks:
+      - id: skill-security-scan
+        name: Skill security scan (cisco-ai-skill-scanner, no LLM)
+        description: >-
+          Run static skill-scanner analyzers against any plugins/<plugin>/skills/<skill>/
+          directory containing staged changes. Fails on HIGH or CRITICAL findings.
+          Does not call the LLM analyzer — fast, offline, no API key required.
+        entry: .github/scripts/precommit-scan-skills.sh
+        language: script
+        files: '^plugins/[^/]+/skills/[^/]+/'
+        require_serial: true
+        pass_filenames: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,28 @@ python -m pytest plugins/wiki/tests/ plugins/check/tests/ -v
 ruff check plugins/
 ```
 
-A pre-commit hook runs `ruff check plugins/` on staged Python files.
-Requires ruff to be installed (`pip install ruff` or via `.[dev]`).
+### Pre-commit hooks
+
+Bootstrap once per clone:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Hooks defined in `.pre-commit-config.yaml`:
+
+- **`skill-security-scan`** — runs `cisco-ai-skill-scanner` (static analyzers
+  only, no LLM) against any `plugins/<plugin>/skills/<skill>/` directory with
+  staged changes. Fails the commit on HIGH or CRITICAL findings. Requires
+  `pip install cisco-ai-skill-scanner==2.0.9`.
+
+Run on demand without committing:
+
+```bash
+pre-commit run --all-files                      # every hook, every file
+pre-commit run skill-security-scan --all-files  # one hook, every file
+```
 
 ## Versioning (SemVer)
 

--- a/plugins/build/skills/check-skill/SKILL.md
+++ b/plugins/build/skills/check-skill/SKILL.md
@@ -44,14 +44,21 @@ doc changes, the dimensions should follow.
 
 ## Prerequisites
 
-- Seven Tier-1 scripts under `scripts/` relative to this SKILL.md
+- Eight Tier-1 scripts under `scripts/` relative to this SKILL.md
   (`check_identity.sh`, `check_frontmatter.sh`, `check_structure.sh`,
   `check_size.sh`, `check_prose.sh`, `scan_secrets.sh`,
-  `scan_dangerous_patterns.sh`)
-- `bash` 3.2+, POSIX utilities (`awk`, `find`, `basename`, `head`,
-  `grep`, `dirname`)
+  `scan_dangerous_patterns.sh`, `scan_cisco.py`)
+- `bash` 3.2+, `python3` 3.9+, POSIX utilities (`awk`, `find`,
+  `basename`, `head`, `grep`, `dirname`)
 - Optional: `gitleaks` on `PATH` for stronger secret scanning
   (`scan_secrets.sh` falls back to a built-in regex set when absent)
+- Optional: `skill-scanner` on `PATH` for the Cisco AI skill-scanner
+  Tier-1 dimension (`scan_cisco.py` emits a single INFO line and
+  exits 0 when absent — install via
+  `pip install --require-hashes -r .github/scripts/requirements.lock`)
+- Optional: `SCAN_USE_LLM=1` (or `--llm` when invoking the script
+  directly) routes the scanner's LLM analyzer too; requires
+  `ANTHROPIC_API_KEY` in env
 - `$ARGUMENTS` may carry a `SKILL.md` path, a `skills/` directory, or
   be empty (scans the current plugin's `skills/` excluding
   `_shared/`)
@@ -63,7 +70,7 @@ doc changes, the dimensions should follow.
    it (excluding `_shared/`). Empty → scan the current plugin's
    `skills/` directory. Report: "Found N skills. Auditing...".
 
-2. **Run Tier-1 deterministic checks.** Invoke all seven scripts
+2. **Run Tier-1 deterministic checks.** Invoke all eight scripts
    against the discovered skill set. Scripts live in `scripts/`
    relative to this SKILL.md; Claude resolves the absolute path from
    the skill's base directory at invocation time. (`$CLAUDE_PLUGIN_ROOT`
@@ -74,14 +81,20 @@ doc changes, the dimensions should follow.
    SCRIPTS="${SKILL_DIR}/scripts"
    TARGETS="$ARGUMENTS"  # path(s) from user; default: plugin's skills/
 
-   bash "$SCRIPTS/check_identity.sh"          $TARGETS
-   bash "$SCRIPTS/check_frontmatter.sh"       $TARGETS
-   bash "$SCRIPTS/check_structure.sh"         $TARGETS
-   bash "$SCRIPTS/check_size.sh"              $TARGETS
-   bash "$SCRIPTS/check_prose.sh"             $TARGETS
-   bash "$SCRIPTS/scan_secrets.sh"            $TARGETS
-   bash "$SCRIPTS/scan_dangerous_patterns.sh" $TARGETS
+   bash    "$SCRIPTS/check_identity.sh"          $TARGETS
+   bash    "$SCRIPTS/check_frontmatter.sh"       $TARGETS
+   bash    "$SCRIPTS/check_structure.sh"         $TARGETS
+   bash    "$SCRIPTS/check_size.sh"              $TARGETS
+   bash    "$SCRIPTS/check_prose.sh"             $TARGETS
+   bash    "$SCRIPTS/scan_secrets.sh"            $TARGETS
+   bash    "$SCRIPTS/scan_dangerous_patterns.sh" $TARGETS
+   python3 "$SCRIPTS/scan_cisco.py"              $TARGETS  # CRITICAL/HIGH → FAIL; MEDIUM → WARN; LOW/INFO → INFO
    ```
+
+   The `scan_cisco.py` step runs static analyzers only by default. If
+   the user asks for the LLM analyzer too, prepend `SCAN_USE_LLM=1`
+   to the invocation (or pass `--llm` directly). LLM mode requires
+   `ANTHROPIC_API_KEY` in env and is slower / costlier — opt-in only.
 
    Emit all Tier-1 output immediately, before any LLM work. Exit
    codes: 0 on clean / WARN-only / INFO-only, 1 on FAIL, 64 on arg
@@ -93,8 +106,9 @@ doc changes, the dimensions should follow.
 3. **Apply orchestration rules.** Skills with a FAIL from
    `check_identity.sh`, `check_frontmatter.sh`, `check_structure.sh`
    (missing required section or Steps-not-ordered-list),
-   `check_size.sh` (>400 lines), or `scan_secrets.sh` are **excluded
-   from Tier 2** — malformed skills don't reach the LLM step.
+   `check_size.sh` (>400 lines), `scan_secrets.sh`, or
+   `scan_cisco.py` (scanner CRITICAL/HIGH) are **excluded from
+   Tier 2** — malformed or unsafe skills don't reach the LLM step.
    `check_structure.sh` WARNs (Examples-without-fenced-block,
    non-sequential Steps), `check_size.sh` WARNs (>300 lines, line
    length), `check_prose.sh` WARNs, and `scan_dangerous_patterns.sh`
@@ -157,6 +171,15 @@ doc changes, the dimensions should follow.
   the script's install hint; re-run once the dependency is on PATH.
   `gitleaks` absence specifically triggers the fallback regex path
   in `scan_secrets.sh` — not a hard failure.
+- **Skill scanner not installed.** `scan_cisco.py` emits a single
+  INFO line with the install command and exits 0; the rest of the
+  audit continues. Recovery: install per Prerequisites, or rely on
+  the CI `Skill Security Audit Scan` workflow for the authoritative
+  pass.
+- **`--llm` requested without `ANTHROPIC_API_KEY`.** `scan_cisco.py`
+  exits 64 with a one-line message naming the missing env var.
+  Recovery: export the key, or omit the LLM mode (default static
+  analyzers cover most rules).
 - **`$ARGUMENTS` path does not exist.** Any script exits 64.
   Recovery: report the bad path and ask the user to correct it.
 - **No structurally valid skills for Tier 2.** Every audited skill

--- a/plugins/build/skills/check-skill/scripts/scan_cisco.py
+++ b/plugins/build/skills/check-skill/scripts/scan_cisco.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""scan_cisco.py — Tier-1 wrapper around cisco-ai-skill-scanner.
+
+Maps each input path to its parent skill directory and runs the
+scanner once per dir. Static analyzers only by default. Pass --llm
+(or set SCAN_USE_LLM=1) to add the LLM analyzer; that path requires
+ANTHROPIC_API_KEY in the environment.
+
+Severity mapping (canonical):
+  CRITICAL / HIGH -> FAIL  (excludes the skill from Tier-2)
+  MEDIUM          -> WARN
+  LOW / INFO      -> INFO
+
+Soft-fail when scanner missing: emits one INFO line and exits 0, so
+/build:check-skill remains runnable on a fresh clone without the
+~5GB scanner dependency tree.
+
+Usage:
+  scan_cisco.py <SKILL.md | skills/dir | file-under-skill> [...]
+  scan_cisco.py --llm plugins/wiki/skills/lint/SKILL.md
+
+Exit codes:
+  0   no FAIL findings (or scanner not installed)
+  1   one or more CRITICAL/HIGH findings
+  64  bad arguments or --llm without API key
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+INSTALL_HINT = (
+    "pip install cisco-ai-skill-scanner==2.0.9 "
+    "(or: pip install --require-hashes -r .github/scripts/requirements.lock)"
+)
+
+SEVERITY_TO_TIER1 = {
+    "CRITICAL": "FAIL",
+    "HIGH": "FAIL",
+    "MEDIUM": "WARN",
+    "LOW": "INFO",
+    "INFO": "INFO",
+}
+
+
+def emit(severity: str, path: str, check: str, detail: str, rec: str) -> None:
+    print(f"{severity}  {path} — {check}: {detail}")
+    print(f"  Recommendation: {rec}")
+
+
+def discover_skill_dirs(paths: list[str]) -> list[Path]:
+    """Resolve each input to its parent skill directory.
+
+    Accepts a SKILL.md path, a directory containing skills, or any
+    file living under a skill directory. Skips _shared/ trees.
+    """
+    dirs: set[Path] = set()
+    for raw in paths:
+        p = Path(raw)
+        if not p.exists():
+            print(f"scan_cisco.py: path not found: {raw}", file=sys.stderr)
+            sys.exit(64)
+        if "_shared" in p.parts:
+            continue
+        if p.is_file() and p.name == "SKILL.md":
+            dirs.add(p.parent)
+        elif p.is_dir():
+            for skill_md in p.rglob("SKILL.md"):
+                if "_shared" in skill_md.parts:
+                    continue
+                dirs.add(skill_md.parent)
+        elif p.is_file():
+            for parent in p.parents:
+                if (parent / "SKILL.md").exists():
+                    dirs.add(parent)
+                    break
+    return sorted(dirs)
+
+
+def run_scanner(skill_dir: Path, use_llm: bool) -> dict:
+    cmd = ["skill-scanner", "scan", str(skill_dir), "--format", "json"]
+    if use_llm:
+        cmd.append("--use-llm")
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if not proc.stdout.strip():
+        return {}
+    return json.loads(proc.stdout)
+
+
+def map_finding(
+    finding: dict, skill_dir: Path
+) -> tuple[str, str, str, str, str] | None:
+    sev = finding.get("severity", "").upper()
+    tier1 = SEVERITY_TO_TIER1.get(sev)
+    if tier1 is None:
+        return None
+    rule = finding.get("rule_id", "scanner")
+    title = finding.get("title") or finding.get("description") or "scanner finding"
+    file_rel = finding.get("file_path") or ""
+    line = finding.get("line_number")
+    path = f"{skill_dir}/{file_rel}" if file_rel else str(skill_dir)
+    detail = f"[{rule}] {title}"
+    if line:
+        detail = f"{detail} (line {line})"
+    rec = finding.get("remediation") or "See `skill-scanner` rule docs."
+    return tier1, path, "Skill scanner", detail, rec
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="scan_cisco.py",
+        description="Tier-1 wrapper around cisco-ai-skill-scanner.",
+    )
+    parser.add_argument(
+        "paths",
+        nargs="+",
+        help="SKILL.md paths, skills/ directories, or files under a skill dir.",
+    )
+    parser.add_argument(
+        "--llm",
+        action="store_true",
+        default=os.environ.get("SCAN_USE_LLM") == "1",
+        help="Include the LLM analyzer (requires ANTHROPIC_API_KEY in env).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        return _main(argv)
+    except KeyboardInterrupt:
+        return 130
+
+
+def _main(argv: list[str] | None) -> int:
+    args = parse_args(argv)
+
+    if shutil.which("skill-scanner") is None:
+        emit(
+            "INFO",
+            "(scanner)",
+            "Skill scanner",
+            "skill-scanner not installed; Tier-1 scanner audit skipped",
+            f"Install with: {INSTALL_HINT}",
+        )
+        return 0
+
+    if args.llm and not (
+        os.environ.get("ANTHROPIC_API_KEY")
+        or os.environ.get("SKILL_SCANNER_LLM_API_KEY")
+    ):
+        print(
+            "scan_cisco.py: --llm requested but ANTHROPIC_API_KEY is not set",
+            file=sys.stderr,
+        )
+        return 64
+
+    skill_dirs = discover_skill_dirs(args.paths)
+    if not skill_dirs:
+        return 0
+
+    any_fail = False
+    for skill_dir in skill_dirs:
+        try:
+            data = run_scanner(skill_dir, args.llm)
+        except (OSError, json.JSONDecodeError) as exc:
+            emit(
+                "WARN",
+                str(skill_dir),
+                "Skill scanner",
+                f"scanner invocation failed: {exc}",
+                "Re-run skill-scanner manually and inspect output.",
+            )
+            continue
+        for finding in data.get("findings", []):
+            mapped = map_finding(finding, skill_dir)
+            if mapped is None:
+                continue
+            sev, *rest = mapped
+            emit(sev, *rest)
+            if sev == "FAIL":
+                any_fail = True
+    return 1 if any_fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Two complementary slices of the cisco-ai-skill-scanner rollout:

1. **Pre-commit hook** — `.pre-commit-config.yaml` + `.github/scripts/precommit-scan-skills.sh`. Scans only the `plugins/<plugin>/skills/<skill>/` directories with staged changes. Static analyzers only. Fails commit on HIGH/CRITICAL.
2. **`/build:check-skill` Tier-1 integration** — new `scripts/scan_cisco.py` invoked alongside the seven existing Tier-1 scripts. Severity map: CRITICAL/HIGH → FAIL (excludes from Tier-2), MEDIUM → WARN, LOW/INFO → INFO. `--llm` (or `SCAN_USE_LLM=1`) opts into the LLM analyzer; default is static-only.

Complementary to the existing CI gate (`skill-audit-scan.yml`), which keeps `--use-llm` and remains authoritative.

## Design notes

- **Granularity** (precommit): scopes to changed *skill dirs*, not whole plugins. Two staged files in the same skill dedupe to one scan.
- **Granularity** (check-skill): one scanner call per skill dir; supports SKILL.md path, skills/ directory, or any file under a skill dir.
- **Failure threshold**: HIGH (matches CI) — `--fail-on-severity high` in precommit; severity-mapping in `scan_cisco.py`.
- **LLM mode**: off by default everywhere. Enable per-invocation via `--llm` or `SCAN_USE_LLM=1`. Requires `ANTHROPIC_API_KEY`; emits a clean error and exits 64 when missing.
- **Soft-fail when scanner missing**: `scan_cisco.py` emits one INFO line and exits 0 — keeps `/build:check-skill` runnable on a fresh clone without the ~5GB scanner dependency tree.
- **Tier-2 exclusion**: scanner CRITICAL/HIGH joins the existing list (`check_identity`, `check_frontmatter`, `check_structure`, `check_size`, `scan_secrets`) that excludes a skill from the LLM rubric.

## Self-audit

- `/build:check-bash-script .github/scripts/precommit-scan-skills.sh` → 0 fail, 0 warn, 0 info
- `/build:check-python-script plugins/build/skills/check-skill/scripts/scan_cisco.py` → 0 fail, 0 warn, 0 info
- Full 8-script Tier-1 sweep on `check-skill/SKILL.md` itself → clean (one expected INFO from `PIPELINE_TAINT_FLOW` teaching content in `repair-playbook.md`)
- Pre-commit hook ran on this branch's commits — passed

## Severity mapping (canonical)

| Scanner | check-skill | Excludes from Tier-2 |
|---|---|---|
| CRITICAL | FAIL | yes |
| HIGH | FAIL | yes |
| MEDIUM | WARN | no |
| LOW | INFO | no |
| INFO | INFO | no |

## Scope diverges from #395

The original #395 plan included a checked-in `policy/skill-scan-baseline.json` for fingerprint-based LOW/INFO suppression. This PR ships without it — current LOW/INFO findings emit directly. Baseline machinery can be added later if noise becomes a problem; meanwhile the LOW/INFO surface is small (single PIPELINE_TAINT_FLOW from teaching content). Issue #395 stays open for follow-on baseline work if needed.

## Test plan

- [x] `pre-commit run skill-security-scan --files <skill files>` — Passed
- [x] `pre-commit run skill-security-scan --files README.md` — Skipped (no files to check)
- [x] Two files in same skill dir → deduped to one scan
- [x] Non-existent skill path in args → skipped without error
- [x] `python3 .../scan_cisco.py --help` exits 0 with usage
- [x] `python3 .../scan_cisco.py <clean-skill>` → exit 0, no output
- [x] `python3 .../scan_cisco.py <noisy-skill>` → emits INFO finding, exit 0 (no HIGH+)
- [x] `python3 .../scan_cisco.py --llm <skill>` without `ANTHROPIC_API_KEY` → exit 64 with clear message
- [x] Soft-fail path simulated (uninstalled scanner) — emits INFO, exit 0
- [x] Tier-1 bash audit clean (precommit script)
- [x] Tier-1 python audit clean (scan_cisco.py)
- [ ] CI `Skill Security Audit Scan` workflow still passes against this branch
- [ ] Reviewer runs `pre-commit install && git commit` against a real change to confirm end-to-end UX
- [ ] Reviewer runs `/build:check-skill` interactively in Claude Code and confirms scanner output appears alongside other Tier-1 output

🤖 Generated with [Claude Code](https://claude.com/claude-code)