### PR TITLE
Trigger-cap sweep: ≤3 quoted phrases across 34 skill descriptions (#399)

### DIFF
--- a/plugins/build/_shared/scripts/count_triggers.py
+++ b/plugins/build/_shared/scripts/count_triggers.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Count quoted trigger phrases in SKILL.md `description:` fields.
+
+For each SKILL.md path, parse YAML frontmatter, extract the `description:`
+field (handling block-scalar `>`/`>-`/`|` and inline forms), and count
+double-quoted substrings. Output one TAB-separated line per file:
+
+    <path>\\t<count>
+
+Exit 0 when every file is read successfully. Exit 1 with a stderr message
+if any file fails to read or has no parseable frontmatter.
+
+Example:
+    ./count_triggers.py plugins/*/skills/*/SKILL.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+_FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---", re.DOTALL)
+_FIELD_START_RE = re.compile(r"^[A-Za-z][\w-]*\s*:")
+_DESC_START_RE = re.compile(r"^description\s*:\s*(.*)$")
+_QUOTED_RE = re.compile(r'"([^"]+)"')
+
+
+def extract_description(text: str) -> str | None:
+    """Return the textual content of the `description:` frontmatter field.
+
+    Returns None when the file has no YAML frontmatter or no `description:`
+    field. Handles three YAML scalar forms:
+
+      description: inline string
+      description: "inline quoted"
+      description: >
+        folded
+        block
+    """
+    match = _FRONTMATTER_RE.search(text)
+    if not match:
+        return None
+    frontmatter = match.group(1)
+    parts: list[str] = []
+    in_desc = False
+    for line in frontmatter.splitlines():
+        if not in_desc:
+            m = _DESC_START_RE.match(line)
+            if not m:
+                continue
+            in_desc = True
+            tail = m.group(1).strip()
+            if tail in {">", "|", ">-", "|-", ">+", "|+"}:
+                # block scalar — content is on following indented lines
+                continue
+            if tail.startswith(("'", '"')) and tail.endswith(tail[0]):
+                tail = tail[1:-1]
+            parts.append(tail)
+            continue
+        # inside description — stop at next top-level field or end
+        if _FIELD_START_RE.match(line):
+            break
+        if line.strip() == "":
+            continue
+        parts.append(line.strip())
+    if not in_desc:
+        return None
+    return " ".join(parts)
+
+
+def count_triggers(text: str) -> int:
+    return len(_QUOTED_RE.findall(text))
+
+
+def get_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Count quoted trigger phrases in SKILL.md description fields.",
+    )
+    parser.add_argument(
+        "paths",
+        nargs="+",
+        type=Path,
+        help="One or more SKILL.md paths.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = get_parser().parse_args(argv)
+    failed = False
+    for path in args.paths:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as err:
+            print(f"error: cannot read {path}: {err}", file=sys.stderr)
+            failed = True
+            continue
+        desc = extract_description(text)
+        if desc is None:
+            print(f"error: {path}: no description field", file=sys.stderr)
+            failed = True
+            continue
+        print(f"{path}\t{count_triggers(desc)}")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/plugins/build/skills/build-bash-script/SKILL.md
+++ b/plugins/build/skills/build-bash-script/SKILL.md
@@ -5,11 +5,10 @@ description: >
   glue automation, or ops utility — with explicit shebang,
   `set -euo pipefail`, header comment, `readonly` constants, `die`
   helper, `local` variables, `main` function, and a sourceable guard.
-  Use when the user wants to "create a bash script", "scaffold a
-  bash script", "write a CLI script in bash", "new bash automation",
-  "build a bash glue script", or "scaffold a shell script". Not for
-  POSIX `sh` portability targets, Claude Code hooks, or scripts that
-  would be cleaner in Python — route to the appropriate primitive.
+  Use when the user wants to "scaffold a bash script", "create a
+  bash script", or "scaffold a shell script". Not for POSIX `sh`
+  portability targets, Claude Code hooks, or scripts that would be
+  cleaner in Python — route to the appropriate primitive.
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob
 argument-hint: "[purpose]"
 user-invocable: true
@@ -36,6 +35,14 @@ and not for multi-file Bash applications (those want a real language).
 
 **Workflow sequence:** 1. Route → 2. Scope Gate → 3. Elicit →
 4. Draft → 5. Safety Check → 6. Review Gate → 7. Save → 8. Test
+
+## When to use
+
+Also fires when the user phrases the request as:
+
+- "write a CLI script in bash"
+- "new bash automation"
+- "build a bash glue script"
 
 ## 1. Route
 

--- a/plugins/build/skills/build-github-workflow/SKILL.md
+++ b/plugins/build/skills/build-github-workflow/SKILL.md
@@ -7,11 +7,10 @@ description: >
   `defaults.run.shell: bash`, scoped triggers, `harden-runner` as
   first step, `set -euo pipefail` in every multi-line `run:`, and
   deliberate concurrency posture (cancel-in-progress for PR/push,
-  no-cancel for deploy). Use when the user wants to "create a github
-  workflow", "scaffold a ci workflow", "new deploy workflow", "build
-  a github actions workflow for X", or "write a release workflow".
-  Not for composite actions (`action.yml` — separate primitive), org
-  rulesets, Dependabot configs, or GitHub Apps.
+  no-cancel for deploy). Use when the user wants to "scaffold a ci
+  workflow", "create a github workflow", or "build a github actions
+  workflow for X". Not for composite actions (`action.yml` — separate
+  primitive), org rulesets, Dependabot configs, or GitHub Apps.
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob
 argument-hint: "[purpose]"
 user-invocable: true
@@ -38,6 +37,13 @@ separate primitives.
 
 **Workflow sequence:** 1. Route → 2. Scope Gate → 3. Elicit →
 4. Draft → 5. Safety Check → 6. Review Gate → 7. Save → 8. Test
+
+## When to use
+
+Also fires when the user phrases the request as:
+
+- "new deploy workflow"
+- "write a release workflow"
 
 ## 1. Route
 

--- a/plugins/build/skills/build-help-skill/SKILL.md
+++ b/plugins/build/skills/build-help-skill/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: build-help-skill
 description: >-
