### PR TITLE
Cycle 3: cite-not-restate Evaluator policy + best-practices sweeps (rows 4, 7, 8, 18)

### DIFF
--- a/plugins/build/.claude-plugin/plugin.json
+++ b/plugins/build/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "build",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Skills for creating and refining Claude Code skills, rules, hooks, and subagents.",
   "author": {
     "name": "Brandon Beidel"

--- a/plugins/build/CHANGELOG.md
+++ b/plugins/build/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 0.23.0
+
+- Repo simplification sweep cycles 1–3 (codify-then-sweep, per design
+  `.designs/2026-05-07-simplification-sweep.design.md`):
+  - **Cycle 1 (#432):** New Tier-1 detector
+    `_shared/scripts/check_handoff_shape.py` flags `Receives:` /
+    `Produces:` lines in any SKILL.md `## Handoff` section. Wired into
+    `check-skill` Tier-1; codified in
+    `skill-best-practices.md`. Sweep removed Receives/Produces
+    boilerplate from ~55 SKILL.md across all 4 plugins.
+  - **Cycle 2 (#433):** New Tier-1 detector
+    `_shared/scripts/check_reference_lead.py` flags judgment-rule
+    `references/*.md` files whose first body paragraph paraphrases the
+    frontmatter `description:` (Jaccard token-overlap ≥ 0.70, stopwords
+    excluded). Wired into `check-skill` Tier-1. Sweep dropped the
+    leading restatement from 39 reference files.
+  - **Cycle 3 (this release):** New Tier-1 detector
+    `_shared/scripts/check_evaluator_policy_echo.py` flags SKILL.md
+    files that copy the verbatim Evaluator-policy bullet triple from
+    `check-skill-pattern.md` instead of citing the canonical SSoT
+    (boolean AND across "Default-closed when borderline", "Severity
+    floor: WARN", "One finding per dimension"). New Tier-2 dimension
+    `check-skill/references/check-best-practices-doc-restatement.md`
+    covers the broader pattern. The pattern doc itself flipped from
+    "(copy verbatim)" to "(cite via anchor link)". Sweeps applied:
+    Row 4 (12 check-* SKILL.md cite Evaluator policy by anchor),
+    Row 7 (6 build-* SKILL.md drop generic "rm <path>" Recovery
+    stanzas), Row 8 (7 build-* SKILL.md drop Won't bullets that
+    echo frontmatter or Scope/Review-Gate steps), Row 18 (2 build-*
+    SKILL.md collapse language-tiebreaker prose to a one-line link
+    to `primitive-routing.md §Language Selection`).
+  - Authoring rule "cite, don't restate, the principles doc" landed in
+    both `skill-best-practices.md` and `skill-pair-best-practices.md`;
+    `build-skill` and `build-skill-pair` scaffolder prose updated.
+
 ## 0.22.0
 
 - Python script profiles (cli/library/skill-helper) for

--- a/plugins/build/_shared/references/check-skill-pattern.md
+++ b/plugins/build/_shared/references/check-skill-pattern.md
@@ -123,12 +123,16 @@ Three load-bearing sections shape the skill's behavior:
 
 **Tier-1 section** invokes scripts with `python3 path/script.py $TARGETS` and `bash path/script.sh $TARGETS`. Documents the JSON envelope shape inline (copy verbatim from this doc). Lists a **Script-to-rules map** table enumerating each script's emitted `rule_id`s — the table is the canonical TOC for the scripted half of the rule set. Names the Tier-2-exclusion-list (which FAILs short-circuit Tier-2; which do not).
 
-**Tier-2 section** says: "the primary agent reads each `references/check-*.md` and judges the artifact directly." No subagent dispatch, no SDK calls, no API key. The dimensions table links each `.md` file. Includes the **Evaluator policy** subsection (copy verbatim):
+**Tier-2 section** says: "the primary agent reads each `references/check-*.md` and judges the artifact directly." No subagent dispatch, no SDK calls, no API key. The dimensions table links each `.md` file. Cites the **Evaluator policy** below by anchor link to this section (`_shared/references/check-skill-pattern.md#evaluator-policy`); does not duplicate the bullets. Verbatim copies are flagged by `evaluator-policy-echo` (Tier-1) and `best-practices-doc-restatement` (Tier-2).
 
-> - **Single locked-rubric pass per artifact.** Read all N files first, then evaluate each in turn against the unified rubric. A single locked-rubric pass stabilizes severity.
-> - **Default-closed when borderline.** When evidence is ambiguous, return `warn`, not `pass`.
-> - **Severity floor: WARN.** Judgment-mode findings default to WARN — coaching, not blocking. Escalate to FAIL only for safety concerns Tier-1 missed.
-> - **One finding per dimension maximum.** Surface the highest-signal location with concrete detail. Bulk findings train the user to disregard the audit.
+### Evaluator policy
+
+This is the canonical statement. SKILL.md cites; does not restate.
+
+- **Single locked-rubric pass per artifact.** Read all N files first, then evaluate each in turn against the unified rubric. A single locked-rubric pass stabilizes severity.
+- **Default-closed when borderline.** When evidence is ambiguous, return `warn`, not `pass`.
+- **Severity floor: WARN.** Judgment-mode findings default to WARN — coaching, not blocking. Escalate to FAIL only for safety concerns Tier-1 missed.
+- **One finding per dimension maximum.** Surface the highest-signal location with concrete detail. Bulk findings train the user to disregard the audit.
 
 **Tier-3 section** (cross-entity collision) fires only when the audit scope holds multiple artifacts. It is itself a judgment rule — usually `references/check-cross-entity-collision.md` — and follows the same Tier-2 contract. Single-artifact scope returns `inapplicable` silently.
 

--- a/plugins/build/_shared/references/skill-best-practices.md
+++ b/plugins/build/_shared/references/skill-best-practices.md
@@ -64,6 +64,8 @@ Load-bearing elements: the frontmatter identity (`name`, `description`, `version
 
 **Keep the Handoff section to `Chainable to:` only.** When a skill ends with a `## Handoff` section, write a single `**Chainable to:**` line naming the next-step skills. Do not include `**Receives:**` (it restates `argument-hint:` frontmatter) or `**Produces:**` (it restates the `## Output Format` heading). The deterministic check is `plugins/build/_shared/scripts/check_handoff_shape.py`.
 
+**Cite, don't restate, the principles doc.** When the SKILL.md cites a `*-best-practices.md` (or comparable SSoT like `check-skill-pattern.md`), the SKILL.md does not restate that doc's named principles. Link to the canonical statement and proceed; verbatim copies drift on every edit and double-count the same content. Tier-1 helper `check_evaluator_policy_echo.py` covers the Evaluator-policy case; Tier-2 dimension `check-best-practices-doc-restatement` covers the broader pattern.
+
 **Speak in plain, direct English.** Define domain terms on first use; avoid undefined jargon and abbreviations. Keep terminology consistent — if one step names `service_name`, don't later call it `svc`. Prefer definite phrasing over hedges like *etc.*, *maybe*, *probably*, *somehow*, *TBD*, *???*; ambiguity propagates directly into model behavior.
 
 **Anchor with a concrete example.** At least one `## Examples` entry with inputs, outputs, and observable side effects. Abstract rules alone drift.

--- a/plugins/build/_shared/references/skill-pair-best-practices.md
+++ b/plugins/build/_shared/references/skill-pair-best-practices.md
@@ -90,6 +90,7 @@ The check half's rule set is the union of `references/check-*.md` filenames + `r
 - **Per-finding Repair Loop.** The audit always offers an opt-in repair with per-item confirmation. Bulk application overwrites mid-refactor intent; per-finding keeps the user in control.
 - **Scope Gate in the build half.** A scaffolder that forgets its scope produces out-of-bounds artifacts. Explicit refusal signals (wrong primitive, wrong language, setuid intent, etc.) at the top of the build workflow keep the pair honest.
 - **Pair registered in `primitive-routing.md`.** Both route lines (`/build:build-<primitive>` and `/build:check-<primitive>`) appear, and the primitive class is described under *What Each Primitive Was Designed For* (new class) or *Language Selection* (variant).
+- **SKILL.md cites the principles doc; it does not restate it.** When either half links to the principles doc (or to `check-skill-pattern.md` for the check half's Evaluator policy), the body emits a citation, not a copy. Verbatim duplicates of named principles drift on every edit; the Tier-1 helper `check_evaluator_policy_echo.py` and the Tier-2 dimension `check-best-practices-doc-restatement` flag the pattern.
 
 ## Anti-Patterns
 

--- a/plugins/build/_shared/scripts/check_evaluator_policy_echo.py
+++ b/plugins/build/_shared/scripts/check_evaluator_policy_echo.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Detect verbatim Evaluator-policy bullets in check-* SKILL.md files.
+
+The canonical Evaluator policy lives in
+`plugins/build/_shared/references/check-skill-pattern.md#evaluator-policy`.
+A check-* SKILL.md should cite that anchor, not duplicate the bullets.
+
+This detector flags any SKILL.md whose body contains all three sentinel
+phrases that uniquely identify the Evaluator-policy bullets:
+- "Default-closed when borderline"
+- "Severity floor: WARN"
+- "One finding per dimension"
+
+All three must appear (boolean AND) before the SKILL.md is flagged. Two
+of three is permitted — partial overlap is common in unrelated prose.
+
+Usage:
+    check_evaluator_policy_echo.py <path> [<path> ...]
+    check_evaluator_policy_echo.py --human plugins
+    check_evaluator_policy_echo.py --envelope plugins/build/skills/check-readme/SKILL.md
+
+Each path may be a directory (walked recursively for `SKILL.md`) or a
+single `SKILL.md` file. With no paths, walks the current working
+directory.
+
+Output: JSON array of violations to stdout (or human-readable lines
+with --human, or check-skill envelopes with --envelope). Exit 0 if
+clean, 1 if any violations, 2 on read error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+_SENTINELS = (
+    "Default-closed when borderline",
+    "Severity floor: WARN",
+    "One finding per dimension",
+)
+
+
+def _iter_skill_files(paths: list[Path]) -> list[Path]:
+    out: list[Path] = []
+    for p in paths:
+        if p.is_file() and p.name == "SKILL.md":
+            out.append(p)
+        elif p.is_dir():
+            out.extend(sorted(p.rglob("SKILL.md")))
+    return out
+
+
+def find_violations(text: str) -> list[dict]:
+    """Return [{line, sentinel, text}] for each sentinel hit, but only
+    if all three sentinels are present in the text. If fewer than three
+    appear, return [] — partial overlap is not a violation.
+    """
+    hits: list[dict] = []
+    for sentinel in _SENTINELS:
+        for m in re.finditer(re.escape(sentinel), text):
+            line_no = text.count("\n", 0, m.start()) + 1
+            line_text = text.splitlines()[line_no - 1].strip()
+            hits.append({"line": line_no, "sentinel": sentinel, "text": line_text})
+    sentinels_present = {h["sentinel"] for h in hits}
+    if len(sentinels_present) < len(_SENTINELS):
+        return []
+    hits.sort(key=lambda v: v["line"])
+    return hits
+
+
+def get_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Flag verbatim Evaluator-policy bullets in check-* SKILL.md.",
+    )
+    parser.add_argument(
+        "paths",
+        type=Path,
+        nargs="*",
+        help="SKILL.md files or directories to walk. Defaults to current dir.",
+    )
+    parser.add_argument(
+        "--human",
+        action="store_true",
+        help="Emit human-readable lines instead of JSON.",
+    )
+    parser.add_argument(
+        "--envelope",
+        action="store_true",
+        help="Emit a check-skill-style envelope (rule_id=evaluator-policy-echo).",
+    )
+    return parser
+
+
+_RECOMMENDED_CHANGES = (
+    "Replace the verbatim Evaluator-policy bullets with a citation to "
+    "`_shared/references/check-skill-pattern.md#evaluator-policy`. "
+    "The pattern doc is the SSoT; SKILL.md cites, not duplicates."
+)
+
+
+def _build_envelope(violations: list[dict]) -> dict:
+    findings = [
+        {
+            "status": "warn",
+            "location": {
+                "line": v["line"],
+                "context": f"{v['file']}: {v['text']}",
+            },
+            "reasoning": (
+                f"Sentinel `{v['sentinel']}` echoes the canonical "
+                "Evaluator-policy bullets in check-skill-pattern.md."
+            ),
+            "recommended_changes": _RECOMMENDED_CHANGES,
+        }
+        for v in violations
+    ]
+    return {
+        "rule_id": "evaluator-policy-echo",
+        "overall_status": "warn" if findings else "pass",
+        "findings": findings,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = get_parser()
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as err:
+        return int(err.code) if err.code is not None else 0
+    paths = args.paths or [Path.cwd()]
+    files = _iter_skill_files(paths)
+    all_violations: list[dict] = []
+    for f in files:
+        try:
+            text = f.read_text(encoding="utf-8")
+        except OSError as err:
+            print(f"error: cannot read {f}: {err}", file=sys.stderr)
+            return 2
+        for v in find_violations(text):
+            all_violations.append({"file": str(f), **v})
+    if args.human:
+        for v in all_violations:
+            print(f"{v['file']}:{v['line']}: {v['sentinel']}: {v['text']}")
+        if all_violations:
+            print(
+                f"\n{len(all_violations)} violations across "
+                f"{len({v['file'] for v in all_violations})} files",
+                file=sys.stderr,
+            )
+    elif args.envelope:
+        json.dump(_build_envelope(all_violations), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    else:
+        json.dump(all_violations, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    return 1 if all_violations else 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/plugins/build/_shared/scripts/tests/test_evaluator_policy_echo.py
+++ b/plugins/build/_shared/scripts/tests/test_evaluator_policy_echo.py
@@ -1,0 +1,188 @@
+"""Tests for check_evaluator_policy_echo."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import check_evaluator_policy_echo  # noqa: E402
+
+find_violations = check_evaluator_policy_echo.find_violations
+main = check_evaluator_policy_echo.main
+
+
+CITATION_ONLY = """---
+name: example
+description: example skill
+---
+
+# Example
+
+## 3. Tier-2 Semantic Dimensions
+
+Evaluator policy: see [check-skill-pattern.md §Evaluator
+policy](../../_shared/references/check-skill-pattern.md#eval).
+"""
+
+ALL_THREE_SENTINELS = """---
+name: example
+---
+
+# Example
+
+## 3. Tier-2 Semantic Dimensions
+
+#### Evaluator policy
+
+- **Default-closed when borderline.** Ambiguous → warn.
+- **Severity floor: WARN.** Tier-2 dims are coaching.
+- **One finding per dimension maximum.** Highest-signal only.
+"""
+
+TWO_OF_THREE = """---
+name: example
+---
+
+# Example
+
+## 3. Tier-2 Semantic Dimensions
+
+- **Default-closed when borderline.** When evidence is ambiguous, return `warn`.
+- **Severity floor: WARN.** Coaching, not blocking.
+
+(Third sentinel deliberately absent.)
+"""
+
+ONLY_ONE_SENTINEL = """---
+name: example
+---
+
+# Example
+
+We use a **Severity floor: WARN** policy throughout, but the rest of
+the Evaluator policy is cited from check-skill-pattern.md.
+"""
+
+NO_SENTINELS = """---
+name: example
+---
+
+# Example
+
+A perfectly normal SKILL.md with no Evaluator policy at all.
+"""
+
+
+def test_citation_only_passes():
+    assert find_violations(CITATION_ONLY) == []
+
+
+def test_all_three_sentinels_flagged():
+    violations = find_violations(ALL_THREE_SENTINELS)
+    assert len(violations) == 3
+    sentinels = {v["sentinel"] for v in violations}
+    assert sentinels == {
+        "Default-closed when borderline",
+        "Severity floor: WARN",
+        "One finding per dimension",
+    }
+
+
+def test_two_of_three_passes():
+    """Boolean AND — partial overlap is not a violation."""
+    assert find_violations(TWO_OF_THREE) == []
+
+
+def test_only_one_sentinel_passes():
+    assert find_violations(ONLY_ONE_SENTINEL) == []
+
+
+def test_no_sentinels_passes():
+    assert find_violations(NO_SENTINELS) == []
+
+
+def test_violations_carry_line_numbers():
+    violations = find_violations(ALL_THREE_SENTINELS)
+    for v in violations:
+        assert isinstance(v["line"], int)
+        assert v["line"] > 0
+
+
+def test_main_emits_json_array(tmp_path, capsys):
+    skill = tmp_path / "skill-dir" / "SKILL.md"
+    skill.parent.mkdir()
+    skill.write_text(ALL_THREE_SENTINELS, encoding="utf-8")
+    rc = main([str(tmp_path)])
+    assert rc == 1
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    assert isinstance(parsed, list)
+    assert len(parsed) == 3
+    for entry in parsed:
+        assert set(entry.keys()) == {"file", "line", "sentinel", "text"}
+
+
+def test_main_clean_returns_zero(tmp_path, capsys):
+    skill = tmp_path / "skill-dir" / "SKILL.md"
+    skill.parent.mkdir()
+    skill.write_text(CITATION_ONLY, encoding="utf-8")
+    rc = main([str(tmp_path)])
+    assert rc == 0
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    assert parsed == []
+
+
+def test_main_envelope_violation(tmp_path, capsys):
+    skill = tmp_path / "skill-dir" / "SKILL.md"
+    skill.parent.mkdir()
+    skill.write_text(ALL_THREE_SENTINELS, encoding="utf-8")
+    rc = main(["--envelope", str(tmp_path)])
+    assert rc == 1
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    assert parsed["rule_id"] == "evaluator-policy-echo"
+    assert parsed["overall_status"] == "warn"
+    assert len(parsed["findings"]) == 3
+    for finding in parsed["findings"]:
+        assert finding["status"] == "warn"
+        assert "line" in finding["location"]
+        assert finding["recommended_changes"]
+
+
+def test_main_envelope_clean_returns_pass(tmp_path, capsys):
+    skill = tmp_path / "skill-dir" / "SKILL.md"
+    skill.parent.mkdir()
+    skill.write_text(CITATION_ONLY, encoding="utf-8")
+    rc = main(["--envelope", str(tmp_path)])
+    assert rc == 0
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    assert parsed["rule_id"] == "evaluator-policy-echo"
+    assert parsed["overall_status"] == "pass"
+    assert parsed["findings"] == []
+
+
+def test_main_human_output(tmp_path, capsys):
+    skill = tmp_path / "skill-dir" / "SKILL.md"
+    skill.parent.mkdir()
+    skill.write_text(ALL_THREE_SENTINELS, encoding="utf-8")
+    rc = main(["--human", str(tmp_path)])
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "Default-closed when borderline" in captured.out
+    assert str(skill) in captured.out
+
+
+def test_main_two_of_three_passes(tmp_path, capsys):
+    skill = tmp_path / "skill-dir" / "SKILL.md"
+    skill.parent.mkdir()
+    skill.write_text(TWO_OF_THREE, encoding="utf-8")
+    rc = main(["--envelope", str(tmp_path)])
+    assert rc == 0
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    assert parsed["overall_status"] == "pass"

--- a/plugins/build/pyproject.toml
+++ b/plugins/build/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "check"
-version = "0.22.0"
+version = "0.23.0"
 description = "Claude Code plugin for auditing Claude Code skills and rules for quality issues."
 requires-python = ">=3.9"
 dependencies = []

--- a/plugins/build/skills/build-bash-script/SKILL.md
+++ b/plugins/build/skills/build-bash-script/SKILL.md
@@ -59,21 +59,7 @@ Bash is the right language before asking scaffold-specific questions.
 - **A semantic judgment captured as an LLM-evaluated rule** →
   `/build:build-rule`.
 
-**Wrong language — should be Python instead:**
-
-- Task manipulates structured data — arrays of typed records, nested
-  JSON beyond a `jq` one-liner, schema-validated payloads
-- Projected logic exceeds ~300 LOC of business code
-- Task needs testable seams beyond `bats`/`shunit2` glue
-- Task needs concurrency, HTTP with retry / JSON, or cross-platform
-  correctness (Windows)
-
-The full language-selection decision lives in the *Language Selection*
-section of
-[primitive-routing.md](../../_shared/references/primitive-routing.md) —
-consult it when the choice is not obvious. **Tiebreaker rule from that
-doc:** when the decision is genuinely balanced, Python wins on
-interpretability.
+**Wrong language — should be Python instead:** see [primitive-routing.md §Language Selection](../../_shared/references/primitive-routing.md#language-selection--when-the-answer-is-a-script).
 
 **Right primitive and right language** (CLI glue stitching `git` /
 `curl` / `jq` / `find` / `xargs`; Makefile-invoked automation; one-shot

--- a/plugins/build/skills/build-bash-script/SKILL.md
+++ b/plugins/build/skills/build-bash-script/SKILL.md
@@ -354,13 +354,7 @@ baseline-clean starting point.
 - The `command -v` preflight is only scaffolded when Intake step 3.6
   named external dependencies. Do not add an empty preflight as
   "best-effort" structure — it is dead code.
-- Won't scaffold scripts for Claude Code hook events — route to
-  `/build:build-hook`.
-- Won't scaffold POSIX `sh` scripts — out of scope; the synthesis
-  this skill operationalizes is bash-only.
 - Won't scaffold setuid scripts — recommend a compiled wrapper.
-- Won't scaffold when any Scope Gate signal fires — recommend the
-  appropriate alternative.
 
 ## Handoff
 

--- a/plugins/build/skills/build-bash-script/SKILL.md
+++ b/plugins/build/skills/build-bash-script/SKILL.md
@@ -361,9 +361,6 @@ baseline-clean starting point.
 - Won't scaffold setuid scripts — recommend a compiled wrapper.
 - Won't scaffold when any Scope Gate signal fires — recommend the
   appropriate alternative.
-- Recovery if a script is written in error: `rm <path>` removes it
-  cleanly. The scaffold is self-contained (no settings.json entry,
-  no shared-module registration), so removal leaves no dangling state.
 
 ## Handoff
 

--- a/plugins/build/skills/build-github-workflow/SKILL.md
+++ b/plugins/build/skills/build-github-workflow/SKILL.md
@@ -369,8 +369,6 @@ catches anything the Safety Check missed and gives a clean baseline.
   no exceptions; this is the post-tj-actions runtime defense.
 - Every multi-line bash `run:` block starts with `set -euo pipefail`.
 - Write files to disk only after the Review Gate passes.
-- Won't scaffold composite actions — different rubric, different
-  schema. Out of scope.
 - Won't scaffold `pull_request_target` + PR checkout — unconditional
   refuse.
 - Won't scaffold mutable refs (`@main`, `@master`, `@v*.*`) —

--- a/plugins/build/skills/build-github-workflow/SKILL.md
+++ b/plugins/build/skills/build-github-workflow/SKILL.md
@@ -375,9 +375,6 @@ catches anything the Safety Check missed and gives a clean baseline.
   refuse.
 - Won't scaffold mutable refs (`@main`, `@master`, `@v*.*`) —
   unconditional refuse.
-- Recovery if a workflow is written in error: `rm <path>` removes it
-  cleanly. The scaffold is self-contained — no settings.json, no
-  shared-module registration — so removal leaves no dangling state.
 
 ## Handoff
 

--- a/plugins/build/skills/build-makefile/SKILL.md
+++ b/plugins/build/skills/build-makefile/SKILL.md
@@ -300,8 +300,6 @@ Check missed and gives the user a baseline-clean starting point.
   flagged destructive operations. Do not add it as a general pattern.
 - `-include .env.mk` is only scaffolded when Intake step 3.6 opted
   in. Do not add it as dead structure.
-- Won't scaffold when any Scope Gate signal fires — recommend the
-  appropriate alternative.
 
 ## Handoff
 

--- a/plugins/build/skills/build-makefile/SKILL.md
+++ b/plugins/build/skills/build-makefile/SKILL.md
@@ -302,9 +302,6 @@ Check missed and gives the user a baseline-clean starting point.
   in. Do not add it as dead structure.
 - Won't scaffold when any Scope Gate signal fires — recommend the
   appropriate alternative.
-- Recovery if a Makefile is written in error: `rm Makefile` removes
-  it cleanly. No settings.json entries, no shared-module
-  registration — the scaffold is self-contained.
 
 ## Handoff
 

--- a/plugins/build/skills/build-pre-commit-config/SKILL.md
+++ b/plugins/build/skills/build-pre-commit-config/SKILL.md
@@ -303,8 +303,6 @@ Also offer the CI mirror (explicitly not scaffolded above):
 
 - Won't scaffold over an existing `.pre-commit-config.yaml` — Scope
   Gate signal #1 applies. Offer the audit instead.
-- Won't scaffold hand-rolled `.git/hooks/pre-commit` files — out of
-  scope; the principles doc is framework-only.
 - Every `rev:` in the draft is either a verified current tag or a
   placeholder flagged for the user to resolve at Review Gate.
 - `require_serial: true` is mandatory on any hook that modifies

--- a/plugins/build/skills/build-python-script/SKILL.md
+++ b/plugins/build/skills/build-python-script/SKILL.md
@@ -401,10 +401,6 @@ baseline-clean starting point.
 - When Intake picks `pep723`, use only the PEP 723 block — a second
   declaration (colocated `requirements.txt`) creates two sources of
   truth.
-- Won't scaffold scripts for Claude Code hook events — route to
-  `/build:build-hook`.
-- Won't scaffold when any Scope Gate signal fires — recommend the
-  appropriate alternative instead.
 
 ## Handoff
 

--- a/plugins/build/skills/build-python-script/SKILL.md
+++ b/plugins/build/skills/build-python-script/SKILL.md
@@ -58,20 +58,7 @@ Python is the right language before asking scaffold-specific questions.
 - **A semantic judgment captured as an LLM-evaluated rule** →
   `/build:build-rule`.
 
-**Wrong language — should be shell instead:**
-
-- Task is pure glue — stitching `git` / `curl` / `jq` / `find` /
-  `xargs` through a pipeline, no structured data
-- Task is genuinely one-shot and will not grow business logic
-- Execution environment cannot be relied on to ship Python (bare
-  containers, minimal CI images)
-
-The full language-selection decision lives in the *Language Selection*
-section of
-[primitive-routing.md](../../_shared/references/primitive-routing.md) —
-consult it when the choice is not obvious. **Tiebreaker rule from that
-doc:** when the decision is genuinely balanced, Python wins on
-interpretability.
+**Wrong language — should be shell instead:** see [primitive-routing.md §Language Selection](../../_shared/references/primitive-routing.md#language-selection--when-the-answer-is-a-script).
 
 **Right primitive and right language** (CLI tool, data-wrangling helper,
 automation utility, one-shot job with structured data or >100 LOC of

--- a/plugins/build/skills/build-python-script/SKILL.md
+++ b/plugins/build/skills/build-python-script/SKILL.md
@@ -405,9 +405,6 @@ baseline-clean starting point.
   `/build:build-hook`.
 - Won't scaffold when any Scope Gate signal fires — recommend the
   appropriate alternative instead.
-- Recovery if a script is written in error: `rm <path>` removes it
-  cleanly. The scaffold is self-contained (no settings.json entry, no
-  shared-module registration), so removal leaves no dangling state.
 
 ## Handoff
 

--- a/plugins/build/skills/build-readme/SKILL.md
+++ b/plugins/build/skills/build-readme/SKILL.md
@@ -309,8 +309,6 @@ catches anything the Safety Check missed.
   Default to the target shell / language; never empty info-strings.
 - Use relative links by default; switch to absolute URLs only when
   Intake #9 flags package-mirror distribution.
-- Won't scaffold sub-package READMEs — out of scope; different
-  audience, different rubric.
 - Won't scaffold over a non-trivial existing README — offer
   `/build:check-readme` instead.
 - Won't inline real secrets, hostnames, or credentials in examples

--- a/plugins/build/skills/build-readme/SKILL.md
+++ b/plugins/build/skills/build-readme/SKILL.md
@@ -315,9 +315,6 @@ catches anything the Safety Check missed.
   `/build:check-readme` instead.
 - Won't inline real secrets, hostnames, or credentials in examples
   — use reserved ranges.
-- Recovery if a README is scaffolded in error: `rm <path>` removes
-  it cleanly. The scaffold is self-contained (no sibling file
-  writes, no registration), so removal leaves no dangling state.
 
 ## Handoff
 

--- a/plugins/build/skills/build-skill-pair/SKILL.md
+++ b/plugins/build/skills/build-skill-pair/SKILL.md
@@ -252,7 +252,14 @@ under `scripts/check_<id>.{py,sh}`) → Judgment Checks (Tier-2 against
 each `references/check-<dim>.md`) → Cross-Entity (Tier-3, if scope is
 a directory) → Report → Opt-In Repair Loop. Frontmatter `references:`
 includes the principles doc and every `references/check-<dim>.md`
-file produced as Artifact 4.
+file produced as Artifact 4. The Tier-2 section cites the Evaluator
+policy from
+[check-skill-pattern.md §Evaluator policy](../../_shared/references/check-skill-pattern.md#evaluator-policy)
+by anchor link; it does NOT duplicate the bullets. SKILL.md bodies
+that cite a `*-best-practices.md` (or comparable SSoT) link to it and
+do not restate its named principles — verbatim copies are flagged by
+`evaluator-policy-echo` (Tier-1) and `best-practices-doc-restatement`
+(Tier-2).
 
 **Artifact 4 — `check-<primitive>/references/check-<dim>.md`** *(one
 file per judgment dimension)*. Each file carries `name`, `description`,

--- a/plugins/build/skills/build-skill-pair/SKILL.md
+++ b/plugins/build/skills/build-skill-pair/SKILL.md
@@ -416,13 +416,6 @@ paragraph under *What Each Primitive Was Designed For* and appending
 
 ## Key Instructions
 
-- Won't scaffold over an existing pair — Scope Gate signal #1 applies
-  without exception. Offer to revise instead.
-- Won't produce a principles doc from zero input material — Scope
-  Gate signal #2 applies. Any mix of files, URLs, pasted text, or
-  named model knowledge clears the gate; *nothing* does not.
-- Won't write any artifact — or the routing-doc diff — until the
-  Review Gate passes.
 - Principles doc lives in `_shared/references/`, not inside either
   skill directory. Both halves reference it at the same path so
   creation and review stay aligned.

--- a/plugins/build/skills/build-skill/SKILL.md
+++ b/plugins/build/skills/build-skill/SKILL.md
@@ -229,6 +229,12 @@ Runs `/build:check-skill` — 0 findings. Reports the path.
   [skill-best-practices.md](../../_shared/references/skill-best-practices.md);
   don't invent frontmatter fields or required sections
   (`/build:check-skill`'s Tier-1 flags unknown structural shapes)
+- When the new SKILL.md cites a `*-best-practices.md` (or comparable
+  SSoT like `check-skill-pattern.md`), the SKILL.md body does NOT
+  duplicate that doc's named principles — link only. Emit a citation,
+  not a restatement; the linked doc IS the authority. Verbatim copies
+  are flagged by `evaluator-policy-echo` (Tier-1) and
+  `best-practices-doc-restatement` (Tier-2).
 - Lead with load-bearing content in the first ~5K tokens —
   compaction-safe window
 - Hold the write until the user approves the draft (Step 7 gate)

--- a/plugins/build/skills/build-subagent/SKILL.md
+++ b/plugins/build/skills/build-subagent/SKILL.md
@@ -325,9 +325,6 @@ Check missed and gives a baseline-clean starting point.
   skill.
 - Won't list `Agent` in a subagent's `tools` — it's filtered at the
   platform level for delegated agents.
-- Recovery if a definition is written in error: `rm
-  .claude/agents/<name>.md` removes it cleanly. The definition is
-  self-contained (no registration, no shared-module dependency).
 
 ## Handoff
 

--- a/plugins/build/skills/check-bash-script/SKILL.md
+++ b/plugins/build/skills/check-bash-script/SKILL.md
@@ -201,21 +201,11 @@ mechanical portion of those rules is now scripted; the judgment portion
 folds into D5 Function Design and the canonical convention doc
 [bash-script-best-practices.md](../../_shared/references/bash-script-best-practices.md).)
 
-**Evaluator policy:**
+**Evaluator policy:** see [check-skill-pattern.md §Evaluator policy](../../_shared/references/check-skill-pattern.md#evaluator-policy). Read all six files first, then evaluate each in turn against the same artifact.
 
-- **Single locked-rubric pass per artifact.** Read all six files first,
-  then evaluate each in turn against the same artifact. Don't
-  re-decompose into sub-checks; the unified rubric stabilizes severity.
-- **Default-closed when borderline.** If evidence is ambiguous or an
-  exception nearly fits, return `warn`, not `pass`. False-positive
-  WARNs cost a glance; false-negative PASSes erode trust.
-- **Severity floor: WARN.** Judgment-mode findings default to WARN —
-  coaching, not blocking. Escalate to FAIL only for safety concerns
-  that Tier-1 missed (e.g., a hand-rolled SQL-shaped string in shell).
-- **One finding per dimension maximum.** If a dimension identifies
-  multiple problematic locations, surface the highest-signal one with
-  concrete detail (line numbers, what to extract). Bulk findings train
-  the user to disregard the audit.
+**Skill-specific FAIL escalations.** Beyond the canonical WARN floor,
+escalate to FAIL only for safety concerns Tier-1 missed (e.g., a
+hand-rolled SQL-shaped string in shell).
 
 ### 4. Tier-3 Cross-Entity Collision
 

--- a/plugins/build/skills/check-github-workflow/SKILL.md
+++ b/plugins/build/skills/check-github-workflow/SKILL.md
@@ -105,12 +105,7 @@ For each workflow that passed the Tier-2 exclusion gate, evaluate against the **
 | [check-performance-and-concurrency.md](references/check-performance-and-concurrency.md) | D6 — concurrency posture deliberate; caches deterministic | warn |
 | [check-maintainability.md](references/check-maintainability.md) | D7 — names are developer-facing; long blocks extracted | warn |
 
-#### Evaluator policy
-
-- **Single locked-rubric pass per workflow.** Read all 7 rule files first, then evaluate the workflow in one LLM call.
-- **Default-closed when borderline.** When evidence is ambiguous, return `warn`.
-- **Severity floor: WARN.**
-- **One finding per dimension maximum.**
+**Evaluator policy:** see [check-skill-pattern.md §Evaluator policy](../../_shared/references/check-skill-pattern.md#evaluator-policy). Read all 7 rule files first, then evaluate the workflow in one LLM call.
 
 ### 4. Tier-3
 

--- a/plugins/build/skills/check-help-skill/SKILL.md
+++ b/plugins/build/skills/check-help-skill/SKILL.md
@@ -113,17 +113,7 @@ the **5 judgment rules** at `references/check-*.md`:
 | [check-scope-discipline.md](references/check-scope-discipline.md) | D4 — stays inside (synopsis, index, workflows, pointers) | warn |
 | [check-trigger-quality.md](references/check-trigger-quality.md) | D5 — fires on meta-questions, not the plugin's own workflows | warn |
 
-#### Evaluator policy
-
-- **Single locked-rubric pass.** Read all 5 rule files first, then
-  evaluate the help-skill against the unified rubric. A single
-  locked-rubric pass produces stable scoring.
-- **Default-closed when borderline.** When evidence is ambiguous,
-  return `warn`, not `pass`.
-- **Severity floor: WARN.** All 5 Tier-2 dimensions are coaching, not
-  blocking. Escalate to FAIL only for safety concerns Tier-1 missed.
-- **One finding per dimension maximum.** If a single hook trips one
-  dimension at multiple locations, surface the highest-signal one.
+**Evaluator policy:** see [check-skill-pattern.md §Evaluator policy](../../_shared/references/check-skill-pattern.md#evaluator-policy). Read all 5 rule files first, then evaluate the help-skill in one LLM call.
 
 ### 4. Tier-3 cross-entity trigger collision
 

--- a/plugins/build/skills/check-hook/SKILL.md
+++ b/plugins/build/skills/check-hook/SKILL.md
@@ -105,23 +105,14 @@ The 18 dimensions:
 | [check-brief-presence-and-content.md](references/check-brief-presence-and-content.md) | Brief presence + content (5 H2 sections; specific *So-what*) | warn |
 | [check-primitive-routing-coverage.md](references/check-primitive-routing-coverage.md) | CLAUDE.md → hook conversion candidates | warn |
 
-#### Evaluator policy
+**Evaluator policy:** see [check-skill-pattern.md §Evaluator policy](../../_shared/references/check-skill-pattern.md#evaluator-policy). Read all 18 rule files first, then evaluate each hook in turn against the unified rubric.
 
-- **Single locked-rubric pass per hook.** Read all 18 rule files
-  first, then evaluate each hook in turn against the unified rubric.
-  A single locked-rubric pass stabilizes severity.
-- **Default-closed when borderline.** When evidence is ambiguous,
-  return `warn`, not `pass`.
-- **Severity floor: WARN.** Most dimensions are coaching, not
-  blocking. Escalate to FAIL only for the 7 rules whose severity is
-  documented as `fail` (event-matcher-fit, exit-code-contract,
-  async-blocking-coherence, stop-loop-guard, destructive-operations,
-  injection-safety, jq-handling for Copilot field-path mismatch,
-  latency for recursive `claude` invocation).
-- **One finding per dimension per hook maximum.** If a single hook
-  trips one dimension at multiple locations, surface the
-  highest-signal location with concrete detail. Bulk findings train
-  the user to disregard the audit.
+**Skill-specific severity floor exceptions.** The default WARN floor is
+overridden for the 7 rules documented as `fail`:
+event-matcher-fit, exit-code-contract, async-blocking-coherence,
+stop-loop-guard, destructive-operations, injection-safety, jq-handling
+(Copilot field-path mismatch), and latency (recursive `claude`
+invocation).
 
 For each finding, capture: dimension name, offending hook / command /
 file, specific issue, severity. The finding's `recommended_changes`

--- a/plugins/build/skills/check-makefile/SKILL.md
+++ b/plugins/build/skills/check-makefile/SKILL.md
@@ -115,12 +115,7 @@ For each Makefile that passed the Tier-2 exclusion gate, evaluate against the **
 | [check-naming-and-structure.md](references/check-naming-and-structure.md) | D6 — target names verb-ish; helpers prefixed; sections grouped | warn |
 | [check-documentation-intent.md](references/check-documentation-intent.md) | D7 — header comment + per-target `## help`; comments explain why | warn |
 
-#### Evaluator policy
-
-- **Single locked-rubric pass per Makefile.** Read all 7 rule files first, then evaluate the Makefile in one LLM call.
-- **Default-closed when borderline.** When evidence is ambiguous, return `warn`.
-- **Severity floor: WARN.**
-- **One finding per dimension maximum.**
+**Evaluator policy:** see [check-skill-pattern.md §Evaluator policy](../../_shared/references/check-skill-pattern.md#evaluator-policy). Read all 7 rule files first, then evaluate the Makefile in one LLM call.
 
 ### 4. Tier-3 Cross-Makefile Collision
 

--- a/plugins/build/skills/check-pre-commit-config/SKILL.md
+++ b/plugins/build/skills/check-pre-commit-config/SKILL.md
@@ -93,12 +93,7 @@ For each config that passed the Tier-2 exclusion gate, evaluate against the **7 
 | [check-developer-experience.md](references/check-developer-experience.md) | D6 — names + ids developer-facing; minimum_pre_commit_version pinned | warn |
 | [check-hook-structure.md](references/check-hook-structure.md) | D7 — repo entries grouped logically; one concern per hook | warn |
 
-#### Evaluator policy
-
-- **Single locked-rubric pass per config.** Read all 7 rule files first, then evaluate the config in one LLM call.
-- **Default-closed when borderline.** When evidence is ambiguous, return `warn`, not `pass`.
-- **Severity floor: WARN.** All 7 Tier-2 dimensions are coaching, not blocking.
-- **One finding per dimension maximum.**
+**Evaluator policy:** see [check-skill-pattern.md §Evaluator policy](../../_shared/references/check-skill-pattern.md#evaluator-policy). Read all 7 rule files first, then evaluate the config in one LLM call.
 
 ### 4. Tier-3 Cross-Config Collision
 

--- a/plugins/build/skills/check-python-script/SKILL.md
+++ b/plugins/build/skills/check-python-script/SKILL.md
@@ -144,12 +144,7 @@ For each script that passed the Tier-2 exclusion gate, evaluate against the **9 
 | [check-structured-stderr-errors.md](references/check-structured-stderr-errors.md) | Skill-helper — JSON to stderr, not tracebacks | warn | skill-helper |
 | [check-exit-code-meaning.md](references/check-exit-code-meaning.md) | Skill-helper — distinct exit codes by recovery class | warn | skill-helper |
 
-#### Evaluator policy
-
-- **Single locked-rubric pass per script.** Read all 9 rule files first, then evaluate the script in one LLM call.
-- **Default-closed when borderline.** When evidence is ambiguous, return `warn`.
-- **Severity floor: WARN.**
-- **One finding per dimension maximum.**
+**Evaluator policy:** see [check-skill-pattern.md §Evaluator policy](../../_shared/references/check-skill-pattern.md#evaluator-policy). Read all 9 rule files first, then evaluate the script in one LLM call.
 
 ### 4. Tier-3 Cross-Script Collision
 

--- a/plugins/build/skills/check-readme/SKILL.md
+++ b/plugins/build/skills/check-readme/SKILL.md
@@ -112,12 +112,7 @@ For each README that passed the Tier-2 exclusion gate, evaluate against the **7 
 | [check-maintenance-posture.md](references/check-maintenance-posture.md) | D6 — README freshness signals (last-updated, contributor links) | warn |
 | [check-style-and-voice.md](references/check-style-and-voice.md) | D7 — direct, plain English; no marketing prose | warn |
 
-#### Evaluator policy
-
-- **Single locked-rubric pass per README.** Read all 7 rule files first, then evaluate the README in one LLM call against the unified rubric. A single locked-rubric pass produces stable scoring.
-- **Default-closed when borderline.** When evidence is ambiguous, return `warn`, not `pass`.
-- **Severity floor: WARN.** All 7 Tier-2 dimensions are coaching, not blocking.
-- **One finding per dimension maximum.** Surface the highest-signal location.
+**Evaluator policy:** see [check-skill-pattern.md §Evaluator policy](../../_shared/references/check-skill-pattern.md#evaluator-policy). Read all 7 rule files first, then evaluate the README in one LLM call.
 
 ### 4. Tier-3 Cross-README Collision
 

--- a/plugins/build/skills/check-resolver/SKILL.md
+++ b/plugins/build/skills/check-resolver/SKILL.md
@@ -89,12 +89,7 @@ For resolvers that passed the Tier-2 exclusion gate, evaluate against the **4 ju
 | [check-eval-representativeness.md](references/check-eval-representativeness.md) | D3 — evals exercise both filing/context routing; ≥1 case per filing row; ≥15% negative | warn |
 | [check-brief-presence-and-content.md](references/check-brief-presence-and-content.md) | D4 — `.briefs/<slug>.brief.md` exists with 5 H2s; *So-what* is specific | warn |
 
-#### Evaluator policy
-
-- **Single locked-rubric pass.** Read all 4 rule files first, then evaluate the resolver in one LLM call against the unified rubric. A single locked-rubric pass produces stable scoring.
-- **Default-closed when borderline.** When evidence is ambiguous, return `warn`, not `pass`.
-- **Severity floor: WARN.** All 4 Tier-2 dimensions are coaching, not blocking. Escalate to FAIL only for safety concerns Tier-1 missed.
-- **One finding per dimension maximum.** Surface the highest-signal location with concrete excerpts.
+**Evaluator policy:** see [check-skill-pattern.md §Evaluator policy](../../_shared/references/check-skill-pattern.md#evaluator-policy). Read all 4 rule files first, then evaluate the resolver in one LLM call.
 
 Include `RESOLVER.md` verbatim in the Tier-2 prompt — never summarize. Include the directory scan output, `.resolver/evals.yml`, and `.briefs/<slug>.brief.md` (if present).
 

--- a/plugins/build/skills/check-rule/SKILL.md
+++ b/plugins/build/skills/check-rule/SKILL.md
@@ -94,12 +94,7 @@ For each structurally valid rule, evaluate against the **8 judgment rules** at `
 | [check-judgment-not-linter.md](references/check-judgment-not-linter.md) | D7 — semantic conventions only; no formatter/linter overlap | warn |
 | [check-example-realism.md](references/check-example-realism.md) | D8 — domain-specific identifiers, not synthetic placeholders | warn |
 
-#### Evaluator policy
-
-- **Single locked-rubric pass per rule.** Read all 8 rule files first, then evaluate each rule in turn against the unified rubric. A single locked-rubric pass produces stable scoring.
-- **Default-closed when borderline.** When evidence is ambiguous, return `warn`, not `pass`.
-- **Severity floor: WARN.** All 8 Tier-2 dimensions are coaching, not blocking. Escalate to FAIL only for safety concerns Tier-1 missed.
-- **One finding per dimension per rule maximum.** If a single rule trips one dimension at multiple locations, surface the highest-signal one with concrete excerpts.
+**Evaluator policy:** see [check-skill-pattern.md §Evaluator policy](../../_shared/references/check-skill-pattern.md#evaluator-policy). Read all 8 rule files first, then evaluate each rule in turn against the unified rubric.
 
 Include the full rule file verbatim in the prompt — never summarize. Include the Tier-1 shape-hints keyword sniff as context. Dimensions that don't apply (e.g., D8 Example Realism on a rule with no examples) return `inapplicable` silently.
 

--- a/plugins/build/skills/check-skill/SKILL.md
+++ b/plugins/build/skills/check-skill/SKILL.md
@@ -13,6 +13,7 @@ version: 1.0.0
 owner: build-plugin
 references:
   - ../../_shared/references/skill-best-practices.md
+  - references/check-best-practices-doc-restatement.md
   - references/check-clarity-and-consistency.md
   - references/check-description-retrieval-signal.md
   - references/check-example-realism.md
@@ -27,9 +28,9 @@ license: MIT
 
 # /build:check-skill
 
-Evaluate the quality of an existing Claude Code skill. Three tiers, in order: deterministic format checks (no LLM), per-skill semantic checks (nine always-on dimensions in a single locked-rubric call), then cross-skill description collision detection.
+Evaluate the quality of an existing Claude Code skill. Three tiers, in order: deterministic format checks (no LLM), per-skill semantic checks (ten always-on dimensions in a single locked-rubric call), then cross-skill description collision detection.
 
-This skill follows the [check-skill pattern](../../_shared/references/check-skill-pattern.md). Tier-1 detection is in 8 per-skill scripts emitting JSON envelopes via `_common.py` plus two shared detectors (`_shared/scripts/check_handoff_shape.py` and `_shared/scripts/check_reference_lead.py`, both invoked with `--envelope`), 23 rule_ids total. Tier-2 has 9 judgment dimensions read inline by the primary agent. Tier-3 is a judgment-driven cross-skill description-collision pass over candidate pairs.
+This skill follows the [check-skill pattern](../../_shared/references/check-skill-pattern.md). Tier-1 detection is in 8 per-skill scripts emitting JSON envelopes via `_common.py` plus three shared detectors (`_shared/scripts/check_handoff_shape.py`, `_shared/scripts/check_reference_lead.py`, and `_shared/scripts/check_evaluator_policy_echo.py`, all invoked with `--envelope`), 24 rule_ids total. Tier-2 has 10 judgment dimensions read inline by the primary agent. Tier-3 is a judgment-driven cross-skill description-collision pass over candidate pairs.
 
 The audit rubric mirrors the authoring principles in [skill-best-practices.md](../../_shared/references/skill-best-practices.md). Each Tier-2 dimension cites its source principle. When the principles doc changes, the dimensions should follow.
 
@@ -67,13 +68,14 @@ bash    "$SCRIPTS/check_prose.sh"              $TARGETS   # 2 rules: prose-hedge
 bash    "$SCRIPTS/check_secret.sh"             $TARGETS   # 1 rule:  secret
 bash    "$SCRIPTS/check_dangerous_patterns.sh" $TARGETS   # 2 rules: remote-exec, destructive-cmd
 python3 "$SCRIPTS/check_cisco.py"              $TARGETS   # 2 rules: scanner-fail, scanner-warn (inapplicable when scanner missing)
-python3 "$SHARED_SCRIPTS/check_handoff_shape.py"  --envelope $TARGETS   # 1 rule:  handoff-shape
-python3 "$SHARED_SCRIPTS/check_reference_lead.py" --envelope $TARGETS   # 1 rule:  reference-lead-echo (walks each SKILL.md's sibling references/)
+python3 "$SHARED_SCRIPTS/check_handoff_shape.py"           --envelope $TARGETS   # 1 rule:  handoff-shape
+python3 "$SHARED_SCRIPTS/check_reference_lead.py"          --envelope $TARGETS   # 1 rule:  reference-lead-echo (walks each SKILL.md's sibling references/)
+python3 "$SHARED_SCRIPTS/check_evaluator_policy_echo.py"   --envelope $TARGETS   # 1 rule:  evaluator-policy-echo
 ```
 
 Each script emits a JSON array of envelopes: `{rule_id, overall_status, findings[]}`. `recommended_changes` is canonical — copy through verbatim.
 
-**Script-to-rules map** (23 Tier-1 rule_ids):
+**Script-to-rules map** (24 Tier-1 rule_ids):
 
 | Script | rule_ids | Severity |
 |---|---|---|
@@ -100,6 +102,7 @@ Each script emits a JSON array of envelopes: `{rule_id, overall_status, findings
 | `check_cisco.py` | `scanner-warn` | warn |
 | `_shared/scripts/check_handoff_shape.py` | `handoff-shape` | warn |
 | `_shared/scripts/check_reference_lead.py` | `reference-lead-echo` | warn |
+| `_shared/scripts/check_evaluator_policy_echo.py` | `evaluator-policy-echo` | warn |
 
 **Tier-2 exclusion list.** Any FAIL in `filename`, `directory-basename`, `name-slug`, `reserved-names`, `required-frontmatter`, `version-shape`, `description-cap`, `required-sections`, `body-length` (>400 line case), `secret`, or `scanner-fail` excludes the skill from Tier-2 — malformed skills don't reach the LLM step.
 
@@ -107,7 +110,7 @@ Each script emits a JSON array of envelopes: `{rule_id, overall_status, findings
 
 ### 3. Tier-2 Semantic Dimensions (One LLM Call per Skill)
 
-For each structurally valid skill, evaluate against the **9 judgment rules** at `references/check-*.md`:
+For each structurally valid skill, evaluate against the **10 judgment rules** at `references/check-*.md`:
 
 | File | Dimension | Severity |
 |---|---|---|
@@ -120,6 +123,7 @@ For each structurally valid skill, evaluate against the **9 judgment rules** at 
 | [check-safety-gating.md](references/check-safety-gating.md) | D7 — destructive ops gate on user confirmation | warn |
 | [check-example-realism.md](references/check-example-realism.md) | D8 — examples use domain-specific identifiers | warn |
 | [check-mechanical-work-partition.md](references/check-mechanical-work-partition.md) | D9 — mechanical work in scripts; judgment in SKILL.md | warn |
+| [check-best-practices-doc-restatement.md](references/check-best-practices-doc-restatement.md) | D10 — SKILL.md cites `*-best-practices.md`; does not restate principles | warn |
 
 #### Evaluator policy
 
@@ -178,7 +182,7 @@ After each applied fix, re-run the relevant Tier-1 script (or re-judge the Tier-
 ## Key Instructions
 
 - Run Tier-1 deterministic checks first; gate LLM evaluation on structural validity.
-- Present all 9 Tier-2 dimensions as a single locked-rubric call per skill.
+- Present all 10 Tier-2 dimensions as a single locked-rubric call per skill.
 - Include the full SKILL.md verbatim in every LLM evaluation.
 - Limit Tier-3 collision comparison to skill pairs that could co-fire.
 - Surface borderline evidence as WARN (default-closed).

--- a/plugins/build/skills/check-skill/SKILL.md
+++ b/plugins/build/skills/check-skill/SKILL.md
@@ -125,12 +125,7 @@ For each structurally valid skill, evaluate against the **10 judgment rules** at
 | [check-mechanical-work-partition.md](references/check-mechanical-work-partition.md) | D9 — mechanical work in scripts; judgment in SKILL.md | warn |
 | [check-best-practices-doc-restatement.md](references/check-best-practices-doc-restatement.md) | D10 — SKILL.md cites `*-best-practices.md`; does not restate principles | warn |
 
-#### Evaluator policy
-
-- **Single locked-rubric pass per skill.** Read all 9 rule files first, then evaluate each skill in turn against the unified rubric. A single locked-rubric pass produces stable scoring.
-- **Default-closed when borderline.** When evidence is ambiguous, return `warn`, not `pass`.
-- **Severity floor: WARN.** All 9 Tier-2 dimensions are coaching, not blocking. Escalate to FAIL only for safety concerns Tier-1 missed.
-- **One finding per dimension per skill maximum.** Surface the highest-signal location with concrete excerpts.
+**Evaluator policy:** see [check-skill-pattern.md §Evaluator policy](../../_shared/references/check-skill-pattern.md#evaluator-policy). Read all 10 rule files first, then evaluate each skill in turn against the unified rubric.
 
 Include the full SKILL.md verbatim — never summarize. Dimensions that don't apply (e.g., D7 Safety Gating on a skill with no destructive ops; D8 Example Realism on a skill with no examples) return `inapplicable` silently.
 

--- a/plugins/build/skills/check-skill/references/check-best-practices-doc-restatement.md
+++ b/plugins/build/skills/check-skill/references/check-best-practices-doc-restatement.md
@@ -1,0 +1,26 @@
+---
+name: Best-Practices-Doc Restatement
+description: When a SKILL.md cites a `*-best-practices.md` (or comparable SSoT reference), the SKILL.md body must not duplicate that doc's named principles — link only.
+paths:
+  - "**/SKILL.md"
+---
+
+**Why:** A SKILL.md that links to `_shared/references/<topic>-best-practices.md` already carries the authoritative source — the link is the contract. When the body restates the linked doc's principles, the SKILL.md grows by 5–20 lines per section without adding signal: a reader who follows the link sees the canonical statement; a reader who doesn't sees a paraphrase that drifts on every edit. The cost surfaces when the source-of-truth doc evolves and the SKILL.md copy stays frozen, contradicting the link target. Source principle: skill-best-practices.md and skill-pair-best-practices.md ("If the SKILL.md cites a `*-best-practices.md`, the SKILL.md does not restate that doc's named principles.").
+
+**How to apply:** When a SKILL.md links to a `*-best-practices.md` (or any comparable SSoT — `check-skill-pattern.md`, `primitive-routing.md`, `skill-pair-best-practices.md`), the SKILL.md cites the relevant section by anchor and proceeds. Skill-specific elaborations (a domain-specific example, a primitive-specific tiebreaker) are kept as standalone bullets adjacent to the citation. Verbatim duplicates of the linked doc's named principles are dropped. The Tier-1 helper `check_evaluator_policy_echo` covers one specific case (Evaluator-policy bullets); this Tier-2 dimension covers the broader pattern.
+
+```markdown
+## 3. Tier-2 Semantic Dimensions
+
+Evaluator policy: see [check-skill-pattern.md §Evaluator policy](../../_shared/references/check-skill-pattern.md#evaluator-policy).
+
+(No bullet list — the cited section IS the bullet list.)
+```
+
+**Common fail signals (audit guidance):**
+- A `*-best-practices.md` link in the SKILL.md is followed by 4+ bullets that paraphrase the linked doc's named principles
+- Authoring Principles section in a `build-*` SKILL.md restates the same shape rules already named in `<primitive>-best-practices.md`
+- "Recovery if a script is written in error: `rm <path>` removes it…" or comparable universal-knowledge stanzas appearing in 3+ build-* SKILL.md
+- `### Won't` bullets that restate the frontmatter `description:`'s "Not for…" clause without naming a primitive-specific failure mode
+
+**Exception:** A SKILL.md may include a standalone bullet that elaborates on the linked principle with primitive-specific detail (e.g., a check-bash-script-only edge case). The dimension flags duplication of the doc's general statement, not domain-specific extensions.

--- a/plugins/build/skills/check-subagent/SKILL.md
+++ b/plugins/build/skills/check-subagent/SKILL.md
@@ -112,12 +112,7 @@ For each structurally valid subagent, evaluate against the **7 judgment rules** 
 | [check-failure-behavior.md](references/check-failure-behavior.md) | D6 — named failure modes with explicit recovery | warn |
 | [check-injection-surface.md](references/check-injection-surface.md) | D7 — payload-derived input not exec'd or eval'd unsafely | warn |
 
-#### Evaluator policy
-
-- **Single locked-rubric pass per subagent.** Read all 7 rule files first, then evaluate each subagent in one LLM call against the unified rubric. A single locked-rubric pass produces stable scoring.
-- **Default-closed when borderline.** When evidence is ambiguous, return `warn`, not `pass`.
-- **Severity floor: WARN.** All 7 Tier-2 dimensions are coaching, not blocking. Escalate to FAIL only for safety concerns Tier-1 missed.
-- **One finding per dimension per subagent maximum.** Surface the highest-signal location with concrete excerpts.
+**Evaluator policy:** see [check-skill-pattern.md §Evaluator policy](../../_shared/references/check-skill-pattern.md#evaluator-policy). Read all 7 rule files first, then evaluate each subagent in one LLM call.
 
 Include the full subagent definition verbatim — never summarize. Dimensions that don't apply (e.g., D7 Injection Surface on a subagent that never reads input) return `inapplicable` silently.
 


### PR DESCRIPTION
## Summary

Cycle 3 of the 2026-05-07 repo simplification sweep, per
`.designs/2026-05-07-simplification-sweep.design.md` and
`.plans/2026-05-07-cycle-3-best-practices-restatement.plan.md`.

Stops SKILL.md from restating principles already stated by linked
`*-best-practices.md` (or comparable SSoT) docs. Lands a Tier-1
detector + a Tier-2 dimension, flips the upstream "copy verbatim"
instruction in `check-skill-pattern.md`, then sweeps four restatement
classes.

### Codify

- **Tier-1 detector** `_shared/scripts/check_evaluator_policy_echo.py`
  flags SKILL.md files that copy the verbatim Evaluator-policy
  bullet triple (boolean AND across "Default-closed when borderline"
  + "Severity floor: WARN" + "One finding per dimension"). Stdlib
  only. 12 unit tests, mirrors `check_handoff_shape.py` shape. Wired
  into `check-skill` Tier-1 alongside the cycle-1/2 helpers (24
  rule_ids total).
- **Tier-2 dimension**
  `check-skill/references/check-best-practices-doc-restatement.md`
  covers the broader pattern (Recovery stanzas, frontmatter-echo
  Won't bullets, Authoring Principles duplication).
- **Pattern doc flipped.** `check-skill-pattern.md` SKILL.md section
  now says "cite by anchor link to `#evaluator-policy`" instead of
  "(copy verbatim)" — the doc is the SSoT.
- **Authoring rule codified** in `skill-best-practices.md` and
  `skill-pair-best-practices.md`: "If the SKILL.md cites a
  `*-best-practices.md`, the SKILL.md does not restate that doc's
  named principles."
- **Scaffolders updated.** `build-skill` and `build-skill-pair`
  SKILL.md teach the cite-not-duplicate rule so newly emitted
  SKILL.md does not re-introduce the patterns.

### Sweep

- **Row 4 (12 files):** every `check-*/SKILL.md` flagged by the new
  detector replaced its verbatim Evaluator-policy block with a one-line
  citation. Skill-specific FAIL escalations (check-bash-script,
  check-hook) preserved as standalone subsections. Net –74 lines.
- **Row 7 (6 files):** generic "Recovery if a script is written in
  error: `rm <path>`…" stanzas dropped from `build-bash-script`,
  `build-github-workflow`, `build-makefile`, `build-python-script`,
  `build-readme`, `build-subagent`. Three Recovery stanzas KEPT
  because they carry non-generic procedural content
  (`build-hook` chmod-x + settings.json + silent-failure semantics;
  `build-pre-commit-config` yaml + scripts/hooks/ dir;
  `build-skill-pair` build dir + check dir + principles doc + routing
  diff). Net –18 lines.
- **Row 8 (7 files):** `### Won't` bullets that echo the frontmatter
  `description:`'s "Not for…" clause OR restate Scope/Review-Gate
  workflow steps were dropped across `build-bash-script`,
  `build-python-script`, `build-makefile`, `build-readme`,
  `build-github-workflow`, `build-pre-commit-config`,
  `build-skill-pair`. Per-file decisions documented in 3258660. Net
  –25 lines.
- **Row 18 (2 files):** `build-bash-script` and `build-python-script`
  collapsed their ~14-line "Wrong language" prose + tiebreaker
  paragraph to a one-line link to
  `primitive-routing.md §Language Selection`. Net –27 lines.

Plus changelog backfill: cycles 1 and 2 (#432, #433) merged without
bumping the build plugin version. Bump 0.22.0 → 0.23.0 covers all
three cycles.

## Validation

- `python3 plugins/build/_shared/scripts/check_evaluator_policy_echo.py plugins/build/skills/*/SKILL.md` → exit 0
- `python3 plugins/build/_shared/scripts/check_handoff_shape.py plugins/build/skills/*/SKILL.md` → exit 0
- `python3 plugins/build/_shared/scripts/check_reference_lead.py plugins/build/skills/check-skill/references/*.md` → exit 0
- `python3 -m pytest plugins/wiki/tests/ plugins/build/_shared/scripts/tests/` → 295 passed
- `python3 plugins/wiki/scripts/lint.py` → All checks passed
- `grep -n "copy verbatim" plugins/build/_shared/references/check-skill-pattern.md` → only matches in unrelated patterns (JSON envelope shape on line 124, Anti-Pattern Guards on line 139); the Evaluator-policy "(copy verbatim)" instruction targeted by row 4 was removed.
- Pre-existing `pattern-skill-md-references` FAIL on `check-python-script` confirmed against `main`; out of scope for cycle 3.

## Test plan

- [ ] Smoke `check_evaluator_policy_echo` against the corpus → 0 hits
- [ ] Confirm `check-skill` references[] enumerates all 10 Tier-2 dims
- [ ] Spot-check three swept SKILL.md files render the citation link correctly
- [ ] CI green