### PR TITLE
Python script profiles: cli/library/skill-helper bundle (#380 + #389)

### DIFF
--- a/plugins/build/.claude-plugin/plugin.json
+++ b/plugins/build/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "build",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Skills for creating and refining Claude Code skills, rules, hooks, and subagents.",
   "author": {
     "name": "Brandon Beidel"

--- a/plugins/build/_shared/references/python-script-profiles.md
+++ b/plugins/build/_shared/references/python-script-profiles.md
@@ -1,0 +1,186 @@
+---
+name: Python Script Profiles
+description: Profile enum and per-profile rule applicability for python-script primitives. Defines cli/library/skill-helper, the heuristic detection rules, and which Tier-1 detector scripts and Tier-2 judgment dimensions apply per profile. Referenced by build-python-script and check-python-script.
+---
+
+# Python Script Profiles
+
+A *profile* is the shape a python-script takes — its entry-point contract, its imports posture, its I/O contract. Three concrete profiles cover the python-script use cases this skill library supports. Profile is a string enum, not a composable feature flag, because three concrete shapes cover the stated workload and composability invites combinatorial explosion in the rule applicability matrix.
+
+## Profiles
+
+### cli
+
+The default shape: a single-file program invoked from the shell, parses arguments via `argparse`, returns an exit code. Every existing python-script in the repo is `cli`-profile by default — when no `--profile=<name>` flag is provided and the heuristic does not strongly indicate `library` or `skill-helper`, the profile resolves to `cli`.
+
+Required shape:
+- `#!/usr/bin/env python3` shebang
+- module docstring with one example invocation
+- `main(argv: list[str] | None = None) -> int`
+- `if __name__ == "__main__": sys.exit(main())` guard
+- `argparse` for any flags
+- `KeyboardInterrupt` handled at the top level
+
+### library
+
+A module imported by other code, not invoked from a shell. The CLI shell from `cli` is dead weight here; the rules that enforce shebang/main/argparse become *expected absent* and new rules around import-time discipline take their place.
+
+Required shape:
+- module docstring (a one-line synopsis followed by an optional paragraph naming the public API)
+- `__all__` declared at module scope (explicit public-API surface)
+- public functions and classes type-hinted
+- public symbols carry docstrings
+- no module-level side effects (no work at import time other than imports, type aliases, `__all__`, and pure-RHS constant assignments)
+
+Forbidden shape:
+- shebang
+- `if __name__ == "__main__":` guard
+- `main()` function returning `int`
+- `argparse` (a library does not parse CLI flags)
+
+### skill-helper
+
+A specialized `cli` for the contract that Claude Code skills shell out to. Reads a JSON payload from stdin, writes a JSON summary to stdout, emits structured JSON errors to stderr with non-zero exit codes, and writes any output files atomically.
+
+Required shape (in addition to `cli` requirements):
+- payload arrives via `json.loads(sys.stdin.read())` — *not* via `--payload-file` or any other flag-based mechanism
+- summary emitted to stdout via `json.dumps(...)`
+- on error, structured JSON to stderr matching `{"error": "<code>", "message": "<str>", "hint": "<str>"}` (the `hint` field is optional)
+- distinct exit codes carry meaning: `0` success, `2` user error, `3` internal error (a script that uses only `0` and `1` is below the contract — non-zero must be subdivided when the user's recovery action differs)
+- atomic writes use `<path>.tmp` followed by `os.replace(<tmp>, <path>)` — direct `<path>.write_text(...)` is non-atomic and may leave half-written state on interruption
+
+Forbidden shape:
+- raw tracebacks emitted to stderr (the contract is structured JSON; `--debug` for verbose output is the escape hatch)
+- payload arriving through CLI flags
+
+## Heuristic Detection
+
+Used by `check-python-script` when no `--profile=<name>` flag is supplied. The detection is best-effort — when ambiguous, the result is `cli` (the safe default). The flag override always wins.
+
+Detection rules, applied in order:
+
+1. **library**: if the script has *no* shebang AND *no* `if __name__ == "__main__":` guard AND *no* `main(` function definition, return `library`.
+2. **skill-helper**: if the script imports `argparse` AND uses `sys.stdin.read()` AND uses `json.loads(`, return `skill-helper`.
+3. **cli (default)**: anything else.
+
+The detector lives at `plugins/build/_shared/scripts/detect_python_profile.py` and exposes both library use (`from detect_python_profile import detect`) and CLI use (`./detect_python_profile.py <path>` prints the resolved profile name).
+
+## Tier-1 Applicability Matrix
+
+`check-python-script`'s 6 existing Tier-1 scripts, plus the 2 new profile-specific Tier-1 scripts:
+
+| Script | cli | library | skill-helper |
+|---|---|---|---|
+| `check_argparse.sh` | ✓ | — | ✓ |
+| `check_deps.sh` | ✓ | ✓ | ✓ |
+| `check_ruff.sh` | ✓ | ✓ | ✓ |
+| `check_secrets.sh` | ✓ | ✓ | ✓ |
+| `check_size.sh` | ✓ | ✓ | ✓ |
+| `check_structure.sh` | ✓ | — | ✓ |
+| `check_library_discipline.py` (new) | — | ✓ | — |
+| `check_skill_helper_contract.py` (new) | — | — | ✓ |
+
+`check_argparse.sh` and `check_structure.sh` enforce the cli-shell shape (shebang, main, `__main__` guard, argparse). They do not apply under `library` because the absence of those items is *correct*. They do apply under `skill-helper` because skill-helper is a cli-shell variant that adds rules on top.
+
+## Tier-2 Applicability Matrix
+
+The 9 existing Tier-2 dimensions apply across all profiles — they describe judgment-level concerns (input validation, output discipline, naming, function design, etc.) that are profile-agnostic. The 5 new dimensions are profile-specific:
+
+| Dimension | cli | library | skill-helper |
+|---|---|---|---|
+| (existing 9: input-validation, output-discipline, dependency-posture, performance-intent, naming, function-design, module-scope-discipline, literal-intent, commenting-intent) | ✓ | ✓ | ✓ |
+| `check-no-import-time-side-effects` | — | ✓ | — |
+| `check-public-symbols-typed` | — | ✓ | — |
+| `check-public-symbols-documented` | — | ✓ | — |
+| `check-structured-stderr-errors` | — | — | ✓ |
+| `check-exit-code-meaning` | — | — | ✓ |
+
+## Build-Side Templates
+
+Three conditional templates in `build-python-script`'s Draft step. The `cli` template is the existing scaffold; the other two are new shapes.
+
+**`cli`** — unchanged (current behavior). See the existing template in `build-python-script/SKILL.md` Step 4.
+
+**`library`** — module docstring + explicit public-API + nothing else.
+
+```python
+"""<one-line synopsis of the module>.
+
+<Optional paragraph naming the public API.>
+"""
+
+from __future__ import annotations
+
+__all__ = ["<public_symbol>"]
+
+# (public functions and classes here, type-hinted, docstring'd)
+```
+
+**`skill-helper`** — cli template + stdin-JSON read + structured-error helper + atomic-write helper + distinct exit codes.
+
+```python
+#!/usr/bin/env python3
+"""<one-line synopsis>.
+
+Reads JSON payload from stdin; writes JSON summary to stdout;
+emits structured errors to stderr with distinct exit codes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+EXIT_OK = 0
+EXIT_USER_ERROR = 2
+EXIT_INTERNAL_ERROR = 3
+
+
+def get_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="<one-line purpose>")
+    # flags only — payload arrives on stdin
+    return parser
+
+
+def emit_error(code: str, message: str, hint: str | None = None) -> None:
+    payload: dict[str, str] = {"error": code, "message": message}
+    if hint:
+        payload["hint"] = hint
+    print(json.dumps(payload), file=sys.stderr)
+
+
+def atomic_write(path: Path, content: str) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(content, encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = get_parser().parse_args(argv)
+    try:
+        payload = json.loads(sys.stdin.read())
+    except json.JSONDecodeError as err:
+        emit_error("invalid-json", f"could not parse stdin: {err}")
+        return EXIT_USER_ERROR
+    try:
+        result: dict = {}
+        # ... do work, populate result ...
+        print(json.dumps(result))
+        return EXIT_OK
+    except KeyboardInterrupt:
+        return 130
+    except Exception as err:  # noqa: BLE001 — top-level safety net
+        emit_error("internal", str(err))
+        return EXIT_INTERNAL_ERROR
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+## Versioning
+
+The profile enum is closed at v1: `cli`, `library`, `skill-helper`. Adding a fourth value (`service`, `notebook`, etc.) requires a deliberate scoping pass — applicability matrices, build templates, and check rules all need a coherent extension. Until that pass happens, ambiguous cases default to `cli` and the user can override with `--profile=<name>`.

--- a/plugins/build/_shared/scripts/detect_python_profile.py
+++ b/plugins/build/_shared/scripts/detect_python_profile.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Detect the profile of a python script.
+
+Profiles are defined in `plugins/build/_shared/references/python-script-profiles.md`:
+
+  - library:      no shebang AND no `if __name__ == "__main__":` AND no `main(`
+  - skill-helper: imports argparse AND uses sys.stdin.read() AND uses json.loads(
+  - cli:          default
+
+The detection is best-effort. The `--profile=<name>` flag override always wins.
+
+Usage:
+    detect_python_profile.py <path>
+    detect_python_profile.py --profile=library <path>
+
+Output: prints the resolved profile name to stdout. Exit 0 on success,
+1 on read error, 2 on invalid `--profile` value.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+VALID_PROFILES = ("cli", "library", "skill-helper")
+
+_SHEBANG_RE = re.compile(r"^#!\s*\S+python")
+_MAIN_GUARD_RE = re.compile(
+    r'^if\s+__name__\s*==\s*[\'"]__main__[\'"]\s*:', re.MULTILINE
+)
+_MAIN_DEF_RE = re.compile(r"^def\s+main\s*\(", re.MULTILINE)
+_ARGPARSE_IMPORT_RE = re.compile(
+    r"^(?:import\s+argparse|from\s+argparse\s+import)", re.MULTILINE
+)
+_STDIN_READ_RE = re.compile(r"sys\.stdin\.read\s*\(")
+_JSON_LOADS_RE = re.compile(r"json\.loads?\s*\(")
+
+
+def detect(text: str) -> str:
+    """Return the resolved profile name for the given script source."""
+    has_shebang = bool(_SHEBANG_RE.search(text.split("\n", 1)[0])) if text else False
+    has_main_guard = bool(_MAIN_GUARD_RE.search(text))
+    has_main_def = bool(_MAIN_DEF_RE.search(text))
+    if not has_shebang and not has_main_guard and not has_main_def:
+        return "library"
+    has_argparse = bool(_ARGPARSE_IMPORT_RE.search(text))
+    has_stdin_read = bool(_STDIN_READ_RE.search(text))
+    has_json_loads = bool(_JSON_LOADS_RE.search(text))
+    if has_argparse and has_stdin_read and has_json_loads:
+        return "skill-helper"
+    return "cli"
+
+
+def get_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Detect the profile of a python script.",
+    )
+    parser.add_argument(
+        "path",
+        type=Path,
+        help="Path to the python script to inspect.",
+    )
+    parser.add_argument(
+        "--profile",
+        choices=VALID_PROFILES,
+        default=None,
+        help="Override detection. When set, this profile name is printed verbatim.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = get_parser()
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as err:
+        # argparse exits with 2 on invalid arguments — preserve that contract
+        return int(err.code) if err.code is not None else 0
+    if args.profile is not None:
+        print(args.profile)
+        return 0
+    try:
+        text = args.path.read_text(encoding="utf-8")
+    except OSError as err:
+        print(f"error: cannot read {args.path}: {err}", file=sys.stderr)
+        return 1
+    print(detect(text))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/plugins/build/_shared/scripts/tests/test_detect_profile.py
+++ b/plugins/build/_shared/scripts/tests/test_detect_profile.py
@@ -1,0 +1,137 @@
+"""Tests for detect_python_profile."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import detect_python_profile  # noqa: E402
+
+detect = detect_python_profile.detect
+main = detect_python_profile.main
+
+
+LIBRARY_FIXTURE = '''"""A library module — imported, not invoked."""
+
+from __future__ import annotations
+
+__all__ = ["greet"]
+
+
+def greet(name: str) -> str:
+    """Return a greeting."""
+    return f"hello, {name}"
+'''
+
+CLI_FIXTURE = '''#!/usr/bin/env python3
+"""A CLI script.
+
+Example:
+    ./greet.py --name world
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--name", required=True)
+    args = parser.parse_args(argv)
+    print(f"hello, {args.name}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+'''
+
+SKILL_HELPER_FIXTURE = '''#!/usr/bin/env python3
+"""A skill-helper script — JSON over stdio."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.parse_args(argv)
+    payload = json.loads(sys.stdin.read())
+    print(json.dumps({"received": payload}))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+'''
+
+# Has shebang + main_def but no argparse/stdin/json — falls through to cli
+AMBIGUOUS_FIXTURE = '''#!/usr/bin/env python3
+"""An ambiguous script."""
+
+
+def main():
+    print("hi")
+
+
+if __name__ == "__main__":
+    main()
+'''
+
+
+def test_detect_library():
+    assert detect(LIBRARY_FIXTURE) == "library"
+
+
+def test_detect_cli():
+    assert detect(CLI_FIXTURE) == "cli"
+
+
+def test_detect_skill_helper():
+    assert detect(SKILL_HELPER_FIXTURE) == "skill-helper"
+
+
+def test_detect_ambiguous_defaults_to_cli():
+    assert detect(AMBIGUOUS_FIXTURE) == "cli"
+
+
+def test_empty_text_is_library():
+    # No shebang, no main, no main_def
+    assert detect("") == "library"
+
+
+def test_main_with_path_argument(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    script = tmp_path / "fixture.py"
+    script.write_text(LIBRARY_FIXTURE)
+    rc = main([str(script)])
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == "library"
+
+
+def test_main_profile_override_wins(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    # Library content but --profile=cli wins
+    script = tmp_path / "fixture.py"
+    script.write_text(LIBRARY_FIXTURE)
+    rc = main(["--profile=cli", str(script)])
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == "cli"
+
+
+def test_main_invalid_profile_value(capsys: pytest.CaptureFixture[str]):
+    rc = main(["--profile=notaprofile", "/dev/null"])
+    assert rc == 2  # argparse usage-error contract
+
+
+def test_main_unreadable_path_returns_1(capsys: pytest.CaptureFixture[str]):
+    rc = main(["/nonexistent/path/that/does/not/exist.py"])
+    assert rc == 1
+    assert "cannot read" in capsys.readouterr().err

--- a/plugins/build/pyproject.toml
+++ b/plugins/build/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "check"
-version = "0.21.0"
+version = "0.22.0"
 description = "Claude Code plugin for auditing Claude Code skills and rules for quality issues."
 requires-python = ">=3.9"
 dependencies = []

--- a/plugins/build/skills/build-python-script/SKILL.md
+++ b/plugins/build/skills/build-python-script/SKILL.md
@@ -113,7 +113,28 @@ purpose field. Otherwise ask, one question at a time:
 **1. Purpose** — one sentence: what does this script do? Preferably
 verb-phrased ("fetch daily exchange rates and write them to a CSV").
 
-**2. Invocation style** — pick one:
+**2. Profile** — pick one. See
+[python-script-profiles.md](../../_shared/references/python-script-profiles.md)
+for the full spec.
+- `cli` (default) — single-file program invoked from the shell;
+  argparse, exit codes, `__main__` guard. The current scaffold shape.
+- `library` — a module imported, not invoked. No shebang, no main,
+  no argparse. Module docstring + `__all__` + public API only.
+- `skill-helper` — JSON-over-stdio helper called from a skill.
+  Reads `json.loads(sys.stdin.read())`; writes JSON to stdout;
+  emits structured JSON errors to stderr; distinct exit codes
+  (`EXIT_OK=0`, `EXIT_USER_ERROR=2`, `EXIT_INTERNAL_ERROR=3`);
+  atomic file writes via `<path>.tmp` + `os.replace`.
+
+When profile=library, **skip Questions 3, 4, 5, and 6** (invocation
+style, input shape, output destination, destructive ops are all
+CLI-shape concerns). Ask Question 7 (third-party dependencies — a
+library can have them too) and Question 8 (save path).
+
+When profile=skill-helper, skip Question 3 (invocation style is
+fixed by the profile). Keep the rest.
+
+**3. Invocation style** *(cli only)* — pick one:
 - `cli` — accepts flags and positional args via `argparse`; has
   `--help` output. Default for anything a human invokes.
 - `glue` — fixed positional args, called from a Makefile or another
@@ -123,12 +144,12 @@ verb-phrased ("fetch daily exchange rates and write them to a CSV").
   structure already supports this; pick when the user will write
   `pytest` against `main()`.
 
-**3. Input shape** — where does the script read from?
+**4. Input shape** *(cli only)* — where does the script read from?
 - `args` — filenames or values passed as positional arguments.
 - `stdin` — reads from stdin, supports `-` as stdin sentinel.
 - `none` — no input beyond flags.
 
-**4. Output destination** — where does primary output go?
+**5. Output destination** *(cli, skill-helper)* — where does primary output go?
 - `stdout` — default; data to stdout, logs to stderr. Composable in
   pipelines.
 - `file` — writes to a path provided via `--out`. Pair with
@@ -136,12 +157,12 @@ verb-phrased ("fetch daily exchange rates and write them to a CSV").
 - `none` — the script is called for its side effects (e.g., network
   calls).
 
-**5. Destructive operations?** — does the script delete, overwrite,
-move files, or make irreversible network calls? If yes, the scaffold
-adds a `--dry-run` flag (default true) and a `--yes` confirmation
-flag. If no, those are omitted.
+**6. Destructive operations?** *(cli, skill-helper)* — does the script
+delete, overwrite, move files, or make irreversible network calls? If
+yes, the scaffold adds a `--dry-run` flag (default true) and a `--yes`
+confirmation flag. If no, those are omitted.
 
-**6. Third-party dependencies** — any non-stdlib imports? If yes,
+**7. Third-party dependencies** — any non-stdlib imports? If yes,
 collect the list and pick the declaration mechanism:
 - `pep723` — inline `# /// script` block at the top of the file. Best
   for portable single-file scripts run via `uv run` or `pipx run`.
@@ -152,7 +173,7 @@ collect the list and pick the declaration mechanism:
   needs are met by `argparse`, `pathlib`, `json`, `csv`,
   `subprocess`, `logging`, `http.client`, `tempfile`).
 
-**7. Save path** — where should the script land? No default; common
+**8. Save path** — where should the script land? No default; common
 homes: `scripts/`, `bin/`, `plugins/<name>/scripts/`,
 `.github/scripts/`. Ask explicitly.
 
@@ -160,7 +181,26 @@ homes: `scripts/`, `bin/`, `plugins/<name>/scripts/`,
 
 Produce two artifacts.
 
-**Artifact 1: The script.**
+**Artifact 1: The script.** Branch on profile.
+
+### Profile: library
+
+Use the `library` template from
+[python-script-profiles.md](../../_shared/references/python-script-profiles.md):
+module docstring + `__all__` + public functions / classes only. No
+shebang, no main, no `__main__` guard, no argparse. Type-hint the
+public API; docstring the public symbols.
+
+### Profile: skill-helper
+
+Use the `skill-helper` template from the profiles spec: cli template
+extended with `EXIT_OK / EXIT_USER_ERROR / EXIT_INTERNAL_ERROR`
+constants, `json.loads(sys.stdin.read())` payload read in `main()`,
+an `emit_error(code, message, hint=None)` helper writing JSON to
+stderr, and an `atomic_write(path, content)` helper using `<path>.tmp`
++ `os.replace`. Argparse holds flags only — payload arrives on stdin.
+
+### Profile: cli (default)
 
 One conditionalized template. Sections marked *(if destructive)* or
 *(if pep723)* are omitted when the intake rules them out.
@@ -277,6 +317,16 @@ those come from arguments or `os.environ.get()`.
 **Dependencies.** If any non-stdlib import is present, dependencies
 are declared (PEP 723 block, colocated `requirements.txt`, or
 top-of-file comment). No wildcard imports. No unused imports.
+
+**Profile fit** *(applies when profile≠cli)*. For profile=library,
+verify the draft has no shebang, no `__main__` guard, no `main()`,
+no argparse, and declares `__all__`. For profile=skill-helper,
+verify the draft reads JSON from stdin (`json.loads(sys.stdin.read())`),
+emits structured JSON to stderr on error, declares ≥2 distinct
+non-zero exit-code constants, and uses `os.replace` for any file
+writes. The
+[profiles spec](../../_shared/references/python-script-profiles.md)
+is the canonical applicability matrix.
 
 **Detector-script hygiene** *(applies when the script scans source
 for forbidden patterns — `check-*/scripts/`, or a docstring that

--- a/plugins/build/skills/check-python-script/SKILL.md
+++ b/plugins/build/skills/check-python-script/SKILL.md
@@ -33,7 +33,9 @@ license: MIT
 
 Audit a standalone Python 3 script for structural soundness, dependency posture, ruff-backed lint cleanliness, and adherence to the project's Python conventions. The rubric — what makes a Python script load-bearing, the anatomy template, the patterns that work — lives in [python-script-best-practices.md](../../_shared/references/python-script-best-practices.md).
 
-This skill follows the [check-skill pattern](../../_shared/references/check-skill-pattern.md). Tier-1 detection is in 6 scripts emitting JSON envelopes via `_common.py` (25 rule_ids total, including 13 from `check_ruff.sh` wrapping ruff). Tier-2 has 9 judgment dimensions read inline by the primary agent. Tier-3 is `collision` (cross-script duplication).
+This skill follows the [check-skill pattern](../../_shared/references/check-skill-pattern.md). Tier-1 detection is in 6 base scripts plus 2 profile-specific scripts emitting JSON envelopes via `_common.py`. Tier-2 has 9 base judgment dimensions plus up to 3 profile-specific dimensions read inline by the primary agent. Tier-3 is `collision` (cross-script duplication).
+
+**Profiles.** This skill audits three python-script shapes: `cli` (default), `library`, `skill-helper`. The applicable Tier-1 scripts and Tier-2 dimensions vary per profile. See [python-script-profiles.md](../../_shared/references/python-script-profiles.md) for the complete applicability matrix.
 
 ## When to use
 
@@ -50,36 +52,63 @@ Also fires when the user phrases the request as:
 
 Read `$ARGUMENTS`. Resolve to a `.py` file or directory walking top-level for Python scripts. Confirm scope aloud.
 
+**Resolve profile.** If `$ARGUMENTS` carries `--profile=<name>` (one of `cli`, `library`, `skill-helper`), use that. Else run the detector and use its result:
+
+```bash
+PROFILE=$(python3 "${SHARED_SCRIPTS}/detect_python_profile.py" "$TARGET")
+```
+
+The detector is heuristic and best-effort; ambiguous cases default to `cli`. Print the resolved profile to the user before continuing — if it looks wrong, they can re-run with `--profile=<name>`.
+
 ### 2. Tier-1 Deterministic Checks
 
-Invoke 6 detection scripts:
+Per-profile invocation list (full matrix in [python-script-profiles.md](../../_shared/references/python-script-profiles.md)):
 
 ```bash
 SCRIPTS="${SKILL_DIR}/scripts"
 TARGETS="$ARGUMENTS"
 
-bash "$SCRIPTS/check_secrets.sh"   $TARGETS   # 1 rule:  secret (FAIL)
-bash "$SCRIPTS/check_structure.sh" $TARGETS   # 6 rules: shebang, guard-missing, guard-shape, syntax (FAIL); main-returns, keyboard-interrupt (WARN)
-bash "$SCRIPTS/check_argparse.sh"  $TARGETS   # 3 rules: argparse-when-argv, add-argument-help, subprocess-check (WARN)
-bash "$SCRIPTS/check_deps.sh"      $TARGETS   # 1 rule:  declared-deps (WARN)
-bash "$SCRIPTS/check_ruff.sh"      $TARGETS   # 13 rules wrapping ruff codes; inapplicable when ruff missing
-bash "$SCRIPTS/check_size.sh"      $TARGETS   # 1 rule:  size (WARN)
+# Base set — runs under cli + skill-helper
+bash "$SCRIPTS/check_secrets.sh"   $TARGETS   # 1 rule:  secret (FAIL) — all profiles
+bash "$SCRIPTS/check_deps.sh"      $TARGETS   # 1 rule:  declared-deps (WARN) — all profiles
+bash "$SCRIPTS/check_ruff.sh"      $TARGETS   # 13 rules wrapping ruff codes — all profiles
+bash "$SCRIPTS/check_size.sh"      $TARGETS   # 1 rule:  size (WARN) — all profiles
+
+# CLI-shell rules — skip when profile=library
+if [[ "$PROFILE" != "library" ]]; then
+  bash "$SCRIPTS/check_structure.sh" $TARGETS   # 6 rules
+  bash "$SCRIPTS/check_argparse.sh"  $TARGETS   # 3 rules
+fi
+
+# Profile-specific
+case "$PROFILE" in
+  library)
+    python3 "$SCRIPTS/check_library_discipline.py"      $TARGETS  # 2 rules
+    ;;
+  skill-helper)
+    python3 "$SCRIPTS/check_skill_helper_contract.py"   $TARGETS  # 3 rules
+    ;;
+esac
 ```
 
 Each script emits a JSON array of envelopes. `recommended_changes` is canonical — copy through verbatim.
 
-**Script-to-rules map** (25 Tier-1 rule_ids):
+**Script-to-rules map** (Tier-1 rule_ids per profile):
 
-| Script | rule_ids | Severity |
-|---|---|---|
-| `check_secrets.sh` | `secret` | fail |
-| `check_structure.sh` | `shebang`, `guard-missing`, `guard-shape`, `syntax` | fail |
-| `check_structure.sh` | `main-returns`, `keyboard-interrupt` | warn |
-| `check_argparse.sh` | `argparse-when-argv`, `add-argument-help`, `subprocess-check` | warn |
-| `check_deps.sh` | `declared-deps` | warn |
-| `check_ruff.sh` | `ruff-D100`, `ruff-SIM115`, `ruff-PLW1514`, `ruff-PTH`, `ruff-F401`, `ruff-ANN`, `ruff-format`, `ruff-fstring-modernize` | warn |
-| `check_ruff.sh` | `ruff-E722`, `ruff-shell-true`, `ruff-S307`, `ruff-F403`, `ruff-S108` | fail |
-| `check_size.sh` | `size` | warn |
+| Script | rule_ids | Severity | Profiles |
+|---|---|---|---|
+| `check_secrets.sh` | `secret` | fail | cli, library, skill-helper |
+| `check_structure.sh` | `shebang`, `guard-missing`, `guard-shape`, `syntax` | fail | cli, skill-helper |
+| `check_structure.sh` | `main-returns`, `keyboard-interrupt` | warn | cli, skill-helper |
+| `check_argparse.sh` | `argparse-when-argv`, `add-argument-help`, `subprocess-check` | warn | cli, skill-helper |
+| `check_deps.sh` | `declared-deps` | warn | cli, library, skill-helper |
+| `check_ruff.sh` | `ruff-D100`, `ruff-SIM115`, `ruff-PLW1514`, `ruff-PTH`, `ruff-F401`, `ruff-ANN`, `ruff-format`, `ruff-fstring-modernize` | warn | cli, library, skill-helper |
+| `check_ruff.sh` | `ruff-E722`, `ruff-shell-true`, `ruff-S307`, `ruff-F403`, `ruff-S108` | fail | cli, library, skill-helper |
+| `check_size.sh` | `size` | warn | cli, library, skill-helper |
+| `check_library_discipline.py` | `library-no-side-effects` | fail | library |
+| `check_library_discipline.py` | `library-public-api-declared` | warn | library |
+| `check_skill_helper_contract.py` | `skill-helper-stdin-json` | fail | skill-helper |
+| `check_skill_helper_contract.py` | `skill-helper-atomic-write`, `skill-helper-distinct-error-codes` | warn | skill-helper |
 
 The previously-INFO `exec-bit` rule is dropped (the pattern has no INFO; the executable-bit check still runs in `_ast_checks.py` for parity but emits no finding).
 
@@ -91,7 +120,7 @@ The previously-INFO `exec-bit` rule is dropped (the pattern has no INFO; the exe
 
 ### 3. Tier-2 Judgment Dimensions
 
-For each script that passed the Tier-2 exclusion gate, evaluate against the **9 judgment rules** at `references/check-*.md`:
+For each script that passed the Tier-2 exclusion gate, evaluate against the **9 base judgment rules** at `references/check-*.md` (all profiles), plus the profile-specific dimensions from the table below:
 
 | File | Dimension | Severity |
 |---|---|---|
@@ -104,6 +133,16 @@ For each script that passed the Tier-2 exclusion gate, evaluate against the **9 
 | [check-module-scope-discipline.md](references/check-module-scope-discipline.md) | D7 — import + constant + main; no top-level work | warn |
 | [check-literal-intent.md](references/check-literal-intent.md) | D8 — magic numbers / strings named via constants | warn |
 | [check-commenting-intent.md](references/check-commenting-intent.md) | D9 — docstring + why-comments, no what-comments | warn |
+
+**Profile-specific dimensions:**
+
+| File | Dimension | Severity | Profile |
+|---|---|---|---|
+| [check-no-import-time-side-effects.md](references/check-no-import-time-side-effects.md) | Library — no work at import time | warn | library |
+| [check-public-symbols-typed.md](references/check-public-symbols-typed.md) | Library — type hints on public surface | warn | library |
+| [check-public-symbols-documented.md](references/check-public-symbols-documented.md) | Library — docstrings on public symbols | warn | library |
+| [check-structured-stderr-errors.md](references/check-structured-stderr-errors.md) | Skill-helper — JSON to stderr, not tracebacks | warn | skill-helper |
+| [check-exit-code-meaning.md](references/check-exit-code-meaning.md) | Skill-helper — distinct exit codes by recovery class | warn | skill-helper |
 
 #### Evaluator policy
 

--- a/plugins/build/skills/check-python-script/references/check-exit-code-meaning.md
+++ b/plugins/build/skills/check-python-script/references/check-exit-code-meaning.md
@@ -1,0 +1,16 @@
+---
+name: Exit Code Meaning (skill-helper)
+description: Skill-helper scripts subdivide non-zero exit codes by recovery class. `0` is success, `2` is user error (caller should fix the input), `≥3` is internal error (caller should retry / surface / fall back). A script that uses only `0` and `1` flattens decisions the caller needs.
+paths:
+  - "**/*.py"
+---
+
+A skill-helper's exit code is a structured signal to the caller. When all non-zero outcomes collapse to a single `1`, the caller cannot distinguish "fix your input" from "retry" from "give up" — and the helper's value as a composable building block degrades.
+
+**Why:** The skill-helper contract calls for distinct exit codes by recovery class. `0` is success. `2` is user error: the caller (and, transitively, the user) needs to change the input or invocation. `3` (or higher) is internal error: the helper itself failed in a way the caller can choose to retry, surface, or fall back from. The Tier-1 rule `skill-helper-distinct-error-codes` checks the *declaration* (at least 2 distinct non-zero exit-code constants); this dimension is the judgment that the *meaning* lines up — a script with `EXIT_USER_ERROR = 2` and `EXIT_INTERNAL_ERROR = 3` declared but with both codes returned interchangeably from the same code path is below the contract.
+
+**How to apply:** find the exit-code constants declared at module scope (e.g., `EXIT_USER_ERROR = 2`, `EXIT_INTERNAL_ERROR = 3`). Trace each `return <CONSTANT>` in `main()` and verify the recovery class matches: user errors (bad payload, missing required field, file-not-found of a user-supplied path) return `EXIT_USER_ERROR`; internal errors (disk full, network timeout, unexpected `Exception`) return `EXIT_INTERNAL_ERROR`. A bare `return 1` or a `return 2` from a code path that's clearly internal is a finding. The docstring or a header comment should name the exit-code meanings briefly.
+
+**Common fail signals (audit guidance):** distinct constants declared but used interchangeably (the same `except` block returns `EXIT_USER_ERROR` regardless of cause); a bare `return 1` in `main()` without a named constant; an internal error returned with `EXIT_USER_ERROR` because the author "didn't want to add a third constant"; no comment or docstring naming exit-code meanings.
+
+**What is NOT a finding:** a script that genuinely has only one failure mode and returns `EXIT_USER_ERROR` for it (recovery class is uniform); KeyboardInterrupt → 130 (signal-conventional, not an error class to subdivide); argparse usage errors → 2 (argparse owns this exit code by convention).

--- a/plugins/build/skills/check-python-script/references/check-no-import-time-side-effects.md
+++ b/plugins/build/skills/check-python-script/references/check-no-import-time-side-effects.md
@@ -1,0 +1,16 @@
+---
+name: No Import-Time Side Effects (library)
+description: Library modules perform no work at import time other than imports, type aliases, `__all__`, and pure-RHS constant assignments. Side effects at module scope make the module hostile to import for testing, partial introspection, and reuse.
+paths:
+  - "**/*.py"
+---
+
+Library modules — files imported, not invoked — must execute no work at import time. The Tier-1 `library-no-side-effects` rule catches obvious cases (top-level statements outside `def`/`class`/`import`/`AnnAssign`/`Assign`/`if TYPE_CHECKING:` block); this dimension carries the judgment for nuance the regex/AST cannot resolve.
+
+**Why:** A module that does work at import time imposes that work on every consumer that imports it — even those that only need a single symbol. It also fights testability (you can't `import` to introspect without paying the cost), couples module load order to runtime correctness, and creates difficult-to-debug surprises (`ImportError`s caused by unrelated startup code). Source principle: *Keep the module scope disciplined.* Constants, imports, type aliases, and `__all__` are fine; everything else belongs inside a function.
+
+**How to apply:** read the top-level statements of the module. Each one should be: an import, a `def`, a `class`, a constant assignment with a literal RHS, an `__all__` declaration, a type alias (e.g., `Foo: TypeAlias = int`), the module docstring, or a `if TYPE_CHECKING:` block guarding type-only imports. Anything else — a function call at module scope, a `for`/`while`/`try` block, a non-trivial expression evaluated at top level — is import-time work and is a finding. Pay particular attention to "configuration" idioms (`logging.basicConfig(...)` at module scope, `os.environ[...] = ...` at module scope) — these are the most common offenders and the most insidious.
+
+**Common fail signals (audit guidance):** `logging.basicConfig(...)` or similar configuration call at module scope; `print(...)` or other I/O at module scope; `os.environ[...] = ...` or other env-var mutation at module scope; a top-level `try/except` block doing real work (e.g., loading a config file with a fallback); a `for` loop populating a module-level constant from a runtime source.
+
+**What is NOT a finding:** module docstring (always allowed); imports including conditional imports under `if TYPE_CHECKING:`; `__all__` declaration; type aliases via `AnnAssign` (`Foo: TypeAlias = int`); module-level constants with literal RHS (`MAX_RETRIES = 3`).

--- a/plugins/build/skills/check-python-script/references/check-public-symbols-documented.md
+++ b/plugins/build/skills/check-python-script/references/check-public-symbols-documented.md
@@ -1,0 +1,16 @@
+---
+name: Public Symbols Documented (library)
+description: Public functions, classes, and methods carry docstrings explaining purpose, contract, and edge cases. The docstring is the agent-facing API contract for consumers who will not read the body.
+paths:
+  - "**/*.py"
+---
+
+Library modules document their public symbols with docstrings. The docstring is the agent-facing description a consumer reads before deciding to call the function — it is part of the API surface, not optional decoration.
+
+**Why:** Public symbols without docstrings force consumers to read the body to understand the contract. That is a friction tax paid by every consumer on every reference, and it lets the contract drift silently as the body changes. Source principle: *Document intent at the top.* The docstring is also the source the IDE, the help system, and downstream documentation tools render — silence here means silence everywhere.
+
+**How to apply:** for each top-level function, class, or method whose name does not start with `_`, verify that the first statement of its body is a string literal. The docstring should name what the symbol does, what its parameters mean (when not obvious from naming and type hints), what it returns or raises (when non-trivial), and any preconditions or edge cases the caller must know. One-line docstrings are fine for trivial functions; multi-line for anything with non-obvious behavior. Class docstrings name the invariant the class preserves. Internal helpers (names beginning with `_`) are out of scope.
+
+**Common fail signals (audit guidance):** a public function whose first statement is not a string literal; a public class whose first statement is not a string literal; a one-line docstring on a function with non-trivial behavior, edge cases, or exceptions ("does X" without naming the X-vs-Y distinction); a docstring that only restates the function name (`"""Greet a name."""` on `def greet(name)` adds no information).
+
+**What is NOT a finding:** internal helpers (names beginning with `_`); trivial properties (a property whose getter is `return self._x` is its own documentation); `__init__` methods when the class docstring already names the invariant (constructor docs are optional when they would duplicate the class docstring).

--- a/plugins/build/skills/check-python-script/references/check-public-symbols-typed.md
+++ b/plugins/build/skills/check-python-script/references/check-public-symbols-typed.md
@@ -1,0 +1,16 @@
+---
+name: Public Symbols Typed (library)
+description: Public functions and class methods declare type hints on parameters and return types. Type hints are documentation that does not drift, enable static analysis downstream, and make IDE introspection useful.
+paths:
+  - "**/*.py"
+---
+
+Library modules expose a public API surface. The functions, classes, and methods on that surface that callers will use must declare type hints — on parameters and on return types. Internal helpers (names beginning with `_`) are out of scope; the public surface is the contract.
+
+**Why:** Type hints are documentation that the runtime (and static analyzers) can verify. Without them, a public function's signature is opaque to callers — they read the body to figure out what it accepts. Source principle: *Dress the style — add type hints to function signatures.* Type hints are also the lowest-friction interface for static checking (`mypy`, `pyright`, IDE introspection) — without them, downstream consumers can't reason about the library mechanically.
+
+**How to apply:** for each top-level function, class, or method whose name does not start with `_`, verify that its parameters and return type are annotated. `def greet(name)` is a finding; `def greet(name: str) -> str:` is not. For class methods, `self` and `cls` do not require annotations; other parameters do. Generic types (`list[str]`, `Iterable[Path]`, `dict[str, int]`) are preferred over bare `list`, `Iterable`, `dict`. Use `from __future__ import annotations` to enable forward-references and avoid circular-import noise.
+
+**Common fail signals (audit guidance):** a public function without parameter annotations; a public function without a return-type annotation (use `-> None` for procedures); a public class method using `Any` to dodge the annotation work; bare `list`/`dict`/`tuple` without parametric types; a public function whose only annotation is on `self`.
+
+**What is NOT a finding:** internal helpers (names beginning with `_`); `self` and `cls` parameters; `*args, **kwargs` in subclassing/decoration scenarios where the signature is intentionally permissive (cite the reason).

--- a/plugins/build/skills/check-python-script/references/check-structured-stderr-errors.md
+++ b/plugins/build/skills/check-python-script/references/check-structured-stderr-errors.md
@@ -1,0 +1,16 @@
+---
+name: Structured Stderr Errors (skill-helper)
+description: Skill-helper scripts emit structured JSON to stderr on error, never raw tracebacks. Errors carry a `code`, a `message`, and an optional `hint`; verbose / traceback output is gated behind a `--debug` flag.
+paths:
+  - "**/*.py"
+---
+
+A skill-helper script is read by another agent. The agent's caller (a skill or another script) parses stderr to decide what to do next — surface the error to the user, retry, fall back, abort. Raw Python tracebacks defeat that machine-readability and tell the user only what failed, not why or what to do.
+
+**Why:** The skill-helper contract calls stderr a structured channel: `{"error": "<code>", "message": "<human-readable>", "hint": "<optional recovery>"}`. The `code` is a stable identifier the caller can branch on; the `message` is what reaches the human; the `hint` is the recovery action the human takes. A traceback is a debug artifact, not a contract — useful behind `--debug`, hostile by default. Source principle (skill-helper profile): structured stderr errors enforce the contract every other helper script will follow.
+
+**How to apply:** identify the error paths in `main()`. Each non-zero exit should be preceded by an `emit_error(code, message, hint=None)`-style call (or equivalent) that writes JSON to stderr. The `code` should be a short, stable identifier (`invalid-json`, `missing-required-field`, `disk-full`) — not the exception class name verbatim. Tracebacks belong behind `--debug` (or equivalent verbose flag); the default error path emits the structured envelope and nothing else. Look for `traceback.print_exc()`, bare `raise` from `main()`, or `print(err, file=sys.stderr)` (which emits the exception's `str(...)` rendering, not a structured envelope).
+
+**Common fail signals (audit guidance):** `traceback.print_exc()` in the default error path (no `--debug` gate); `raise` allowed to propagate from `main()` to the `__main__` guard (Python prints the traceback); `print(err, file=sys.stderr)` emitting an unstructured one-liner; an error message that exposes a stack frame literal (`"NoneType has no attribute 'bar'"`) instead of a stable code.
+
+**What is NOT a finding:** debug output behind a `--debug` flag (caller opted in); the structured envelope being emitted via a wrapper helper that the script declares (e.g., `emit_error()` defined as a module-level function); `KeyboardInterrupt` (130) bypassing the structured-stderr requirement (signal-driven exit, not an error path).

--- a/plugins/build/skills/check-python-script/scripts/check_library_discipline.py
+++ b/plugins/build/skills/check-python-script/scripts/check_library_discipline.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Tier-1 library-profile checks. Emits JSON ARRAY of two envelopes.
+
+Two rules:
+  - library-no-side-effects (FAIL): module-level statement outside
+    def / class / import / `__all__` assignment / type-annotated
+    assignment / `if TYPE_CHECKING:` block / module docstring.
+  - library-public-api-declared (WARN): module has public symbols
+    (top-level functions or classes with non-underscore names) but no
+    `__all__` declared.
+
+The library profile applies to modules imported, not invoked. The CLI
+shell rules from `check_structure.sh` and `check_argparse.sh` do not
+apply here; this script provides the library-specific replacements.
+
+Usage:
+    check_library_discipline.py <path> [<path> ...]
+
+Exit codes:
+    0  no FAIL findings
+    1  one or more FAIL findings
+    64 usage error
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _common import emit_json_finding, emit_rule_envelope, print_envelope  # noqa: E402
+
+EXIT_CLEAN = 0
+EXIT_FAIL = 1
+EXIT_USAGE = 64
+
+RULE_SIDE_EFFECTS = "library-no-side-effects"
+RULE_PUBLIC_API = "library-public-api-declared"
+
+RECIPE_SIDE_EFFECTS = (
+    "Move executable code into a function. Library modules should perform "
+    "no work at import time other than imports, `__all__`, type aliases, "
+    "and pure-RHS constant assignments. If guarding type-only imports, "
+    "use `if TYPE_CHECKING:` from typing."
+)
+RECIPE_PUBLIC_API = (
+    "Declare `__all__ = [...]` at module scope listing the public "
+    "symbols. Explicit `__all__` documents the public surface and "
+    "controls `from module import *` behavior."
+)
+
+ALLOWED_TOP_LEVEL_NODES = (
+    ast.Import,
+    ast.ImportFrom,
+    ast.FunctionDef,
+    ast.AsyncFunctionDef,
+    ast.ClassDef,
+    ast.AnnAssign,
+)
+
+
+def _is_docstring(node: ast.AST) -> bool:
+    if not isinstance(node, ast.Expr):
+        return False
+    value = node.value
+    return isinstance(value, ast.Constant) and isinstance(value.value, str)
+
+
+def _is_type_checking_guard(node: ast.AST) -> bool:
+    if not isinstance(node, ast.If):
+        return False
+    test = node.test
+    if isinstance(test, ast.Name) and test.id == "TYPE_CHECKING":
+        return True
+    if isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING":
+        return True
+    return False
+
+
+def _scan_side_effects(tree: ast.Module) -> list[dict]:
+    """Return findings for top-level statements that look like side effects."""
+    findings: list[dict] = []
+    for idx, node in enumerate(tree.body):
+        if isinstance(node, ALLOWED_TOP_LEVEL_NODES):
+            continue
+        if isinstance(node, ast.Assign):
+            # Permit any plain assignment — we trust the author for module-
+            # level constants and __all__. A future tightening could check
+            # that RHS is a literal or a pure expression.
+            continue
+        if idx == 0 and _is_docstring(node):
+            continue
+        if _is_type_checking_guard(node):
+            continue
+        line = getattr(node, "lineno", 0)
+        col = getattr(node, "col_offset", 0)
+        # Try to render a short context snippet.
+        try:
+            context = ast.unparse(node).split("\n", 1)[0][:80]
+        except Exception:  # noqa: BLE001
+            context = type(node).__name__
+        findings.append(
+            emit_json_finding(
+                rule_id=RULE_SIDE_EFFECTS,
+                status="fail",
+                location={"line": line, "context": context},
+                reasoning=(
+                    f"Top-level {type(node).__name__} at line {line}"
+                    f" col {col} runs at import time. Library modules "
+                    "should be side-effect-free."
+                ),
+                recommended_changes=RECIPE_SIDE_EFFECTS,
+            )
+        )
+    return findings
+
+
+def _has_public_symbols(tree: ast.Module) -> bool:
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            if not node.name.startswith("_"):
+                return True
+    return False
+
+
+def _has_dunder_all(tree: ast.Module) -> bool:
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "__all__":
+                    return True
+        elif isinstance(node, ast.AnnAssign):
+            target = node.target
+            if isinstance(target, ast.Name) and target.id == "__all__":
+                return True
+    return False
+
+
+def _scan_public_api(tree: ast.Module) -> list[dict]:
+    if not _has_public_symbols(tree):
+        return []
+    if _has_dunder_all(tree):
+        return []
+    return [
+        emit_json_finding(
+            rule_id=RULE_PUBLIC_API,
+            status="warn",
+            location=None,
+            reasoning=(
+                "Module has public symbols (non-underscore top-level "
+                "functions or classes) but does not declare `__all__`. "
+                "Explicit public-API declaration is missing."
+            ),
+            recommended_changes=RECIPE_PUBLIC_API,
+        )
+    ]
+
+
+def _iter_targets(paths: list[Path]) -> list[Path]:
+    out: list[Path] = []
+    for p in paths:
+        if p.is_dir():
+            out.extend(sorted(p.glob("*.py")))
+        elif p.is_file():
+            out.append(p)
+        else:
+            print(f"warning: {p} not found, skipping", file=sys.stderr)
+    return out
+
+
+def _scan_file(path: Path) -> tuple[list[dict], list[dict]]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as err:
+        print(f"error: cannot read {path}: {err}", file=sys.stderr)
+        return [], []
+    try:
+        tree = ast.parse(text, filename=str(path))
+    except SyntaxError as err:
+        # Invalid Python — emit a single FAIL finding under side-effects.
+        finding = emit_json_finding(
+            rule_id=RULE_SIDE_EFFECTS,
+            status="fail",
+            location={"line": err.lineno or 0, "context": str(err.msg)},
+            reasoning=f"Cannot parse {path}: {err}",
+            recommended_changes="Fix the syntax error before auditing.",
+        )
+        return [finding], []
+    return _scan_side_effects(tree), _scan_public_api(tree)
+
+
+def get_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Tier-1 library-profile checks for Python modules.",
+    )
+    parser.add_argument(
+        "paths",
+        nargs="+",
+        type=Path,
+        help="Paths to Python files or directories.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = get_parser().parse_args(argv)
+    targets = _iter_targets(args.paths)
+    if not targets:
+        print("error: no Python files found", file=sys.stderr)
+        return EXIT_USAGE
+
+    side_findings: list[dict] = []
+    api_findings: list[dict] = []
+    for path in targets:
+        s, a = _scan_file(path)
+        side_findings.extend(s)
+        api_findings.extend(a)
+
+    side_envelope = emit_rule_envelope(RULE_SIDE_EFFECTS, side_findings)
+    api_envelope = emit_rule_envelope(RULE_PUBLIC_API, api_findings)
+    print_envelope([side_envelope, api_envelope])
+
+    return EXIT_FAIL if side_envelope["overall_status"] == "fail" else EXIT_CLEAN
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/plugins/build/skills/check-python-script/scripts/check_skill_helper_contract.py
+++ b/plugins/build/skills/check-python-script/scripts/check_skill_helper_contract.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Tier-1 skill-helper-profile checks. Emits JSON ARRAY of three envelopes.
+
+Three rules:
+  - skill-helper-stdin-json (FAIL): the script does not read a JSON
+    payload from stdin. Required pattern is `json.loads(sys.stdin.read())`
+    or `json.load(sys.stdin)`.
+  - skill-helper-atomic-write (WARN): the script writes to files but
+    does not use the `<path>.tmp` + `os.replace` atomic-write pattern.
+  - skill-helper-distinct-error-codes (WARN): the script may exit
+    non-zero but does not declare distinct error codes (e.g.,
+    `EXIT_USER_ERROR = 2` and `EXIT_INTERNAL_ERROR = 3`).
+
+Usage:
+    check_skill_helper_contract.py <path> [<path> ...]
+
+Exit codes:
+    0  no FAIL findings
+    1  one or more FAIL findings
+    64 usage error
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _common import emit_json_finding, emit_rule_envelope, print_envelope  # noqa: E402
+
+EXIT_CLEAN = 0
+EXIT_FAIL = 1
+EXIT_USAGE = 64
+
+RULE_STDIN_JSON = "skill-helper-stdin-json"
+RULE_ATOMIC_WRITE = "skill-helper-atomic-write"
+RULE_EXIT_CODES = "skill-helper-distinct-error-codes"
+
+RECIPE_STDIN_JSON = (
+    "Read the payload from stdin via "
+    "`payload = json.loads(sys.stdin.read())`. The skill-helper "
+    "contract is JSON over stdio — do not accept payload through "
+    "CLI flags."
+)
+RECIPE_ATOMIC_WRITE = (
+    "When writing files, use the atomic-write pattern: "
+    "`tmp = path.with_suffix(path.suffix + '.tmp'); "
+    "tmp.write_text(content); os.replace(tmp, path)`. Direct "
+    "`path.write_text(...)` may leave half-written state on "
+    "interruption."
+)
+RECIPE_EXIT_CODES = (
+    "Declare distinct exit-code constants and return them by intent: "
+    "`EXIT_OK = 0`, `EXIT_USER_ERROR = 2`, `EXIT_INTERNAL_ERROR = 3`. "
+    "A script that uses only 0 and 1 is below the contract — non-zero "
+    "must be subdivided when the caller's recovery action differs."
+)
+
+_FILE_WRITE_RE = re.compile(
+    r"\.write_text\s*\(|\.write_bytes\s*\(|\bopen\s*\([^)]*[\"']w"
+)
+_OS_REPLACE_RE = re.compile(r"os\.replace\s*\(|\.replace\s*\(\s*[a-zA-Z_]")
+_TMP_SUFFIX_RE = re.compile(r"['\"]\.tmp['\"]|with_suffix\s*\([^)]*tmp")
+
+
+def _has_stdin_json(tree: ast.Module, source: str) -> bool:
+    """True if the script reads stdin and parses JSON from it."""
+    has_stdin_read = False
+    has_json_loads = False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute) and node.attr == "read":
+            value = node.value
+            if (
+                isinstance(value, ast.Attribute)
+                and value.attr == "stdin"
+                and isinstance(value.value, ast.Name)
+                and value.value.id == "sys"
+            ):
+                has_stdin_read = True
+        if isinstance(node, ast.Attribute) and node.attr in ("loads", "load"):
+            value = node.value
+            if isinstance(value, ast.Name) and value.id == "json":
+                has_json_loads = True
+    if has_stdin_read and has_json_loads:
+        return True
+    # Allow the shorter form `json.load(sys.stdin)` even without an explicit
+    # `.read()` call.
+    return bool(re.search(r"json\.load\s*\(\s*sys\.stdin", source))
+
+
+def _has_atomic_write(source: str) -> bool:
+    if not _FILE_WRITE_RE.search(source):
+        # No file writes detected — rule is inapplicable, treat as pass.
+        return True
+    return bool(_OS_REPLACE_RE.search(source) and _TMP_SUFFIX_RE.search(source))
+
+
+def _has_distinct_error_codes(tree: ast.Module) -> bool:
+    """True if at least 2 distinct non-zero exit-code constants are declared."""
+    distinct_nonzero: set[int] = set()
+    for node in tree.body:
+        if isinstance(node, (ast.Assign, ast.AnnAssign)):
+            value = getattr(node, "value", None)
+            if isinstance(value, ast.Constant) and isinstance(value.value, int):
+                if value.value > 0:
+                    distinct_nonzero.add(value.value)
+    return len(distinct_nonzero) >= 2
+
+
+def _scan_file(path: Path) -> dict[str, list[dict]]:
+    findings_by_rule: dict[str, list[dict]] = {
+        RULE_STDIN_JSON: [],
+        RULE_ATOMIC_WRITE: [],
+        RULE_EXIT_CODES: [],
+    }
+    try:
+        source = path.read_text(encoding="utf-8")
+    except OSError as err:
+        print(f"error: cannot read {path}: {err}", file=sys.stderr)
+        return findings_by_rule
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError as err:
+        findings_by_rule[RULE_STDIN_JSON].append(
+            emit_json_finding(
+                rule_id=RULE_STDIN_JSON,
+                status="fail",
+                location={"line": err.lineno or 0, "context": str(err.msg)},
+                reasoning=f"Cannot parse {path}: {err}",
+                recommended_changes="Fix the syntax error before auditing.",
+            )
+        )
+        return findings_by_rule
+
+    if not _has_stdin_json(tree, source):
+        findings_by_rule[RULE_STDIN_JSON].append(
+            emit_json_finding(
+                rule_id=RULE_STDIN_JSON,
+                status="fail",
+                location=None,
+                reasoning=(
+                    "No `json.loads(sys.stdin.read())` (or equivalent) "
+                    "found. The skill-helper contract requires the "
+                    "payload to arrive on stdin as JSON."
+                ),
+                recommended_changes=RECIPE_STDIN_JSON,
+            )
+        )
+
+    if not _has_atomic_write(source):
+        findings_by_rule[RULE_ATOMIC_WRITE].append(
+            emit_json_finding(
+                rule_id=RULE_ATOMIC_WRITE,
+                status="warn",
+                location=None,
+                reasoning=(
+                    "File writes detected but no atomic-write pattern "
+                    "(`.tmp` + `os.replace`) found. Direct writes can "
+                    "leave half-written state on interruption."
+                ),
+                recommended_changes=RECIPE_ATOMIC_WRITE,
+            )
+        )
+
+    if not _has_distinct_error_codes(tree):
+        findings_by_rule[RULE_EXIT_CODES].append(
+            emit_json_finding(
+                rule_id=RULE_EXIT_CODES,
+                status="warn",
+                location=None,
+                reasoning=(
+                    "Fewer than two distinct non-zero exit-code "
+                    "constants declared. The contract calls for "
+                    "subdividing failure (e.g., user vs internal "
+                    "error) when the caller's recovery action differs."
+                ),
+                recommended_changes=RECIPE_EXIT_CODES,
+            )
+        )
+
+    return findings_by_rule
+
+
+def _iter_targets(paths: list[Path]) -> list[Path]:
+    out: list[Path] = []
+    for p in paths:
+        if p.is_dir():
+            out.extend(sorted(p.glob("*.py")))
+        elif p.is_file():
+            out.append(p)
+        else:
+            print(f"warning: {p} not found, skipping", file=sys.stderr)
+    return out
+
+
+def get_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Tier-1 skill-helper-profile checks for Python scripts.",
+    )
+    parser.add_argument(
+        "paths",
+        nargs="+",
+        type=Path,
+        help="Paths to Python files or directories.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = get_parser().parse_args(argv)
+    targets = _iter_targets(args.paths)
+    if not targets:
+        print("error: no Python files found", file=sys.stderr)
+        return EXIT_USAGE
+
+    accumulated: dict[str, list[dict]] = {
+        RULE_STDIN_JSON: [],
+        RULE_ATOMIC_WRITE: [],
+        RULE_EXIT_CODES: [],
+    }
+    for path in targets:
+        per_file = _scan_file(path)
+        for rule_id, findings in per_file.items():
+            accumulated[rule_id].extend(findings)
+
+    envelopes = [
+        emit_rule_envelope(rule_id, findings)
+        for rule_id, findings in accumulated.items()
+    ]
+    print_envelope(envelopes)
+
+    has_fail = any(env["overall_status"] == "fail" for env in envelopes)
+    return EXIT_FAIL if has_fail else EXIT_CLEAN
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/plugins/build/skills/check-python-script/scripts/tests/test_library.py
+++ b/plugins/build/skills/check-python-script/scripts/tests/test_library.py
@@ -1,0 +1,118 @@
+"""Tests for check_library_discipline."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import check_library_discipline  # noqa: E402
+
+main = check_library_discipline.main
+
+
+CLEAN_LIBRARY = '''"""A clean library module."""
+
+from __future__ import annotations
+
+__all__ = ["greet"]
+
+
+def greet(name: str) -> str:
+    """Return a greeting."""
+    return f"hello, {name}"
+
+
+class Greeter:
+    """A greeter class."""
+
+    def __init__(self, prefix: str) -> None:
+        self.prefix = prefix
+'''
+
+LIBRARY_WITH_SIDE_EFFECT = '''"""Library with a top-level side effect."""
+
+from __future__ import annotations
+
+__all__ = ["greet"]
+
+print("hello at import time")
+
+
+def greet(name: str) -> str:
+    return f"hello, {name}"
+'''
+
+LIBRARY_MISSING_DUNDER_ALL = '''"""Library without __all__."""
+
+
+def greet(name: str) -> str:
+    """Return a greeting."""
+    return f"hello, {name}"
+'''
+
+LIBRARY_TYPE_CHECKING_OK = '''"""Library that uses TYPE_CHECKING — should be fine."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+__all__ = ["greet"]
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+def greet(name: str) -> str:
+    return f"hello, {name}"
+'''
+
+
+def _run(tmp_path: Path, content: str) -> tuple[int, str]:
+    """Write content to a fixture and run the detector; return (rc, stdout)."""
+    import io
+
+    fixture = tmp_path / "fixture.py"
+    fixture.write_text(content)
+
+    captured = io.StringIO()
+    real_stdout = sys.stdout
+    sys.stdout = captured
+    try:
+        rc = main([str(fixture)])
+    finally:
+        sys.stdout = real_stdout
+    return rc, captured.getvalue()
+
+
+def test_clean_library_passes(tmp_path: Path):
+    rc, out = _run(tmp_path, CLEAN_LIBRARY)
+    assert rc == 0
+    assert '"library-no-side-effects"' in out
+    assert '"overall_status": "pass"' in out
+    # Public API declared, so no warn either:
+    assert out.count('"overall_status": "pass"') == 2
+
+
+def test_side_effect_fails(tmp_path: Path):
+    rc, out = _run(tmp_path, LIBRARY_WITH_SIDE_EFFECT)
+    assert rc == 1
+    assert '"rule_id": "library-no-side-effects"' in out
+    assert '"status": "fail"' in out
+    assert "print" in out
+
+
+def test_missing_dunder_all_warns(tmp_path: Path):
+    rc, out = _run(tmp_path, LIBRARY_MISSING_DUNDER_ALL)
+    # No fail, only warn — exit 0
+    assert rc == 0
+    assert '"rule_id": "library-public-api-declared"' in out
+    assert '"status": "warn"' in out
+
+
+def test_type_checking_block_allowed(tmp_path: Path):
+    rc, out = _run(tmp_path, LIBRARY_TYPE_CHECKING_OK)
+    assert rc == 0
+    # Both rules pass
+    assert out.count('"overall_status": "pass"') == 2

--- a/plugins/build/skills/check-python-script/scripts/tests/test_skill_helper.py
+++ b/plugins/build/skills/check-python-script/scripts/tests/test_skill_helper.py
@@ -1,0 +1,144 @@
+"""Tests for check_skill_helper_contract."""
+
+from __future__ import annotations
+
+import io
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import check_skill_helper_contract  # noqa: E402
+
+main = check_skill_helper_contract.main
+
+
+CLEAN_SKILL_HELPER = '''#!/usr/bin/env python3
+"""A clean skill-helper script."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+EXIT_OK = 0
+EXIT_USER_ERROR = 2
+EXIT_INTERNAL_ERROR = 3
+
+
+def emit_error(code, message):
+    print(json.dumps({"error": code, "message": message}), file=sys.stderr)
+
+
+def atomic_write(path, content):
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(content)
+    os.replace(tmp, path)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    args = parser.parse_args(argv)
+    payload = json.loads(sys.stdin.read())
+    print(json.dumps({"received": payload}))
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+'''
+
+# Reads payload from a file flag instead of stdin — fails the contract.
+HELPER_NO_STDIN_JSON = '''#!/usr/bin/env python3
+"""A non-conforming script that takes payload via a flag."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+EXIT_OK = 0
+EXIT_USER_ERROR = 2
+EXIT_INTERNAL_ERROR = 3
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--payload-file", required=True)
+    args = parser.parse_args(argv)
+    with open(args.payload_file) as f:
+        payload = json.load(f)
+    print(json.dumps(payload))
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+'''
+
+# Has stdin-json but no atomic write and only 0/1 exit codes.
+HELPER_NON_ATOMIC_AND_FLAT_CODES = '''#!/usr/bin/env python3
+"""Script with stdin-json but missing atomic write and distinct codes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args(argv)
+    payload = json.loads(sys.stdin.read())
+    args.out.write_text(json.dumps(payload))  # not atomic
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+'''
+
+
+def _run(tmp_path: Path, content: str) -> tuple[int, str]:
+    fixture = tmp_path / "fixture.py"
+    fixture.write_text(content)
+    captured = io.StringIO()
+    real_stdout = sys.stdout
+    sys.stdout = captured
+    try:
+        rc = main([str(fixture)])
+    finally:
+        sys.stdout = real_stdout
+    return rc, captured.getvalue()
+
+
+def test_clean_skill_helper_passes(tmp_path: Path):
+    rc, out = _run(tmp_path, CLEAN_SKILL_HELPER)
+    assert rc == 0
+    # All three envelopes pass
+    assert out.count('"overall_status": "pass"') == 3
+
+
+def test_no_stdin_json_fails(tmp_path: Path):
+    rc, out = _run(tmp_path, HELPER_NO_STDIN_JSON)
+    assert rc == 1
+    assert '"rule_id": "skill-helper-stdin-json"' in out
+    # The fail finding text mentions the rule
+    assert '"status": "fail"' in out
+
+
+def test_non_atomic_and_flat_codes_warn(tmp_path: Path):
+    rc, out = _run(tmp_path, HELPER_NON_ATOMIC_AND_FLAT_CODES)
+    # No fail (stdin-json passes), only warns — exit 0
+    assert rc == 0
+    assert '"rule_id": "skill-helper-atomic-write"' in out
+    assert '"rule_id": "skill-helper-distinct-error-codes"' in out
+    # At least 2 warns total
+    assert out.count('"status": "warn"') >= 2


### PR DESCRIPTION
## Summary

Closes #380 and closes #389. Bundles two issues under one coherent abstraction: a profile mechanism for the python-script primitives.

Three profiles, defined in a single source of truth:

- **`cli`** — current behavior (default). Every existing python script in the repo is `cli`-profile; nothing changes for them.
- **`library`** — modules imported, not invoked. No shebang / main / argparse; require `__all__`, type hints, docstrings on the public surface; no module-level side effects.
- **`skill-helper`** — JSON-over-stdio helper called from skills. Reads `json.loads(sys.stdin.read())`; structured JSON errors to stderr; distinct exit codes (`0` / `2` user / `3` internal); atomic file writes via `<path>.tmp` + `os.replace`.

## Architecture (load-bearing decisions, called out in the plan)

1. **Profile = CLI flag** (`--profile=<name>`), not magic-comment in the script. Build asks; check flag-or-detects via heuristic with `cli` as the ambiguous-case fallback.
2. **Asymmetric**: build asks (no script to detect from); check detects-or-flag.
3. **Orchestrator-level applicability** — the existing 6 Tier-1 scripts are unchanged. `check-python-script/SKILL.md` decides per-profile invocation. Minimizes blast radius.
4. **Enum (3 values)**, not composable feature flags.
5. **Default = `cli`** — existing scripts audit identically. Verified by 3 sampled scripts in the smoke-test commit body.

## Commits (10 — one per task)

| # | Subject | SHA |
|---|---|---|
| 1 | Profiles spec | `637d76c` |
| 2 | Profile detector + 9 tests | `0c0428b` |
| 3 | Library Tier-1 detector + 4 tests | `70de3af` |
| 4 | Skill-helper Tier-1 detector + 3 tests | `7de4148` |
| 5 | Library Tier-2 dimensions (3 docs) | `cbd007a` |
| 6 | Skill-helper Tier-2 dimensions (2 docs) | `2dba27a` |
| 7 | build-python-script profile adoption | `d5353ce` |
| 8 | check-python-script orchestration | `ea779c0` |
| 9 | build plugin 0.21.0 → 0.22.0 | `2e035e6` |
| 10 | Verification summary + smoke tests | `7c04eab` |

## What changes for users

- `/build:build-python-script` adds a Profile question early in intake; library and skill-helper profiles get distinct templates from the spec
- `/build:check-python-script` accepts `--profile=<name>` (or auto-detects); the script-to-rules table gains a Profiles column

## Out of scope (explicit)

- `profile=service` (long-running daemons) — separate decision
- `profile=test` (pytest test files) — was #385, closed as won't-do
- Magic-comment / frontmatter in scripts (keeps script convention simple)
- Auto-migrating existing scripts to add `--profile`
- Profile composability (combinable feature flags)
- Edits to existing 6 Tier-1 scripts or 9 existing Tier-2 dimensions

## Validation (12/12)

All automated criteria pass; criteria 8 (CLI regression) and 9 (new-profile smoke tests) human-confirmed and recorded in commit `7c04eab`'s body.

- 19 unit tests pass total (9 detector + 4 library + 3 skill-helper + 13 existing common — no regression)
- 3 sampled existing CLI scripts classified as `cli` by detector (regression check)
- Clean library + clean skill-helper fixtures audit zero-FAIL against their respective Tier-1 detectors

## Test plan

- [ ] CI passes
- [ ] Spot-check the build-python-script intake — profile question fires; library template has no shebang/main/argparse; skill-helper template has stdin-JSON read and atomic-write helper
- [ ] Spot-check the check-python-script orchestration — `--profile=library` skips structure/argparse checks; auto-detection on a library module returns `library`

🤖 Generated with [Claude Code](https://claude.com/claude-code)