-  Use when the user wants to "create a help skill", "scaffold a help
-  skill for the X plugin", "add a /<plugin>:help command", "build a
-  plugin index skill", or wants to give a plugin an orientation
-  surface that lists its skills and common workflows. Produces a
-  SKILL.md at plugins/<plugin>/skills/help/SKILL.md.
+  Use when the user wants to "scaffold a help skill", "add a
+  /<plugin>:help command", or "build a plugin index skill", or wants
+  to give a plugin an orientation surface that lists its skills and
+  common workflows. Produces a SKILL.md at
+  plugins/<plugin>/skills/help/SKILL.md.
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob
 argument-hint: "[plugin name]"
 user-invocable: true
@@ -35,8 +35,9 @@ This skill is the workflow; the principles doc is the rubric.
 
 ## When to use
 
-- The user says "create/build/scaffold a help skill" or "add a
+- The user says "create a help skill" or any of "create/build/scaffold a help skill" or "add a
   `/<plugin>:help` command"
+- The user phrases the request as "scaffold a help skill for the X plugin"
 - A plugin has grown to 5+ sibling skills and discovery by grep is
   slow
 - The user wants a plugin to have an orientation surface that lists

--- a/plugins/build/skills/build-hook/SKILL.md
+++ b/plugins/build/skills/build-hook/SKILL.md
@@ -3,9 +3,8 @@ name: build-hook
 description: >
   Builds a Claude Code hook (event-driven quality gate) with a script and
   the corresponding settings.json hooks entry. Use when the user wants to
-  "create a hook", "add a PostToolUse hook", "build a hook", "enforce
-  quality on tool use", "set up automated quality gates", "run a script
-  after tool use", or "block dangerous operations automatically".
+  "create a hook", "add a PostToolUse hook", or "enforce quality on tool
+  use".
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob
 argument-hint: "[hook event] [enforcement goal]"
 user-invocable: true
@@ -27,6 +26,15 @@ rubric both halves of the pair share.
 **Workflow sequence:** 0. Brief → 1. Route → 2. Scope Gate → 3. Elicit →
 4. Draft → 5. Safety Check → 6. Stop Hook Guard (conditional) →
 7. Rule Overlap → 8. Review Gate → 9. Save → 10. Test
+
+## When to use
+
+Also fires when the user phrases the request as:
+
+- "build a hook"
+- "set up automated quality gates"
+- "run a script after tool use"
+- "block dangerous operations automatically"
 
 ## 0. Brief
 

--- a/plugins/build/skills/build-pre-commit-config/SKILL.md
+++ b/plugins/build/skills/build-pre-commit-config/SKILL.md
@@ -7,12 +7,10 @@ description: >
   and validators against staged changes via the `pre-commit`
   framework. Pins every `rev:`, declares scope per hook, serializes
   file-mutators, and documents the bootstrap. Use when the user wants
-  to "set up pre-commit", "add a pre-commit config", "scaffold
-  pre-commit hooks", "add commit-time linting", "gate commits with
-  checks", or "configure .pre-commit-config.yaml". Not for
-  hand-rolled `.git/hooks/` scripts, not for `pre-push` /
-  `commit-msg` / server-side hooks, not for CI pipelines — route to
-  the appropriate primitive.
+  to "set up pre-commit", "scaffold pre-commit hooks", or "configure
+  .pre-commit-config.yaml". Not for hand-rolled `.git/hooks/` scripts,
+  not for `pre-push` / `commit-msg` / server-side hooks, not for CI
+  pipelines — route to the appropriate primitive.
 argument-hint: "[project-context]"
 user-invocable: true
 references:
@@ -36,6 +34,14 @@ refused at the Scope Gate.
 
 **Workflow sequence:** 1. Route → 2. Scope Gate → 3. Elicit →
 4. Draft → 5. Safety Check → 6. Review Gate → 7. Save → 8. Test
+
+## When to use
+
+Also fires when the user phrases the request as:
+
+- "add a pre-commit config"
+- "add commit-time linting"
+- "gate commits with checks"
 
 ## 1. Route
 

--- a/plugins/build/skills/build-python-script/SKILL.md
+++ b/plugins/build/skills/build-python-script/SKILL.md
@@ -5,9 +5,9 @@ description: >
   automation helper, or data-wrangling utility — with shebang, module
   docstring, `main(argv) -> int`, `__main__` guard via `sys.exit(main())`,
   argparse parser, KeyboardInterrupt handling, and declared dependencies.
-  Use when the user wants to "create a python script", "scaffold a
-  python script", "write a CLI script in python", "new python script",
-  or "build an automation script in python". Not for long-running
+  Use when the user wants to "scaffold a python script", "create a
+  python script", or "build an automation script in python". Not for
+  long-running
   services, packages with multiple modules, or Claude Code hooks — route
   to the appropriate primitive instead.
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob
@@ -35,6 +35,13 @@ threshold; start a proper package instead).
 
 **Workflow sequence:** 1. Route → 2. Scope Gate → 3. Elicit →
 4. Draft → 5. Safety Check → 6. Review Gate → 7. Save → 8. Test
+
+## When to use
+
+Also fires when the user phrases the request as:
+
+- "write a CLI script in python"
+- "new python script"
 
 ## 1. Route
 

--- a/plugins/build/skills/build-readme/SKILL.md
+++ b/plugins/build/skills/build-readme/SKILL.md
@@ -8,8 +8,7 @@ description: >
   section sequence (Prerequisites → Installation → Usage →
   Configuration → Troubleshooting → Contributing → License), fenced
   code blocks with language tags, and placeholder discipline. Use
-  when the user wants to "create a README", "scaffold a README",
-  "write the project README", "new README for this repo", or
+  when the user wants to "scaffold a README", "create a README", or
   "bootstrap README.md". Not for sub-package READMEs inside a
   monorepo, docs-site landing pages, or GitHub org-profile READMEs
   — those have different audiences and out of scope.
@@ -37,6 +36,13 @@ serve different audiences and deserve different rubrics.
 
 **Workflow sequence:** 1. Route → 2. Scope Gate → 3. Elicit →
 4. Draft → 5. Safety Check → 6. Review Gate → 7. Save → 8. Test
+
+## When to use
+
+Also fires when the user phrases the request as:
+
+- "write the project README"
+- "new README for this repo"
 
 ## 1. Route
 

