### PR TITLE
chore: bump wiki/work versions, backfill changelogs

### DIFF
--- a/plugins/build/CHANGELOG.md
+++ b/plugins/build/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.22.0
+
+- Python script profiles (cli/library/skill-helper) for
+  `build-python-script` and `check-python-script` (#430, refs #380 #389):
+  - Profiles spec at `_shared/references/python-script-profiles.md` —
+    canonical source for both halves of the pair.
+  - `_shared/scripts/detect_python_profile.py` heuristic detector with
+    `--profile=<name>` override (stdlib only, 9 unit tests).
+  - `check-python-script` Tier-1 detectors: library-discipline
+    (no-side-effects, public-api-declared) and skill-helper-contract
+    (stdin-json, atomic-write, distinct-error-codes).
+  - `check-python-script` Tier-2 dimensions: library
+    (no-import-time-side-effects, public-symbols-typed,
+    public-symbols-documented) and skill-helper
+    (structured-stderr-errors, exit-code-meaning).
+  - `build-python-script` Step 3 elicits profile up-front; Step 4 Draft
+    branches on profile; Step 5 Safety Check adds Profile-fit group.
+- Trigger-cap sweep: cap each SKILL.md description to ≤3 quoted phrases;
+  surplus phrases relocated to `## When to use` (#429, refs #399). Adds
+  `_shared/scripts/count_triggers.py` audit script. Touches every
+  `build-*` and `check-*` skill description.
+
 ## 0.21.0
 
 - Refactor every check-* skill onto the unified single-artifact-per-rule

--- a/plugins/wiki/.claude-plugin/plugin.json
+++ b/plugins/wiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Skills for building and maintaining structured project context — setup, research, ingest, and lint.",
   "author": {
     "name": "Brandon Beidel"

--- a/plugins/wiki/CHANGELOG.md
+++ b/plugins/wiki/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.5.2
+
+- Trigger-cap sweep: cap each SKILL.md description to ≤3 quoted phrases;
+  surplus phrases relocated to `## When to use` (#429, refs #399).
+  Touches `ingest`, `lint`, and `research` skill descriptions.

--- a/plugins/wiki/pyproject.toml
+++ b/plugins/wiki/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wiki"
-version = "0.5.1"
+version = "0.5.2"
 description = "Claude Code plugin for building and maintaining structured project context."
 requires-python = ">=3.9"
 dependencies = []

--- a/plugins/work/.claude-plugin/plugin.json
+++ b/plugins/work/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "work",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Skills for the full work lifecycle — scope-work, plan-work, start-work, verify-work, and finish-work.",
   "author": {
     "name": "Brandon Beidel"

--- a/plugins/work/CHANGELOG.md
+++ b/plugins/work/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.2.2
+
+- Trigger-cap sweep: cap each SKILL.md description to ≤3 quoted phrases;
+  surplus phrases relocated to `## When to use` (#429, refs #399).
+  Touches `finish-work`, `scope-work`, `start-work`, and `verify-work`
+  skill descriptions.


### PR DESCRIPTION
## Summary

- `build` 0.22.0 — backfill `plugins/build/CHANGELOG.md` with the 0.22.0 entry covering #430 (python-script profiles: cli/library/skill-helper bundle) and #429 (trigger-cap sweep, build half). No code change; the version was already bumped in #430.
- `wiki` 0.5.1 → **0.5.2** — patch bump for #429 trigger-cap sweep across `ingest`/`lint`/`research` skill descriptions. Adds `plugins/wiki/CHANGELOG.md`.
- `work` 0.2.1 → **0.2.2** — patch bump for #429 trigger-cap sweep across `finish-work`/`scope-work`/`start-work`/`verify-work` skill descriptions. Adds `plugins/work/CHANGELOG.md`.
- `consider` — no changes; already at 0.1.3 with up-to-date changelog.

Patch (not minor) per CONTRIBUTING.md: trigger-cap is doc-only reorganization of description text — no new skills, scripts, or behavior.

## Test plan

- [x] `plugin.json` and `pyproject.toml` versions match within each plugin
- [x] No source code changed; only changelogs and version strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)