### PR TITLE
refactor(check-skill-chain): align Manifest mode with the unified pattern (minimal)

### DIFF
--- a/plugins/build/_shared/references/check-skill-pattern.md
+++ b/plugins/build/_shared/references/check-skill-pattern.md
@@ -199,6 +199,19 @@ Three skills warrant separate handling because they may not have detection scrip
 
 Skills wrapping external linters follow `check_shellcheck.py`'s shape: SC-code-to-rule_id mapping dict + per-rule recipe constants. Examples: `check-makefile` (`checkmake`), `check-python-script` (`ruff`), `check-pre-commit-config` (`pre-commit`), `check-github-workflow` (`actionlint`/`zizmor`).
 
+## Carve-Out: Design+Audit Hybrid Skills
+
+Some `check-*` skills are **hybrids** — part design tool (generates a new artifact from a goal), part audit tool (validates an existing artifact). `check-skill-chain` is the canonical example: Goal mode designs a `*.chain.md` manifest from a workflow description; Manifest mode audits an existing manifest. Only the audit half fits this pattern.
+
+For these skills:
+
+- **The pattern applies to the audit half only.** Decompose its dimensions into `references/check-*.md` files; structure the audit-mode workflow as Tier-1/Tier-2/Tier-3; include the Evaluator policy subsection.
+- **The design half stays unchanged.** Keep its existing prose in SKILL.md as a parallel section. Do not force it into the Tier-1/2/3 vocabulary — it is not auditing anything.
+- **Cross-plugin tool delegation is allowed at Tier-1.** A skill can delegate structural checks to a script in another plugin (e.g., `check-skill-chain` invokes `plugins/wiki/scripts/lint.py`) when that script is the canonical authority for the artifact type. Do **not** wrap it in a thin local script just to satisfy "scripts/check_*.py owned by this skill" — duplication for compliance is the wrong tradeoff. SKILL.md documents the delegation explicitly so future readers see the reuse, not a missing script.
+- **`scripts/_common.py` is optional** when no detection scripts are owned locally. The pattern audit script (`check_skill_pattern.py`) already treats `_common.py` as conditional on `_has_detection_scripts(skill_dir)`.
+
+When a hybrid skill emerges that this carve-out doesn't cover, extend this section rather than weakening the main pattern.
+
 ## Review and Decay
 
 A `check-*` skill ages when:

--- a/plugins/build/skills/check-skill-chain/SKILL.md
+++ b/plugins/build/skills/check-skill-chain/SKILL.md
@@ -8,26 +8,36 @@ description: >
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob
 argument-hint: "[workflow goal or path/to/manifest.chain.md]"
 user-invocable: true
+references:
+  - references/check-cross-reference.md
 license: MIT
 ---
 
 # Check Skill-Chain
 
-Design a `*.chain.md` manifest from a workflow goal, or check an existing
-skill-chain manifest for structural and contract correctness with an opt-in repair loop.
+Design a `*.chain.md` manifest from a workflow goal (Goal mode), or audit
+an existing manifest for structural and contract correctness (Manifest
+mode). Manifest mode follows the [check-skill
+pattern](../../_shared/references/check-skill-pattern.md)'s
+**design+audit hybrid carve-out** — Goal mode is design-only and outside
+pattern scope; Manifest mode is the audit half and conforms to the
+Tier-1 / Tier-2 / Evaluator-policy structure.
 
-This skill ships **no scripts of its own**. `scripts/lint.py` referenced
-in Manifest mode below is the plugin-shared script at
-`plugins/wiki/scripts/lint.py` (same script `/wiki:lint` invokes).
-Inputs are validated by argparse; the script does not call subprocess
-with `shell=True` or take untrusted command strings.
+This skill ships **no scripts of its own**. The Tier-1 structural lint
+delegates to `plugins/wiki/scripts/lint.py` (same script `/wiki:lint`
+invokes) — that's the canonical authority for chain-manifest
+structure. Cross-plugin tool delegation is allowed at Tier-1 per the
+pattern's hybrid carve-out; we do not wrap `lint.py` in a thin local
+script just to satisfy "scripts/check_*.py owned by this skill".
+Inputs are validated by argparse; the wrapped script does not call
+subprocess with `shell=True` or take untrusted command strings.
 
 ## Workflow
 
 ### Detect Mode
 