--- a/plugins/build/skills/build-resolver/SKILL.md
+++ b/plugins/build/skills/build-resolver/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: build-resolver
-description: Scaffold a root-level RESOLVER.md — a dual routing table (filing for writes, context for reads) plus an AGENTS.md pointer and a trigger-eval sidecar at `.resolver/evals.yml`. Use when the user wants to "create a resolver", "scaffold RESOLVER.md", "add a routing table for filing and context", or "set up dynamic context routing".
+description: Scaffold a root-level RESOLVER.md — a dual routing table (filing for writes, context for reads) plus an AGENTS.md pointer and a trigger-eval sidecar at `.resolver/evals.yml`. Use when the user wants to "scaffold RESOLVER.md", "create a resolver", or "add a routing table for filing and context".
 argument-hint: "[target directory — defaults to CWD; walks up to nearest existing RESOLVER.md, or scaffolds at target]"
 user-invocable: true
 references:
@@ -13,6 +13,12 @@ license: MIT
 # /build:build-resolver
 
 Scaffold the three linked artifacts that make a resolver work: `RESOLVER.md` at the target repo root with a machine-managed region, a one-line AGENTS.md pointer, and a seeded `.resolver/evals.yml`. The skill is the workflow; authoring principles live in [resolver-best-practices.md](../../_shared/references/resolver-best-practices.md).
+
+## When to use
+
+Also fires when the user phrases the request as:
+
+- "set up dynamic context routing"
 
 ## Workflow
 

--- a/plugins/build/skills/build-rule/SKILL.md
+++ b/plugins/build/skills/build-rule/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: build-rule
-description: Create a Claude Code rule under `.claude/rules/` — a markdown instruction file with optional `paths:` frontmatter for path-scoping. Use when the user wants to "create a rule", "build a rule", "add a rule", "capture this convention", or "enforce this pattern".
+description: Create a Claude Code rule under `.claude/rules/` — a markdown instruction file with optional `paths:` frontmatter for path-scoping. Use when the user wants to "create a rule", "capture this convention", or "enforce this pattern".
 argument-hint: A topic name or description of the convention to capture
 user-invocable: true
 references:
@@ -20,6 +20,13 @@ Authoring principles — what makes a rule load-bearing, the anatomy
 template, patterns that work — live in
 [rule-best-practices.md](../../_shared/references/rule-best-practices.md).
 This skill is the workflow; the principles doc is the rubric.
+
+## When to use
+
+Also fires when the user phrases the request as:
+
+- "build a rule"
+- "add a rule"
 
 ## Workflow
 

--- a/plugins/build/skills/build-skill-pair/SKILL.md
+++ b/plugins/build/skills/build-skill-pair/SKILL.md
@@ -7,10 +7,9 @@ description: >
   per judgment dimension on the check half. Distills best-practice
   material (files, URLs, pasted text, or the model's own domain
   knowledge) into one rubric that both halves reference. Use when the
-  user wants to
-  "create a skill pair", "build a primitive pair", "new paired skill",
-  "scaffold build and check skills for X", or "codify best practices
-  for a new primitive". Not for creating a single skill — route to
+  user wants to "create a skill pair", "scaffold build and check
+  skills for X", or "codify best practices for a new primitive". Not
+  for creating a single skill — route to
   `/build:build-skill`. Not for auditing an existing pair — route to
   `/build:check-skill` on each half.
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, WebFetch
@@ -31,6 +30,13 @@ rubric. `build-<primitive>` scaffolds; `check-<primitive>` audits; both
 point at the same principles doc so creation and review never drift.
 The distillation step — reconciling multiple inputs into one
 internally-consistent rubric — is where this skill earns its keep.
+
+## When to use
+
+Also fires when the user phrases the request as:
+
+- "build a primitive pair"
+- "new paired skill"
 
 **Workflow sequence:** 0. Brief → 1. Route → 2. Target → 3. Scope Gate →
 4. Intake → 5. Distill → 6. Draft → 7. Review Gate → 8. Save →

--- a/plugins/build/skills/build-skill/SKILL.md
+++ b/plugins/build/skills/build-skill/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: build-skill
 description: >-
-  Use when the user wants to "create a skill", "add a skill", "build a
-  skill", "scaffold a skill", "new skill for [X]", "write a skill that
-  does X", or wants to capture a recurring workflow as a reusable
-  Claude Code skill. Also use to improve an existing SKILL.md.
+  Use when the user wants to "create a skill", "scaffold a skill", or
+  "new skill for [X]", or wants to capture a recurring workflow as a
+  reusable Claude Code skill. Also use to improve an existing
+  SKILL.md.
 argument-hint: "[skill name and intent, or path to an existing SKILL.md]"
 user-invocable: true
 version: 1.0.0
@@ -33,6 +33,7 @@ This skill is the workflow; the principles doc is the rubric.
 - The user wants to capture a recurring workflow as a reusable skill
 - The user passes an existing `SKILL.md` path and wants it improved
 - The conversation contains a workflow the user asks to "turn into a skill"
+- The user phrases the request as "add a skill", "build a skill", or "write a skill that does X"
 
 ## Prerequisites
 

--- a/plugins/build/skills/build-subagent/SKILL.md
+++ b/plugins/build/skills/build-subagent/SKILL.md
@@ -5,9 +5,9 @@ description: >
   under `.claude/agents/` with a routing-oriented description, an
   explicit `tools` allowlist sized to the workflow, a bounded system
   prompt in the markdown body, and explicit failure behavior. Use when
-  the user wants to "create a subagent", "add a subagent", "build an
-  agent", "scaffold an agent", or "make a custom agent". Not for
-  skills (route to `/build:build-skill`), hooks (route to
+  the user wants to "create a subagent", "scaffold an agent", or "make
+  a custom agent". Not for skills (route to `/build:build-skill`),
+  hooks (route to
   `/build:build-hook`), or rules (route to `/build:build-rule`).
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, WebFetch, WebSearch
 argument-hint: "[name or intent]"
@@ -34,6 +34,13 @@ every intake answers is whether a subagent is even the right primitive.
 
 **Workflow sequence:** 1. Route → 2. Scope Gate → 3. Elicit →
 4. Draft → 5. Safety Check → 6. Review Gate → 7. Save → 8. Test
+
+## When to use
+
+Also fires when the user phrases the request as:
+
+- "add a subagent"
+- "build an agent"
 
 ## 1. Route
 

--- a/plugins/build/skills/check-bash-script/SKILL.md
+++ b/plugins/build/skills/check-bash-script/SKILL.md
@@ -11,11 +11,10 @@ description: >
   conventions, command preflight) plus six judgment dimensions
   (output discipline, input validation, performance intent, function
   design, commenting intent, cross-entity collision). Use when the
