### PR TITLE
Scaffolder hygiene: enforce allowed-tools, codify detector-script rules (#396)

### DIFF
--- a/plugins/build/_shared/references/bash-script-best-practices.md
+++ b/plugins/build/_shared/references/bash-script-best-practices.md
@@ -118,6 +118,16 @@ Bash scripts run with the invoker's privileges and reach the filesystem, the net
 
 `eval`, `mktemp`/`trap` pairing, hardcoded `/tmp/` literals, `cd` without exit, GNU-flag detection, and unquoted-variable expansion are audited deterministically (mostly via ShellCheck). The remaining rules rely on author judgment — they live in the audit rubric and code review.
 
+## Detector-Script Pattern Hygiene
+
+A pattern-scanning script — anything that greps source for forbidden constructs and emits findings — has a self-incrimination risk: if its docstring, comments, or regex literals contain the byte sequences it scans for, scanning the scanner produces phantom findings that mask real ones. Two rules contain the risk:
+
+**Paraphrase docstrings, comments, and identifier names.** Describe the detected pattern abstractly, not literally. "Pipe-to-shell installer pattern" beats `curl | sh`; "dynamic-evaluation call" beats the literal `eval`-call form. Apply to every place the description lives — header comment, `usage()` text, error messages emitted via `die`, function names. The shipped `plugins/build/skills/check-makefile/scripts/check_safety.py` line 11 ("pipe-to-shell pattern (curl piped into sh/bash)") is the live example for the paraphrase rule, even though that file is Python — the rule applies identically to bash detectors that use `grep`/`awk` patterns embedded in here-docs or arrays.
+
+**Split or interleave grep / regex literals so the byte sequence is non-contiguous.** When a `grep -E`, `awk`, or `[[ =~ ]]` pattern would otherwise contain the literal bytes being detected, structure it so the scanned bytes do not appear adjacent in source — separator character classes, alternation, or string concatenation via `printf -v` all work. The compiled pattern must stay equivalent. `plugins/build/skills/check-readme/scripts/check_safety.py` lines 55–60 demonstrate the technique (Python regex, but the construction translates: separator `\s[^|]*\|\s*` keeps `curl` and `(sh|bash|zsh)` non-adjacent in source).
+
+The two rules together let a detector script pass its own audit without weakening what it detects. Authors writing a new bash pattern-scanner should reach for both at draft time, not retrofit after the first self-flag.
+
 ## Review and Decay
 
 Bash scripts rot. The platform `bash` moves (especially across macOS-Homebrew and Linux versions), the external CLI tools change flags, the `find`/`xargs`/`grep` flavors diverge between distributions. Retire a script when its automation is no longer invoked, when its logic has migrated into a real tool, or when its exit contract can no longer be trusted. **Convert to a real language when the script grows past ~300 non-blank lines, acquires data structures Bash cannot express, or accumulates control flow Bash cannot debug** — `primitive-routing.md` covers the shell-vs-Python decision. A neglected script is worse than a missing one — callers trust the exit code they have stopped reading.

--- a/plugins/build/_shared/references/python-script-best-practices.md
+++ b/plugins/build/_shared/references/python-script-best-practices.md
@@ -110,6 +110,16 @@ Scripts run with the invoker's privileges and reach the filesystem, the network,
 
 Shell-injection, `eval`/`exec`, and literal `/tmp/` path construction are audited deterministically. The remaining rules rely on author judgment — deterministic detection of "is this input validated enough before the delete?" is infeasible — and live in the authoring rubric and code review.
 
+## Detector-Script Pattern Hygiene
+
+A pattern-scanning script — anything that greps source for forbidden constructs and emits findings — has a self-incrimination risk: if its docstring, comments, or regex literals contain the byte sequences it scans for, scanning the scanner produces phantom findings that mask real ones. Two rules contain the risk:
+
+**Paraphrase docstrings, comments, and identifier names.** Describe the detected pattern abstractly, not literally. "Pipe-to-shell installer pattern" beats `curl | sh`; "dynamic-evaluation call" beats `eval(`. Apply to every place the description lives — module docstring, rule headers, error messages, log lines, function names. The shipped scanners under `plugins/build/skills/check-makefile/scripts/check_safety.py` (line 11: `"pipe-to-shell pattern (curl piped into sh/bash)"`) and `plugins/build/skills/check-bash-script/scripts/check_safety.py` (rule headers in the docstring use backticks around the keyword instead of the literal call form) are the live examples.
+
+**Split or interleave regex literals so the byte sequence is non-contiguous.** When a regex literal would otherwise contain the literal pattern being detected, structure it so the scanned bytes do not appear adjacent in source — separator characters, character classes, or string concatenation all work. The compiled regex must stay byte-equivalent. `plugins/build/skills/check-readme/scripts/check_safety.py` lines 55–60 are the live example: the pipe-to-shell regexes have `\s[^|]*\|\s*` between `curl`/`wget` and `(sh|bash|zsh)`, so the literal `curl | sh` byte sequence never appears in the source.
+
+The two rules together let a detector script pass its own audit without weakening what it detects. Authors writing a new pattern-scanner should reach for both at draft time, not retrofit after the first self-flag.
+
 ## Review and Decay
 
 Scripts rot. The platform `python3` moves, third-party APIs change, the shell environment the script assumed goes away. Retire a script when it stops being invoked, when its functionality migrates into a package or service, or when its exit contract can no longer be trusted. Convert to a package when the single file acquires shared state, multiple entry points, or test coverage heavier than the code itself — single-file discipline breaks down past a threshold, and fighting it produces a worse package than starting one would. A neglected script is worse than a missing one — callers trust the exit code they have stopped checking.

--- a/plugins/build/_shared/references/skill-best-practices.md
+++ b/plugins/build/_shared/references/skill-best-practices.md
@@ -18,6 +18,7 @@ description: Use when <concrete trigger>. <One sentence of purpose.>
 version: 1.0.0
 owner: team-or-person
 license: MIT
+allowed-tools: []
 ---
 
 # <Human-readable title>
@@ -45,9 +46,9 @@ Load-bearing elements: the frontmatter identity (`name`, `description`, `version
 
 **Name for discovery.** The file is `SKILL.md`; the directory basename equals `name`; `name` is lowercase kebab-case matching `^[a-z0-9]+(-[a-z0-9]+)*$`, ≤64 characters, unique across the collection. Names are stable identifiers that routing depends on.
 
-**Write the description as a retrieval signal.** Lead with "Use when…" and enumerate concrete invocation triggers — user phrases, file extensions, error strings, event types. Keep it short; long descriptions dilute the signal.
+**Write the description as a retrieval signal.** Lead with "Use when…" and enumerate concrete invocation triggers — user phrases, file extensions, error strings, event types. **Cap the trigger enumeration at 2–3 phrases.** Long lists dilute retrieval ranking (each extra phrase pulls the embedding toward a broader region) and inflate the always-loaded routing context for every conversation. Pick the highest-leverage phrasings; trust the router on near-synonyms.
 
-**Declare identity in frontmatter.** Ship `name`, `description`, `version` (semver), and `owner`. Version bumps are the cache-busting signal consumers rely on; owner is who gets pinged when the skill rots. Add `license` (SPDX identifier such as `MIT`, or a short reference to a bundled `LICENSE` file) so reusers know the redistribution terms — match the host repo's license unless the skill ships under different terms. Invent no keys the skill spec does not sanction.
+**Declare identity in frontmatter.** Ship `name`, `description`, `version` (semver), `owner`, and `allowed-tools`. Version bumps are the cache-busting signal consumers rely on; owner is who gets pinged when the skill rots. `allowed-tools` is the explicit tool-scope contract — declare it on every skill, even when empty (`allowed-tools: []`), so the routing decision is deliberate rather than default-permissive. Omitting the field lets the skill borrow the agent's full toolset, which is rarely what the workflow needs and never what an auditor wants to discover after the fact. Add `license` (SPDX identifier such as `MIT`, or a short reference to a bundled `LICENSE` file) so reusers know the redistribution terms — match the host repo's license unless the skill ships under different terms. Invent no keys the skill spec does not sanction.
 
 **Keep the body short.** Under 300 lines, hard ceiling 400; lines under 120 characters. Move long scripts and reference material to sibling files. Every line is paid for in context tokens.
 

--- a/plugins/build/skills/build-bash-script/SKILL.md
+++ b/plugins/build/skills/build-bash-script/SKILL.md
@@ -282,6 +282,14 @@ option-parsing commands.
 `shfmt -i 2 -ci -bn` (2-space indent, switch-case indent, binop on
 next line).
 
+**Detector-script hygiene** *(applies to pattern-scanners)*. When the
+draft scans source for forbidden constructs (header naming detect /
+scanner / linter, or destination under `check-*/scripts/`), apply the
+*Detector-Script Pattern Hygiene* rules from
+[bash-script-best-practices.md](../../_shared/references/bash-script-best-practices.md):
+paraphrase docstrings/comments/identifiers and split regex literals so
+the scanned byte sequence is non-contiguous in source.
+
 If any check fails, revise the draft before presenting. The Review
 Gate is for user approval, not correctness recovery.
 

--- a/plugins/build/skills/build-python-script/SKILL.md
+++ b/plugins/build/skills/build-python-script/SKILL.md
@@ -271,6 +271,16 @@ those come from arguments or `os.environ.get()`.
 are declared (PEP 723 block, colocated `requirements.txt`, or
 top-of-file comment). No wildcard imports. No unused imports.
 
+**Detector-script hygiene** *(applies when the script scans source
+for forbidden patterns — `check-*/scripts/`, or a docstring that
+names "detect," "scanner," or "linter")*. Docstrings, comments, and
+identifier names paraphrase the detected pattern rather than naming
+it literally (the *Detector-Script Pattern Hygiene* section of
+[python-script-best-practices.md](../../_shared/references/python-script-best-practices.md)
+covers the rules and live examples). Regex literals are structured
+so the scanned byte sequence is non-contiguous in source — a
+self-scan must not produce phantom findings.
+
 If any check fails, revise the draft before presenting. The Review
 Gate is for user approval, not correctness recovery — safety issues
 get fixed in the draft, not at the gate.

--- a/plugins/build/skills/build-skill/SKILL.md
+++ b/plugins/build/skills/build-skill/SKILL.md
@@ -99,30 +99,36 @@ This skill is the workflow; the principles doc is the rubric.
 
 6. **Draft the skill.** Follow the anatomy in
    [skill-best-practices.md](../../_shared/references/skill-best-practices.md).
-   Required frontmatter: `name`, `description`, `version`, `owner`.
+   Required frontmatter: `name`, `description`, `version`, `owner`,
+   `allowed-tools`. `allowed-tools` is required even when empty —
+   declare `allowed-tools: []` for skills that invoke no tools so the
+   scope is explicit, not default-permissive. Canonical forms:
+   space-separated string **or** YAML list; never comma-separated as
+   a string (YAML parses it as one literal). Name tokens `anthropic`
+   and `claude` are platform-owned and rejected at load time.
    Required body sections: `## When to use`, `## Prerequisites`,
-   `## Steps`, `## Failure modes`, `## Examples`. Optional frontmatter
-   fields — `license` (SPDX id like `MIT`, or a short reference to a
-   bundled `LICENSE` file; default to the host repo's license),
-   `argument-hint`, `when_to_use`, `user-invocable: false`,
-   `disable-model-invocation: true`, `paths:`, `allowed-tools`,
-   `context: fork` + `agent:`, `model`, `effort`, `hooks`,
-   `tested_with` — reach for only when the use case calls.
-   `allowed-tools` takes canonical forms: space-separated string
-   **or** YAML list. Never comma-separated as a string — YAML parses
-   it as one literal. Name tokens `anthropic` and `claude` are
-   platform-owned and rejected at load time. First ~5K tokens survive
-   Claude Code compaction — lead with load-bearing content.
+   `## Steps`, `## Failure modes`, `## Examples`. Cap the
+   `description` trigger enumeration at 2–3 phrases — long lists
+   dilute retrieval ranking. Optional frontmatter fields — `license`
+   (SPDX id like `MIT`, or a short reference to a bundled `LICENSE`
+   file; default to the host repo's license), `argument-hint`,
+   `when_to_use`, `user-invocable: false`,
+   `disable-model-invocation: true`, `paths:`, `context: fork` +
+   `agent:`, `model`, `effort`, `hooks`, `tested_with` — reach for
+   only when the use case calls. First ~5K tokens survive Claude Code
+   compaction — lead with load-bearing content.
 
 7. **Present for approval.** Before writing, narrate the design
-   choices in 3–6 bullets. Cover the frontmatter choices and why any
-   non-default field is set; the structure choices (ordering, where
-   gates sit); the partition outcome from Step 5 (which substeps
-   became scripts and why, or that the workflow is judgment-only);
-   and what was skipped and why (often more educational than what
-   was used). A reader who doesn't know skill authoring should be
-   able to follow the narration and disagree with any choice.
-   Iterate on feedback. Hold the write until the user approves.
+   choices in 3–6 bullets. Cover the frontmatter choices (including
+   the `allowed-tools` value and the rationale for any non-empty
+   entries — the user must see and approve the tool scope before the
+   skill is written); the structure choices (ordering, where gates
+   sit); the partition outcome from Step 5 (which substeps became
+   scripts and why, or that the workflow is judgment-only); and what
+   was skipped and why (often more educational than what was used).
+   A reader who doesn't know skill authoring should be able to
+   follow the narration and disagree with any choice. Iterate on
+   feedback. Hold the write until the user approves.
 
 8. **Write.** Create the skill directory if it doesn't exist. Write
    `SKILL.md` to the full path from Step 3. Copy any bundled files
@@ -253,9 +259,13 @@ Runs `/build:check-skill` — 0 findings. Reports the path.
 8. **Invented frontmatter keys.** Unknown top-level frontmatter is
    silently ignored by Claude Code. Stick to the documented spec;
    cross-check against a peer toolkit skill when uncertain.
-9. **Absolute paths in bundled references.** `/home/…` or
-   drive-letter paths break portability. Principle:
-   *(Anatomy — bundled assets referenced by relative path only.)*
+9. **Omitting `allowed-tools`.** Missing the field is not "all tools
+   allowed by intent" — it is "tool scope was never decided." Always
+   declare the field; use `allowed-tools: []` when the skill genuinely
+   invokes none.
+10. **Absolute paths in bundled references.** `/home/…` or
+    drive-letter paths break portability. Principle:
+    *(Anatomy — bundled assets referenced by relative path only.)*
 
 ## Handoff
 

--- a/plugins/build/skills/build-skill/scripts/quick_validate.py
+++ b/plugins/build/skills/build-skill/scripts/quick_validate.py
@@ -55,6 +55,13 @@ def validate_skill(skill_path):
         return False, "Missing 'name' in frontmatter"
     if 'description' not in frontmatter:
         return False, "Missing 'description' in frontmatter"
+    if 'allowed-tools' not in frontmatter:
+        return False, (
+            "Missing 'allowed-tools' in frontmatter. "
+            "Declare 'allowed-tools: []' when the skill needs no tools, "
+            "or list required tools explicitly. "
+            "See skill-best-practices.md."
+        )
 
     # Extract name for validation
     name = frontmatter.get('name', '')


### PR DESCRIPTION
## Summary

Closes #396. Make new skills born with explicit tool scoping, and codify two judgment-call rules in the shared best-practices docs so future scaffolds and reviewers have one referenceable standard.

Two threads, bundled per request:

1. **`allowed-tools:` enforcement** — fail-closed in `quick_validate.py`, documented in `skill-best-practices.md`, surfaced in `build-skill/SKILL.md`.
2. **Trigger cap (2–3 phrases)** — documented authoring guidance, not deterministically enforced.
3. **Detector-script pattern hygiene** — paraphrased docstrings + non-contiguous regex literals, documented in both `python-script-best-practices.md` and `bash-script-best-practices.md`, and wired into the Safety Check step of `build-python-script` and `build-bash-script`.

## Commits (one per task)

| # | Subject | SHA |
|---|---|---|
| 1 | docs(skill-best-practices): require allowed-tools, cap trigger phrases | 4f31544 |
| 2 | feat(quick_validate): require allowed-tools in skill frontmatter | a37fa42 |
| 3 | docs(build-skill): require allowed-tools at scaffold time | fa9e6a5 |
| 4 | docs(python-script): codify detector-script pattern hygiene | f6a5c9d |
| 5 | docs(bash-script): codify detector-script pattern hygiene | a7575a0 |

## Validator behavior — call-out for reviewers

When this lands, any future invocation of `package_skill.py` on the **31 existing SKILL.md files that lack `allowed-tools:`** will fail. CI does not run `quick_validate.py` — only `package_skill.py` does — so existing files do not break the merge. The retroactive sweep to add `allowed-tools: []` to those 31 files is intentionally out of scope here; that is a separate, mechanical change.

## Out of scope (intentionally)

- No retroactive `allowed-tools:` additions to the 31 existing SKILL.md files
- No retroactive description tightening (#399 owns)
- No reference-doc size cap
- No changes to `build-rule` / `build-hook` scaffolders — neither has an `allowed-tools` field
- No new Tier-1 check-skill enforcement — scaffold-time prevention only
- No edits to the shipping `check-*` detector scripts — those are the live examples the new rule cites, not its subject

## Validation

All 9 plan validation criteria passed:

1. ✅ `allowed-tools` mentioned ≥2× in `skill-best-practices.md`
2. ✅ Validator round-trip — rejects missing field (exit 1), accepts `allowed-tools: []` (exit 0) with the new error message naming the empty-list workaround
3. ✅ Trigger-cap (2–3 phrases) principle present
4. ✅ `build-skill/SKILL.md` mentions `allowed-tools` 5×
5. ✅ Detector-script hygiene section in both `python-script-best-practices.md` and `bash-script-best-practices.md`
6. ✅ Detector-script hygiene wired into both `build-python-script/SKILL.md` and `build-bash-script/SKILL.md` Safety Check
7. ✅ All 3 scaffolder SKILL.md files under 400 non-blank lines (no FAIL): `build-skill` 240, `build-python-script` 302, `build-bash-script` 309 — last two are at WARN under the 300 soft cap, well under the 400 hard ceiling
8. ✅ Exactly 5 commits on the branch, one per task
9. ✅ Zero diff to shipping `check-*/scripts/` detector files (no scope creep)

## Test plan

- [ ] CI passes (no `quick_validate.py` invocation in CI, so existing skills missing `allowed-tools:` do not block — confirm)
- [ ] Manual round-trip: create a fresh SKILL.md without `allowed-tools:` → `python3 plugins/build/skills/build-skill/scripts/quick_validate.py <path>` → exit 1 with the new message; add `allowed-tools: []` → exit 0
- [ ] Spot-check `build-skill/SKILL.md` Step 6 + Step 7 read sensibly with `allowed-tools` promoted to required
- [ ] Spot-check the new `## Detector-Script Pattern Hygiene` sections cite the right live-example files (`check-makefile/scripts/check_safety.py:11`, `check-readme/scripts/check_safety.py:55–60`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)