-- **Argument is a path to a `*.chain.md` file** → **Manifest mode**
-- **No argument, or free-text goal** → **Goal mode**
+- **Argument is a path to a `*.chain.md` file** → **Manifest mode** (audit)
+- **No argument, or free-text goal** → **Goal mode** (design)
 
 ### Goal Mode
 
@@ -46,44 +56,85 @@ with `shell=True` or take untrusted command strings.
 4. **Hard gate** — present for user review. State: "This is a design artifact — invoke
    `/work:start-work` or run each skill manually to execute." Do not invoke any step.
 
-### Manifest Mode
+### Manifest Mode (audit)
 
-1. **Structural checks** — run `scripts/lint.py --root <project-root> --no-urls` and
-   extract chain findings for the target manifest. Surface structural failures before
-   cross-reference (fast fail first). If `parse_chain()` raises on a malformed manifest,
-   report it as a `fail` finding and continue — do not crash.
-2. **Cross-reference check** — for each step: read the referenced SKILL.md body; assess
-   whether the declared `output_contract` is plausible given what the skill actually
-   produces. Flag mismatches as `warn` (not `fail`).
-3. **Findings table** — present all findings:
-   ```
-   | File | Issue | Severity |
-   |------|-------|----------|
-   ```
-   Summary line: `N fail, N warn`. Sort: fail before warn; structural before cross-reference.
-4. **Repair loop** — ask: "Apply fixes? Enter y (all), n (skip), or comma-separated numbers."
-   For each selected finding:
-   - Manifest fix: propose targeted edit, show diff, apply on confirmation
-   - SKILL.md fix: propose targeted edit, show diff, apply on confirmation
-   - Missing skill (step references a skill that doesn't exist): invoke `/build:build-skill`
-     inline to create it, then re-check existence
-5. **Re-verify** — after each applied fix, re-run `scripts/lint.py` and re-run
-   cross-reference on affected steps. Return to findings presentation.
-6. **Exit** — when all findings are resolved or user declines remaining fixes:
-   "Skill-chain manifest is well-formed — 0 issues found."
+#### Tier-1: Deterministic structural checks (delegated)
+
+Run `python3 plugins/wiki/scripts/lint.py --root <project-root>
+--no-urls` and extract findings whose `path` matches the target
+manifest. The wiki lint covers five structural dimensions of every
+chain manifest: skills exist on disk, contracts are declared per step,
+gates appear on consequential steps, a termination condition is
+present, and there are no cycles. **Do not re-implement these checks
+locally** — `lint.py` is the canonical authority.
+
+If `parse_chain()` raises on a malformed manifest, report it as a
+`fail` finding and continue. Do not crash.
+
+`lint.py` emits findings in the wiki linter's table format, not the
+JSON envelope shape the broader pattern uses. That's acceptable here
+because the lint is a cross-plugin shared tool with its own consumers
+(e.g., `/wiki:lint`) — translating its output into envelope shape is
+out of scope for this skill.
+
+#### Tier-2: Judgment dimension
+
+For each step in the manifest, evaluate against
+[references/check-cross-reference.md](references/check-cross-reference.md):
+read the step's referenced SKILL.md body; assess whether the declared
+`output_contract` is plausible given what the skill actually produces.
+Mismatches are always `warn` — never `fail` — because the user (not
+the audit) decides whether the manifest's contract or the SKILL.md's
+output is the source of truth.
+
+##### Evaluator policy
+
+- **Single locked-rubric pass per artifact.** Read `check-cross-reference.md` first, then evaluate every step in the manifest against it. Don't re-decompose into sub-checks (RULERS, Hong et al. 2026).
+- **Default-closed when borderline.** When evidence is ambiguous, return `warn`, not `pass`.
+- **Severity floor: WARN.** Cross-reference findings are coaching, not blocking. Escalate to FAIL only for safety concerns Tier-1 missed (extremely unusual for a chain manifest — typically not applicable).
+- **One finding per step maximum.** If a step has multiple discrepancies (shape and detail and naming), surface the highest-signal one with concrete excerpts from both sides. Bulk findings train the user to disregard the audit.
+
+#### Tier-3: Cross-entity collision
+
+A chain manifest is a single artifact; multi-manifest collision is
+out of scope. Tier-3 returns `inapplicable` silently for this skill.
+
+#### Report
+
+Merge Tier-1 (lint.py) and Tier-2 (cross-reference) findings into a
+unified table:
+
+```
+| File | Issue | Severity |
+|------|-------|----------|
+```
+
+Summary line: `N fail, N warn`. Sort: `fail` before `warn`; Tier-1 (structural) before Tier-2 (cross-reference) within the same severity.
+
+#### Repair loop
+
+Ask: "Apply fixes? Enter y (all), n (skip), or comma-separated numbers."
+
+For each selected finding:
+- **Tier-1 manifest fix** — propose targeted edit, show diff, apply on confirmation.
+- **Tier-1 missing-skill** — step references a SKILL.md that doesn't exist. Invoke `/build:build-skill` inline to create it, then re-run `lint.py` to confirm.
+- **Tier-2 contract drift** — read the finding's `recommended_changes` field. The fix may be in the manifest (most common — its contract was speculative) or in the SKILL.md (the actual output evolved). Propose targeted edit, show diff, apply on confirmation.
+
+After each applied fix, re-run the relevant Tier (1 or 2) on the
+affected scope. Return to the findings table.
+
+Exit when all findings are resolved or the user declines remaining
+fixes: "Skill-chain manifest is well-formed — 0 issues found."
 
 ## Anti-Pattern Guards
 
-1. **Cross-reference before structural checks** — `scripts/lint.py` runs first, always;
-   surface structural failures before LLM judgment
-2. **Bulk repair without per-change confirmation** — each fix requires separate confirmation;
-   never apply more than one change without a confirmation step between them
-3. **Executing the skill-chain in goal mode** — goal mode produces a design artifact only; the
-   hard gate must be stated explicitly before exiting
-4. **Treating cross-reference mismatches as fail** — cross-reference findings are `warn`;
-   the user decides whether the contract or the SKILL.md needs updating
-5. **Crashing on malformed manifest** — if parsing fails, report as a `fail` finding and
-   continue; partial or incomplete manifests produce findings, not errors
+1. **Tier-2 before Tier-1** — `wiki/lint.py` runs first, always; surface structural failures before judgment. A manifest that doesn't parse cleanly cannot be cross-referenced productively.
+2. **Bulk repair without per-change confirmation** — each fix requires separate confirmation; never apply more than one change without a confirmation step between them.
+3. **Executing the skill-chain in Goal mode** — Goal mode produces a design artifact only; the hard gate must be stated explicitly before exiting.
+4. **Treating cross-reference mismatches as `fail`** — Tier-2 findings are `warn`; the user decides whether the contract or the SKILL.md needs updating.
+5. **Crashing on malformed manifest** — if parsing fails, report as a `fail` finding and continue; partial or incomplete manifests produce findings, not errors.
+6. **Re-implementing `lint.py`'s structural checks locally** — the wiki lint is the canonical authority for chain-manifest structure. Wrap it, don't duplicate it.
+7. **Embellishing the cross-reference rule's `recommended_changes`** — the recipe in `check-cross-reference.md` is the canonical guidance. When generating per-finding `recommended_changes`, ground it in the rule's "How to apply" — name the discrepancy, name both sides, suggest a fix. Don't paraphrase the rule body itself.
 
 ## Handoff
 

--- a/plugins/build/skills/check-skill-chain/references/check-cross-reference.md
+++ b/plugins/build/skills/check-skill-chain/references/check-cross-reference.md
@@ -1,0 +1,42 @@
+---
+name: Cross-Reference Plausibility
+description: Each step's declared `output_contract` is plausible given the actual output the referenced SKILL.md produces.
+paths:
+  - "**/*.chain.md"
+---
+
+For every step in a `*.chain.md` manifest, the declared `output_contract` must be plausible given what the referenced SKILL.md actually produces. Mismatches surface as `warn` findings — never `fail`.
+
+**Why:** structural lint (delegated to `plugins/wiki/scripts/lint.py`) verifies the manifest is well-formed — skills exist, contracts are declared, gates appear on consequential steps, no cycles. What it cannot verify is whether the *content* of each step's contract matches reality. A step may declare `output_contract: returns a list of validated URLs` while the underlying SKILL.md actually produces a markdown report with embedded URLs. The chain still parses, but the next step's `input_contract` will fail to resolve at execution time. Cross-reference catches this drift between declared and actual contracts before runtime surprises.
+
+**How to apply:** for each step in the manifest:
+
+1. Read the referenced SKILL.md's `## Handoff` (or equivalent) section. Note what the skill actually produces — file types, data structures, side effects, key claims about output.
+2. Compare against the step's declared `output_contract`. Look for: (a) shape mismatches (claims to return data when the skill writes a file); (b) missing-detail mismatches (claims a vague "report" when the SKILL.md produces a specific structured artifact, or vice versa); (c) outright contradictions (different file extensions, different data types).
+3. Surface mismatches as `warn` findings. Severity is **always WARN** — the user decides whether the manifest's contract or the SKILL.md's actual output is the source of truth. Both editing directions are valid; the audit's job is to flag the discrepancy, not to adjudicate.
+4. Be specific in `recommended_changes`: name the discrepancy, name both sides ("manifest says X; SKILL.md says Y"), and suggest the most likely fix (usually the manifest, since it was written second).
+
+```markdown
+# Example: a manifest step with a mismatched contract
+
+## Steps
+
+| Step | Skill | Input Contract | Output Contract | Gate |
+|---|---|---|---|---|
+| 1 | /wiki:research | a topic | a list of citations | none |
+
+# The referenced /wiki:research SKILL.md actually produces
+# a research document at .research/<date>-<slug>.research.md.
+# A list of citations is part of that document, but not the
+# whole output. Surface as WARN — the manifest's contract is
+# under-specified.
+```
+
+**Common fail signals (audit guidance):**
+
+- Step's `output_contract` says "list of <items>" when the SKILL.md's Handoff says it writes a file (artifact-vs-data shape mismatch).
+- Step's `output_contract` is wildly more specific than the SKILL.md describes (over-claiming).
+- Step's `output_contract` is wildly more vague than the SKILL.md describes (under-claiming — usually fixable by inheriting the SKILL.md's wording).
+- Step references a SKILL.md that doesn't exist — this is a **structural** failure caught by `wiki/lint.py` Tier-1, not by this judgment rule. If lint.py missed it, escalate as a Tier-1 bug, not a Tier-2 finding.
+
+**Exception:** when the SKILL.md's output is intentionally generic (e.g., "produces structured findings — shape varies by primitive") and the manifest specializes it, the specialization is fine. Surface as `pass`. The audit's purpose is catching drift, not enforcing prose conformity.