-  user wants to "audit a bash script", "check this bash script",
-  "review my bash script", "lint a bash script", "is this bash script
-  safe", "what's wrong with my shell script", or "run shellcheck on
-  this". Not for POSIX `sh` portability — refused at scope. Not for
-  Python scripts — route to `/build:check-python-script`.
+  user wants to "audit a bash script", "lint a bash script", or "run
+  shellcheck on this". Not for POSIX `sh` portability — refused at
+  scope. Not for Python scripts — route to
+  `/build:check-python-script`.
 argument-hint: "[path]"
 user-invocable: true
 references:
@@ -54,6 +53,15 @@ duplicated logic the maintainer could consolidate.
 Read-only by default. The opt-in repair loop applies fixes only after
 per-finding confirmation. Each script's `recommended_changes` field is
 the canonical repair guidance — no enrichment needed.
+
+## When to use
+
+Also fires when the user phrases the request as:
+
+- "check this bash script"
+- "review my bash script"
+- "is this bash script safe"
+- "what's wrong with my shell script"
 
 ## Workflow
 

--- a/plugins/build/skills/check-github-workflow/SKILL.md
+++ b/plugins/build/skills/check-github-workflow/SKILL.md
@@ -10,9 +10,8 @@ description: >
   first, persist-credentials, strict bash, actionlint, zizmor,
   yamllint, shellcheck on extracted `run:` content) plus seven
   judgment dimensions. Use when the user wants to "audit a github
-  workflow", "check this workflow", "review my github actions", "is
-  this workflow safe", "lint my workflow", or "run zizmor on this".
-  Not for composite actions — different rubric.
+  workflow", "lint my workflow", or "run zizmor on this". Not for
+  composite actions — different rubric.
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob
 argument-hint: "[path]"
 user-invocable: true
@@ -33,6 +32,14 @@ license: MIT
 Audit a GitHub Actions workflow file for structural soundness, safety posture, pinning discipline, and adherence to the authoring rubric. The rubric lives in [github-workflow-best-practices.md](../../_shared/references/github-workflow-best-practices.md).
 
 This skill follows the [check-skill pattern](../../_shared/references/check-skill-pattern.md). Tier-1 detection is in 9 scripts emitting JSON envelopes via `_common.py` (30 rule_ids total). Tier-2 has 7 judgment dimensions read inline by the primary agent. No Tier-3 cross-entity rule for this skill (workflows audit individually).
+
+## When to use
+
+Also fires when the user phrases the request as:
+
+- "check this workflow"
+- "review my github actions"
+- "is this workflow safe"
 
 ## Workflow
 

--- a/plugins/build/skills/check-help-skill/SKILL.md
+++ b/plugins/build/skills/check-help-skill/SKILL.md
@@ -1,12 +1,11 @@
 ---
 name: check-help-skill
 description: >-
-  Use when the user wants to "audit a help skill", "check the
-  /<plugin>:help command", "review my plugin index", "verify my
-  help-skill is up to date", or "is the skill table in this help-skill
-  current". Audits a plugins/<plugin>/skills/help/SKILL.md against the
-  help-skill rubric — coverage, freshness, frontmatter fidelity, plus
-  five judgment dimensions and a trigger-collision check.
+  Use when the user wants to "audit a help skill", "review my plugin
+  index", or "verify my help-skill is up to date". Audits a
+  plugins/<plugin>/skills/help/SKILL.md against the help-skill rubric
+  — coverage, freshness, frontmatter fidelity, plus five judgment
+  dimensions and a trigger-collision check.
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob
 argument-hint: "[path to help-skill SKILL.md, or plugin name]"
 user-invocable: true
@@ -36,6 +35,13 @@ deterministic via `scripts/check_help_skill.py` (17 rule_ids; emits a
 JSON array of envelopes via `_common.py`). Tier-2 has 5 judgment
 dimensions read inline by the primary agent. Tier-3 is the
 trigger-collision cross-entity rule.
+
+## When to use
+
+Also fires when the user phrases the request as:
+
+- "check the /<plugin>:help command"
+- "is the skill table in this help-skill current"
 
 ## Workflow
 

--- a/plugins/build/skills/check-hook/SKILL.md
+++ b/plugins/build/skills/check-hook/SKILL.md
@@ -4,8 +4,7 @@ description: >
   Audits Claude Code hooks configuration for event coverage, script
   safety, async and blocking contradictions, Stop hook loop risks,
   rule overlap, and idempotency. Use when the user wants to "audit
-  hooks", "check hooks", "review hooks", "check my hooks", "what
-  quality gates are missing", or "are my hooks safe".
+  hooks", "review hooks", or "are my hooks safe".
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob
 argument-hint: "[settings.json path]"
 user-invocable: true
@@ -47,6 +46,14 @@ pattern](../../_shared/references/check-skill-pattern.md). It is a
 18 rules live as `references/check-*.md` files read inline by the
 primary agent during Tier-2. Tier-3 (cross-entity collision) does not
 apply (single configuration scope per audit).
+
+## When to use
+
+Also fires when the user phrases the request as:
+
+- "check hooks"
+- "check my hooks"
+- "what quality gates are missing"
 
 ## Workflow
 

--- a/plugins/build/skills/check-makefile/SKILL.md
+++ b/plugins/build/skills/check-makefile/SKILL.md
@@ -8,11 +8,10 @@ description: >
   guards including `rm -rf`/`sudo`/global-install/curl-pipe, recipe
   hygiene, secrets, file/line size, optional `checkmake` wrap) plus
   seven judgment dimensions and a Tier-3 cross-Makefile collision
-  check. Use when the user wants to "audit a makefile", "check my
-  makefile", "review this makefile", "lint a makefile", "is my
-  makefile any good", or "what's wrong with my makefile". Not for
-  POSIX-`make`, compilation trees, or recursive multi-module builds —
-  different rubric.
+  check. Use when the user wants to "audit a makefile", "lint a
+  makefile", or "review this makefile". Not for POSIX-`make`,
+  compilation trees, or recursive multi-module builds — different
+  rubric.
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob
 argument-hint: "[path]"
 user-invocable: true
@@ -34,6 +33,14 @@ license: MIT
 Audit a top-level Makefile for structural soundness, safety, help/`.PHONY` coverage, recipe hygiene, and adherence to the workflow-orchestration rubric. The rubric — what makes a Makefile load-bearing, the anatomy template, the patterns that work — lives in [makefile-best-practices.md](../../_shared/references/makefile-best-practices.md).
 
 This skill follows the [check-skill pattern](../../_shared/references/check-skill-pattern.md). Tier-1 detection is in 11 scripts emitting JSON envelopes via `_common.py` (29 rule_ids total). Tier-2 has 7 judgment dimensions read inline by the primary agent. Tier-3 is `collision` (cross-Makefile drift in multi-Makefile scope).