### PR DESCRIPTION
## Summary

First skill in sweep #408. Brings `check-skill-chain` into pattern compliance per the **design+audit hybrid carve-out** (added to `check-skill-pattern.md` in this PR). Goal mode (design tool) is untouched; Manifest mode (audit tool) gets the Tier-1 / Tier-2 / Evaluator-policy treatment.

- **Pattern doc carve-out** (`64af6f1`) — adds a \"Carve-Out: Design+Audit Hybrid Skills\" section to `check-skill-pattern.md`. Names four flexibility points: pattern applies to audit half only; design half stays in SKILL.md as parallel prose; cross-plugin tool delegation is allowed at Tier-1 (e.g., `wiki/lint.py`); `_common.py` is optional when no scripts are owned locally.
- **Skill alignment** (`75c1775`) — adds `references/check-cross-reference.md` (the one Tier-2 judgment dimension), restructures Manifest mode using Tier-1 / Tier-2 vocabulary, adds the Evaluator policy subsection, expands Anti-Pattern Guards to flag duplication and contract-drift edge cases.

### Why minimal alignment, not full pattern compliance

`check-skill-chain` is fundamentally different from `check-bash-script`:

- It has **two modes**: Goal mode (designs new manifests — generative, not audit) and Manifest mode (audits existing manifests).
- Manifest mode delegates **all** Tier-1 structural checks to `plugins/wiki/scripts/lint.py`, the canonical authority for `*.chain.md` structure (5 dimensions: skills exist, contracts declared, gates on consequential steps, termination condition, no cycles).
- It owns **zero** detection scripts locally.
- It has effectively **one** judgment dimension (cross-reference plausibility).

Force-fitting the full pattern (wrapping `lint.py` in a local thin script, scaffolding `_common.py` + tests + asset for nothing to use) would create duplication for compliance — the wrong tradeoff. The minimal alignment captures the pattern's value (Tier-1/2/3 vocabulary, judgment-rule shape, evaluator policy) without forcing structural symmetry where it doesn't belong.

### Pattern audit result

\`\`\`
$ python3 plugins/build/_shared/scripts/check_skill_pattern.py \\
    plugins/build/skills/check-skill-chain --human

  ✓ PASS  pattern-no-stale-artifacts
  ✓ PASS  pattern-no-subagent-footprint
  ✓ PASS  pattern-judgment-rule-shape
  ✓ PASS  pattern-output-example-asset    (n/a — no scripts)
  ✓ PASS  pattern-common-py-present        (n/a — no scripts)
  ⚠ WARN  pattern-skill-md-references     (no skill-chain-best-practices.md yet)
  ✓ PASS  pattern-no-rule-overlap

Summary: 6 pass, 1 warn, 0 fail
\`\`\`

The single WARN is structural — `skill-chain-best-practices.md` doesn't exist yet (no canonical \"Why\" doc for chain manifests). Out of scope for minimal alignment; could be authored as a follow-up if/when the convention prose accumulates.

## Test plan

- [ ] Pattern audit script reports `6 pass, 1 warn, 0 fail` for `check-skill-chain`
- [ ] `references/check-cross-reference.md` follows the unified Claude-rule shape (frontmatter `name:` + `description:` + body imperative + Why + How to apply + example + Exception)
- [ ] SKILL.md `references[]` enumerates exactly the new check-cross-reference.md
- [ ] Manifest mode workflow uses Tier-1 / Tier-2 / Evaluator-policy vocabulary; Goal mode prose is unchanged
- [ ] `git diff main...HEAD --stat plugins/` — only `_shared/references/check-skill-pattern.md` and `check-skill-chain/` touched
- [ ] No existing tests regressed (this skill ships none of its own; the test surface is wiki/lint.py + the pattern audit script)
- [ ] Cross-plugin invocation of `wiki/lint.py` still resolves correctly (path is unchanged)

## Follow-ups

- [#408](https://github.com/bcbeidel/toolkit/issues/408) — sweep parent. Next target: `check-skill-pair` (pure-judgment, similar shape).
- Optional: author `plugins/build/_shared/references/skill-chain-best-practices.md` if convention prose for chain authoring accumulates. Would clear the lone WARN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)