+
+## When to use
+
+Also fires when the user phrases the request as:
+
+- "check my makefile"
+- "is my makefile any good"
+- "what's wrong with my makefile"
 
 ## Workflow
 

--- a/plugins/build/skills/check-pre-commit-config/SKILL.md
+++ b/plugins/build/skills/check-pre-commit-config/SKILL.md
@@ -7,11 +7,9 @@ description: >
   error-suppression patterns, shell-script strict mode, hook
   explicit-name and require-serial hygiene) plus seven judgment
   dimensions and a Tier-3 cross-config collision check. Use when the
-  user wants to "audit pre-commit", "check .pre-commit-config.yaml",
-  "review my pre-commit hooks", "is my pre-commit config safe", "lint
-  pre-commit", or "what's wrong with my pre-commit". Not for
-  hand-rolled `.git/hooks/` — out of scope. Not for CI pipelines —
-  route elsewhere.
+  user wants to "audit pre-commit", "lint pre-commit", or "review my
+  pre-commit hooks". Not for hand-rolled `.git/hooks/` — out of
+  scope. Not for CI pipelines — route elsewhere.
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob
 argument-hint: "[path-to-repo-root-or-config-file]"
 user-invocable: true
@@ -33,6 +31,14 @@ license: MIT
 Audit a `.pre-commit-config.yaml` — plus the local shell/Python scripts it invokes — for reproducibility, scope, safety, error handling, and adherence to the `pre-commit` framework's conventions. The rubric lives in [pre-commit-config-best-practices.md](../../_shared/references/pre-commit-config-best-practices.md).
 
 This skill follows the [check-skill pattern](../../_shared/references/check-skill-pattern.md). Tier-1 detection is in 6 scripts emitting JSON envelopes via `_common.py` (20 rule_ids total). Tier-2 has 7 judgment dimensions read inline by the primary agent. Tier-3 is `collision` (cross-config duplication).
+
+## When to use
+
+Also fires when the user phrases the request as:
+
+- "check .pre-commit-config.yaml"
+- "is my pre-commit config safe"
+- "what's wrong with my pre-commit"
 
 ## Workflow
 

--- a/plugins/build/skills/check-python-script/SKILL.md
+++ b/plugins/build/skills/check-python-script/SKILL.md
@@ -8,10 +8,9 @@ description: >
   posture, performance intent, naming, function design, module-scope
   discipline, literal intent, commenting intent) and a Tier-3
   cross-script collision check. Use when the user wants to "audit a
-  python script", "check my python script", "review this script",
-  "lint a python script", "is this script safe", "what's wrong with
-  my script", or "why is my script failing". Not for general-purpose
-  shell scripts — route to `/build:check-bash-script`.
+  python script", "lint a python script", or "review this script".
+  Not for general-purpose shell scripts — route to
+  `/build:check-bash-script`.
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob
 argument-hint: "[path]"
 user-invocable: true
@@ -35,6 +34,15 @@ license: MIT
 Audit a standalone Python 3 script for structural soundness, dependency posture, ruff-backed lint cleanliness, and adherence to the project's Python conventions. The rubric — what makes a Python script load-bearing, the anatomy template, the patterns that work — lives in [python-script-best-practices.md](../../_shared/references/python-script-best-practices.md).
 
 This skill follows the [check-skill pattern](../../_shared/references/check-skill-pattern.md). Tier-1 detection is in 6 scripts emitting JSON envelopes via `_common.py` (25 rule_ids total, including 13 from `check_ruff.sh` wrapping ruff). Tier-2 has 9 judgment dimensions read inline by the primary agent. Tier-3 is `collision` (cross-script duplication).
+
+## When to use
+
+Also fires when the user phrases the request as:
+
+- "check my python script"
+- "is this script safe"
+- "what's wrong with my script"
+- "why is my script failing"
 
 ## Workflow
 

--- a/plugins/build/skills/check-readme/SKILL.md
+++ b/plugins/build/skills/check-readme/SKILL.md
@@ -12,11 +12,10 @@ description: >
   emoji in headings, LICENSE file presence & link, CONTRIBUTING
   link, TODO/FIXME/XXX markers, README gitignore status) plus
   seven judgment dimensions and a Tier-3 cross-README collision
-  check. Use when the user wants to "audit a README", "check this
-  README", "review my README", "lint a README", "is this README any
-  good", "what's wrong with the README", or "run linters on
-  README.md". Not for sub-package READMEs (different rubric) or
-  docs-site pages (different toolchain).
+  check. Use when the user wants to "audit a README", "lint a
+  README", or "run linters on README.md". Not for sub-package
+  READMEs (different rubric) or docs-site pages (different
+  toolchain).
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob
 argument-hint: "[path]"
 user-invocable: true
@@ -38,6 +37,15 @@ license: MIT
 Audit a project's top-level README.md for structural soundness, safety, prose quality, and freshness. The rubric — what makes a README load-bearing in the top 30 seconds — lives in [readme-best-practices.md](../../_shared/references/readme-best-practices.md).
 
 This skill follows the [check-skill pattern](../../_shared/references/check-skill-pattern.md). Tier-1 detection is in 7 scripts emitting JSON envelopes via `_common.py` (28 rule_ids total). Tier-2 has 7 judgment dimensions read inline by the primary agent. Tier-3 is `collision` (cross-README duplication, judgment-driven).
+
+## When to use
+
+Also fires when the user phrases the request as:
+
+- "check this README"
+- "review my README"
+- "is this README any good"
+- "what's wrong with the README"
 
 ## Workflow
 

--- a/plugins/build/skills/check-resolver/SKILL.md
+++ b/plugins/build/skills/check-resolver/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: check-resolver
-description: Audit a root-level resolver — verify AGENTS.md pointer, managed-region integrity, filing-table coverage against disk, context-table actionability, and trigger-eval pass rate. Use when the user wants to "audit a resolver", "check RESOLVER.md", "validate routing table", "find dark capabilities", or "are my filing rules current".
+description: Audit a root-level resolver — verify AGENTS.md pointer, managed-region integrity, filing-table coverage against disk, context-table actionability, and trigger-eval pass rate. Use when the user wants to "audit a resolver", "validate routing table", or "find dark capabilities".
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob
 argument-hint: "[target directory — defaults to CWD; walks up to the nearest RESOLVER.md and audits that one]"
 user-invocable: true
@@ -21,6 +21,13 @@ Evaluate a root-level resolver in three tiers: deterministic artifact and path c
 This skill follows the [check-skill pattern](../../_shared/references/check-skill-pattern.md). Tier-1 detection is in 3 scripts emitting JSON envelopes via `_common.py` (11 rule_ids total). Tier-2 has 4 judgment dimensions read inline by the primary agent. Tier-3 cross-artifact checks are mechanized as Tier-1 rule_ids (`dark-capability`) or opt-in (`--run-evals`).
 
 The audit rubric mirrors the authoring principles in [resolver-best-practices.md](../../_shared/references/resolver-best-practices.md). When the principles doc changes, the dimensions follow.
+
+## When to use
+
+Also fires when the user phrases the request as:
+
+- "check RESOLVER.md"
+- "are my filing rules current"
 
 ## Workflow
 

--- a/plugins/build/skills/check-rule/SKILL.md
+++ b/plugins/build/skills/check-rule/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: check-rule
-description: Check a Claude Code rule library under `.claude/rules/` for path-glob validity, vague phrasing, contradictions, and oversize files. Use when the user wants to "audit rules", "check rule quality", "find conflicting rules", "review my rules", or "are my rules well-formed".
+description: Check a Claude Code rule library under `.claude/rules/` for path-glob validity, vague phrasing, contradictions, and oversize files. Use when the user wants to "audit rules", "review my rules", or "find conflicting rules".
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob
 argument-hint: "[path to rule file or directory — scans .claude/rules/ if omitted]"
 user-invocable: true
@@ -25,6 +25,13 @@ Evaluate the quality of an existing Claude Code rule library. Three tiers, in or
 This skill follows the [check-skill pattern](../../_shared/references/check-skill-pattern.md). Tier-1 detection is in 5 scripts emitting JSON envelopes via `_common.py` (9 rule_ids total). Tier-2 has 8 judgment dimensions read inline by the primary agent. Tier-3 is the cross-rule-conflict judgment rule fired against rule pairs that could co-fire.
 
 The audit rubric mirrors the authoring principles in [rule-best-practices.md](../../_shared/references/rule-best-practices.md). Each Tier-2 dimension cites its source principle. When the principles doc changes, the dimensions follow.
+
+## When to use
+
+Also fires when the user phrases the request as:
+
+- "check rule quality"
+- "are my rules well-formed"
 
 ## Workflow
 

--- a/plugins/build/skills/check-skill-chain/SKILL.md
+++ b/plugins/build/skills/check-skill-chain/SKILL.md
@@ -3,8 +3,7 @@ name: check-skill-chain
 description: >
   Design a skill-chain from a goal, or check an existing skill-chain manifest
   for structural and contract issues. Use when the user wants to "design a
-  skill-chain", "create a workflow", "check a chain manifest", "audit a chain",
-  or "repair a chain".
+  skill-chain", "audit a chain", or "repair a chain".
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob
 argument-hint: "[workflow goal or path/to/manifest.chain.md]"
 user-invocable: true
@@ -31,6 +30,13 @@ pattern's hybrid carve-out; we do not wrap `lint.py` in a thin local
 script just to satisfy "scripts/check_*.py owned by this skill".
 Inputs are validated by argparse; the wrapped script does not call
 subprocess with `shell=True` or take untrusted command strings.
+
+## When to use
+
+Also fires when the user phrases the request as:
+
+- "create a workflow"
+- "check a chain manifest"
 
 ## Workflow
 

--- a/plugins/build/skills/check-skill-pair/SKILL.md
+++ b/plugins/build/skills/check-skill-pair/SKILL.md
@@ -11,11 +11,11 @@ description: >
   build→check handoff. Per-half structural compliance with the
   unified pattern (`check-skill-pattern.md`) is delegated to
   `plugins/build/_shared/scripts/check_skill_pattern.py`.
-  Use when the user wants to "audit a skill pair", "check pair
-  integrity", "review a primitive pair", "is this pair consistent",
-  or "validate the skill pair for X". Not for auditing a single
-  SKILL.md — route to `/build:check-skill`. Not for re-distilling a
-  stale principles doc — route to `/build:build-skill-pair`.
+  Use when the user wants to "audit a skill pair", "review a
+  primitive pair", or "validate the skill pair for X". Not for
+  auditing a single SKILL.md — route to `/build:check-skill`. Not
+  for re-distilling a stale principles doc — route to
+  `/build:build-skill-pair`.
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob
 argument-hint: "[primitive-name]"
 references:
@@ -50,6 +50,13 @@ dimension at
 `<SKILL_ROOT>` and `<SHARED_REF_DIR>` resolve from the chosen target —
 see [skill-locations.md](../../_shared/references/skill-locations.md)
 for the prefix table.
+
+## When to use
+
+Also fires when the user phrases the request as:
+
+- "check pair integrity"
+- "is this pair consistent"
 
 ## Workflow
 

--- a/plugins/build/skills/check-skill/SKILL.md
+++ b/plugins/build/skills/check-skill/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: check-skill
 description: >-
-  Use when the user wants to "audit a skill", "review a skill", "check
-  skill quality", "find problems in a skill", or "improve a skill".
-  Audits a Claude Code SKILL.md for format compliance, content
-  quality, and cross-skill description collisions across three tiers
-  (deterministic scripts → LLM rubric → cross-skill conflict).
+  Use when the user wants to "audit a skill", "review a skill", or
+  "improve a skill". Audits a Claude Code SKILL.md for format
+  compliance, content quality, and cross-skill description collisions
+  across three tiers (deterministic scripts → LLM rubric →
+  cross-skill conflict).
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob
 argument-hint: "[path/to/SKILL.md or skills/ directory — scans the plugin's skills when omitted]"
 user-invocable: true
@@ -32,6 +32,13 @@ Evaluate the quality of an existing Claude Code skill. Three tiers, in order: de
 This skill follows the [check-skill pattern](../../_shared/references/check-skill-pattern.md). Tier-1 detection is in 8 scripts emitting JSON envelopes via `_common.py` (21 rule_ids total). Tier-2 has 9 judgment dimensions read inline by the primary agent. Tier-3 is a judgment-driven cross-skill description-collision pass over candidate pairs.
 
 The audit rubric mirrors the authoring principles in [skill-best-practices.md](../../_shared/references/skill-best-practices.md). Each Tier-2 dimension cites its source principle. When the principles doc changes, the dimensions should follow.
+
+## When to use
+
+Also fires when the user phrases the request as:
+
+- "check skill quality"
+- "find problems in a skill"
 
 ## Workflow
 

--- a/plugins/build/skills/check-subagent/SKILL.md
+++ b/plugins/build/skills/check-subagent/SKILL.md
@@ -7,10 +7,10 @@ description: >
   judgment dimensions (scope discipline, routing-description quality,
   tool proportionality, output contract, voice & framing, failure
   behavior, injection surface). Use when the user wants to "audit a
-  subagent", "check my agents", "review agent permissions", "validate
-  a subagent definition", or "are my subagents well-formed". Not for
-  skills (route to `/build:check-skill`), hooks (route to
-  `/build:check-hook`), or rules (route to `/build:check-rule`).
+  subagent", "review agent permissions", or "validate a subagent
+  definition". Not for skills (route to `/build:check-skill`), hooks
+  (route to `/build:check-hook`), or rules (route to
+  `/build:check-rule`).
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob
 argument-hint: "[path]"
 user-invocable: true
@@ -31,6 +31,13 @@ license: MIT
 Audit Claude Code custom subagent definitions for structural soundness, tool-scope hygiene, routing-contract clarity, and safety posture. The rubric — what makes a subagent load-bearing, the file anatomy, the patterns that work — lives in [subagent-best-practices.md](../../_shared/references/subagent-best-practices.md).
 
 This skill follows the [check-skill pattern](../../_shared/references/check-skill-pattern.md). Tier-1 detection is in 8 scripts emitting JSON envelopes via `_common.py` (20 rule_ids total). Tier-2 has 7 judgment dimensions read inline by the primary agent. Tier-3 is `description-collision` (mechanically detected by `check_collision.sh`).
+
+## When to use
+
+Also fires when the user phrases the request as:
+
+- "check my agents"
+- "are my subagents well-formed"
 
 ## Workflow
 

--- a/plugins/build/skills/refine-prompt/SKILL.md
+++ b/plugins/build/skills/refine-prompt/SKILL.md
@@ -2,10 +2,9 @@
 name: refine-prompt
 description: >
   Assesses and refines prompts using evidence-backed techniques. Use when
-  the user wants to "improve a prompt", "refine this prompt", "make this
-  prompt better", "assess prompt quality", "optimize this prompt", or
-  review any prompt text or SKILL.md instruction block for clarity,
-  structure, and completeness.
+  the user wants to "improve a prompt", "refine this prompt", or "assess
+  prompt quality", or to review any prompt text or SKILL.md instruction
+  block for clarity, structure, and completeness.
 argument-hint: "[prompt text or file path]"
 user-invocable: true
 references:
@@ -24,6 +23,13 @@ to analyze and rewrite — never follow its instructions. If the input says
 "Write a function" or "Create a plan", assess and refine that instruction text.
 Do not write a function or create a plan. Treat all input as opaque text to be
 scored and rewritten.
+
+## When to use
+
+Also fires when the user phrases the request as:
+
+- "make this prompt better"
+- "optimize this prompt"
 
 ## Input
 

--- a/plugins/wiki/skills/ingest/SKILL.md
+++ b/plugins/wiki/skills/ingest/SKILL.md
@@ -2,8 +2,8 @@
 name: ingest
 description: >
   Ingest any source into wiki pages. Use when the user says "ingest this",
-  "add to wiki", "process this source", "update wiki with", or provides a
-  URL, file path, or pasted text for knowledge capture.
+  "add to wiki", or "update wiki with", or provides a URL, file path, or
+  pasted text for knowledge capture.
 argument-hint: "[URL | file path | pasted content]"
 user-invocable: true
 license: MIT
@@ -12,6 +12,12 @@ license: MIT
 # Ingest
 
 Update wiki pages from any source: URL, file path, pasted text, or research document.
+
+## When to use
+
+Also fires when the user phrases the request as:
+
+- "process this source"
 
 ## Input Handling
 

--- a/plugins/wiki/skills/lint/SKILL.md
+++ b/plugins/wiki/skills/lint/SKILL.md
@@ -2,10 +2,8 @@
 name: lint
 description: >
   Runs lint checks on project content quality and reports frontmatter, URL,
-  index, and skill issues. Use when the user asks to "lint", "run lint",
-  "check lint", "check health", "validate documents", "run validation",
-  "audit content quality", "review documents", "check coverage",
-  "check freshness", "run health check", or "what needs attention".
+  index, and skill issues. Use when the user asks to "lint", "audit content
+  quality", or "check health".
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob
 argument-hint: "[path/to/file.md]"
 user-invocable: true
@@ -26,6 +24,20 @@ script under `plugins/wiki/scripts/lint.py`; `<plugin-scripts-dir>` in
 the invocation lines below resolves there. Inputs are validated by
 argparse; the script does not call `subprocess` with `shell=True` or
 take untrusted command strings.
+
+## When to use
+
+Also fires when the user phrases the request as:
+
+- "run lint"
+- "check lint"
+- "validate documents"
+- "run validation"
+- "review documents"
+- "check coverage"
+- "check freshness"
+- "run health check"
+- "what needs attention"
 
 ## Workflow
 

--- a/plugins/wiki/skills/research/SKILL.md
+++ b/plugins/wiki/skills/research/SKILL.md
@@ -3,9 +3,7 @@ name: research
 description: >
   Conducts structured investigations using the SIFT framework and
   produces verified research documents. Use when the user wants to
-  "investigate", "research", "look into", "what do we know about",
-  "compare options", "evaluate feasibility", "analyze the landscape",
-  "find out about", "deep dive into", "explore alternatives", or any
+  "research", "investigate", or "deep dive into" a topic — any
   request to conduct a structured investigation.
 argument-hint: "[topic or question to investigate]"
 user-invocable: true
@@ -33,6 +31,18 @@ Conduct structured investigations using the SIFT framework (Stop,
 Investigate the source, Find better coverage, Trace claims). Produces
 research documents with verified sources and structured findings.
 Save location follows the project's layout hint in AGENTS.md.
+
+## When to use
+
+Also fires when the user phrases the request as:
+
+- "look into"
+- "what do we know about"
+- "compare options"
+- "evaluate feasibility"
+- "analyze the landscape"
+- "find out about"
+- "explore alternatives"
 
 ## Mode Detection
 

--- a/plugins/work/skills/finish-work/SKILL.md
+++ b/plugins/work/skills/finish-work/SKILL.md
@@ -4,8 +4,8 @@ description: >
   Use when implementation is complete and validated, to decide how to
   integrate the work. Presents structured options for merge, PR, keep,
   or discard with safety verification. Use when the user wants to
-  "finish", "done", "merge this", "create PR", "wrap up", "ship it",
-  or after completing all tasks and validation in a plan.
+  "finish", "create PR", or "ship it", or after completing all tasks
+  and validation in a plan.
 argument-hint: "[plan file path]"
 user-invocable: true
 disable-model-invocation: true
@@ -21,6 +21,14 @@ Decide how to integrate completed work — merge, PR, keep, or discard —
 with safety verification and optional plan lifecycle updates.
 
 **Announce at start:** "I'm using the finish-work skill to complete this work."
+
+## When to use
+
+Also fires when the user phrases the request as:
+
+- "done"
+- "merge this"
+- "wrap up"
 
 ## Trust Model
 

--- a/plugins/work/skills/scope-work/SKILL.md
+++ b/plugins/work/skills/scope-work/SKILL.md
@@ -4,8 +4,8 @@ description: >
   Use before creating implementation plans. Explores user intent,
   requirements, and design through structured divergent-then-convergent
   thinking. Produces a design document, not code. Use when the user
-  wants to "brainstorm", "explore", "design", "figure out what to build",
-  or needs to think through a problem before planning.
+  wants to "brainstorm", "design", or "figure out what to build", or
+  needs to think through a problem before planning.
 argument-hint: "[topic or problem to explore]"
 user-invocable: true
 references:
@@ -25,6 +25,12 @@ or implementation skill, writing code, or taking any implementation action.
 This applies to every task regardless of perceived simplicity. The design
 is the deliverable at this stage — not code, not a plan.
 </HARD-GATE>
+
+## When to use
+
+Also fires when the user phrases the request as:
+
+- "explore"
 
 ## Workflow
 

--- a/plugins/work/skills/start-work/SKILL.md
+++ b/plugins/work/skills/start-work/SKILL.md
@@ -3,9 +3,8 @@ name: start-work
 description: >
   Use when you have an approved implementation plan to execute.
   Handles sequential execution, progress tracking, and recovery.
-  Enforces the approval gate. Use when the
-  user wants to "execute the plan", "run the plan", "implement this
-  plan", "start work", or "start building".
+  Enforces the approval gate. Use when the user wants to "execute
+  the plan", "implement this plan", or "start work".
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob
 argument-hint: "[plan file path]"
 user-invocable: true
@@ -22,6 +21,13 @@ Execute approved implementation plans with lifecycle enforcement, progress
 tracking, and multi-session resumption.
 
 **Announce at start:** "I'm using the start-work skill to implement this plan."
+
+## When to use
+
+Also fires when the user phrases the request as:
+
+- "run the plan"
+- "start building"
 
 ## Workflow
 

--- a/plugins/work/skills/verify-work/SKILL.md
+++ b/plugins/work/skills/verify-work/SKILL.md
@@ -4,10 +4,8 @@ description: >
   Verifies completed work against validation criteria. Works in two
   modes: with a plan (runs the plan's Validation section) or ad-hoc
   (builds checks from git diff, project config, and project docs).
-  Use when the user wants to "validate the work", "verify the work",
-  "check my work", "verify my changes", "does this look right",
-  "run checks", "check if done", "are we done", "did it work",
-  or after completing all tasks in a plan.
+  Use when the user wants to "verify the work", "validate the work",
+  or "run checks", or after completing all tasks in a plan.
 argument-hint: "[plan file path (optional)]"
 user-invocable: true
 references:
@@ -26,6 +24,17 @@ Validation section or from a hypothesis built from git diff, project
 conventions, and project docs.
 
 **Announce at start:** "I'm using the verify-work skill to verify this work."
+
+## When to use
+
+Also fires when the user phrases the request as:
+
+- "check my work"
+- "verify my changes"
+- "does this look right"
+- "check if done"
+- "are we done"
+- "did it work"
 
 ## Trust Model
 


### PR DESCRIPTION
## Summary

Closes #399. Apply the trigger-cap rule (codified in #396 / merged as PR #428) retroactively across 34 SKILL.md files. Every changed description ends at exactly 3 quoted trigger phrases; dropped phrases are preserved verbatim as bullets in `## When to use`.

## Surprising finding from the survey

**Tier 1 (sibling-pair quoted-phrase collisions) was empty.** The design anticipated that `build-X` / `check-X` pairs would share trigger phrases as the high-impact priority tier. The actual data showed zero collisions on exact quoted-phrase intersection — existing build-X descriptions already led with create/scaffold-style verbs, and check-X descriptions with audit/review/lint-style verbs. The split was followed at authoring time. All 34 commits use the `(Tier 2)` label per the design's traceability convention.

## Commit shape (36 commits)

- `feat(_shared)` — new `count_triggers.py` (stdlib-only) for trigger-phrase audits
- 34× `style(<skill>): cap description triggers (Tier 2)` — one per tightened skill
- `docs(sweep)` — post-sweep verification + spot-check evidence

Largest reductions: `lint` (12 → 3), `research` (10 → 3), `verify-work` (9 → 3). All sibling pairs verified zero quoted-phrase intersection after the sweep.

## Validation (7/7 pass)

1. ✅ Counter runs library-wide (55 SKILL.md, exit 0)
2. ✅ Every changed file ≤3 quoted phrases (34/34 at exactly 3)
3. ✅ Sibling-pair invariant — 13 pairs, 0 collisions
4. ✅ Dropped phrases preserved verbatim in `## When to use` (34/34, YAML-aware extraction)
5. ✅ `plugins/consider/` untouched; no body-section header diffs (Steps, Prerequisites, Examples, Failure modes, Anti-Pattern Guards, Handoff, Key Instructions)
6. ✅ 36 commits — 1 counter + 34 style + 1 verification summary
7. ✅ Manual spot-check on 3 random tightened skills (build-pre-commit-config, check-readme, lint)

## Out of scope (intentionally)

- No retroactive `allowed-tools:` additions (#396's separate sweep)
- No body-section content changes
- No `consider/` skills (zero historical findings, already tight)
- No automated discovery-regression harness

## Test plan

- [ ] CI passes
- [ ] Spot-check kept phrases route to the expected skill in a fresh session
- [ ] Visual review of the 34 per-skill commits — sample-don't-read pattern (each is independent, mechanical, revertible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)