### PR TITLE
Cycle 5: loose-end deletions (rows 1, 2, 10, 12, 17, 24, 25, 27, 28)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,11 +34,6 @@ LLMs lose attention mid-document — first and last sections are what agents ret
 - Link bidirectionally — if A references B in `related`, B should reference A.
 <!-- wiki:end -->
 
-## Content Routing
-
-Before filing new content or loading context beyond a skill's eager
-`references:`, consult [RESOLVER.md](RESOLVER.md).
-
 ## Plugin Structure
 
 | Plugin | Path | Skills |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,11 +47,7 @@ Each plugin's skills live at `plugins/<plugin>/skills/<name>/SKILL.md`.
 Python package: `plugins/wiki/src/wiki/` (editable install).
 Shared scripts: `plugins/wiki/scripts/`.
 
-`build/check-skill` audits authorship quality (structure, completeness,
-prompt clarity); `skill-audit-*` (the CI workflows under
-`.github/workflows/skill-audit-*.yml`) audits adversarial content
-(prompt injection, exfiltration, supply-chain risk). They are
-independent, complementary signals — both pass for a skill to merge.
+- `build/check-skill` audits authorship quality (structure, prompt clarity); `skill-audit-*` workflows audit adversarial content (injection, exfiltration, supply-chain). Both must pass to merge.
 
 ## Preferences
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # AGENTS.md
 
+This repo is **toolkit** — a Claude Code plugin marketplace. You are building the tools, not using them.
+
 <!-- wiki:begin -->
 ## Context Navigation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,1 @@
 @AGENTS.md
-
-# CLAUDE.md
-
-This repo is **toolkit** — a Claude Code plugin marketplace. You are building
-the tools, not using them.

--- a/RESOLVER.md
+++ b/RESOLVER.md
@@ -35,6 +35,4 @@ Routing table for filing new content and loading context. Machine-managed region
 
 ## Notes
 
-Add context bundles or filing conventions here; prose outside the managed region survives regeneration.
-
 When filing into a directory not listed above (and not in **Out of scope**), run `/build:check-resolver` first. It either confirms the directory is a dark capability that needs a filing row, or surfaces drift to regenerate. Routing follows the most specific `RESOLVER.md` on the filing path — today the root resolver is the only one, but nested resolvers may be introduced for directories with rich substructure.

--- a/plugins/build/.claude-plugin/plugin.json
+++ b/plugins/build/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "build",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Skills for creating and refining Claude Code skills, rules, hooks, and subagents.",
   "author": {
     "name": "Brandon Beidel"

--- a/plugins/build/CHANGELOG.md
+++ b/plugins/build/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.24.1
+
+- **Cycle 5 row 25**: drop dead-link to nonexistent `rule-header-comment.md`
+  from `check-bash-script/references/check-commenting-intent.md`.
+
 ## 0.24.0
 
 - **Cycle 4 — Process-Echo Guards Sweep** (codify-then-sweep, per

--- a/plugins/build/pyproject.toml
+++ b/plugins/build/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "check"
-version = "0.24.0"
+version = "0.24.1"
 description = "Claude Code plugin for auditing Claude Code skills and rules for quality issues."
 requires-python = ">=3.9"
 dependencies = []

--- a/plugins/build/skills/check-bash-script/references/check-commenting-intent.md
+++ b/plugins/build/skills/check-bash-script/references/check-commenting-intent.md
@@ -8,7 +8,7 @@ paths:
 
 **Why:** comments that restate code rot alongside it — `# increment counter` above `((counter++))` adds nothing in the present and lies after the next refactor. Comments that explain *why* (constraints, workarounds, hidden invariants, performance reasons, security considerations) stay useful because they answer questions the code itself can't. The header serves a different role — it orients a reader who has never seen the file before, telling them what to expect in 10 seconds. TODOs without an owner accumulate as orphan maintenance debt; a tagged TODO has someone responsible for it (or a ticket where the work is tracked), making the backlog auditable.
 
-**How to apply:** the header (in the first 10 lines, after the shebang) covers purpose, usage signature, and external dependencies — see `rule-header-comment.md` for the deterministic check. Inline comments answer questions the code can't: *why* this approach, *why* this workaround, *why* this seemingly-redundant check. Reserve comments for the non-obvious; obvious code doesn't need explanation. Tag every TODO with `TODO(<owner>):` or `TODO(<ticket>):` so it can be tracked or assigned.
+**How to apply:** the header (in the first 10 lines, after the shebang) covers purpose, usage signature, and external dependencies. Inline comments answer questions the code can't: *why* this approach, *why* this workaround, *why* this seemingly-redundant check. Reserve comments for the non-obvious; obvious code doesn't need explanation. Tag every TODO with `TODO(<owner>):` or `TODO(<ticket>):` so it can be tracked or assigned.
 
 ```bash
 # Header (first 10 lines)

--- a/plugins/consider/.claude-plugin/plugin.json
+++ b/plugins/consider/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "consider",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Structured mental models for decision-making — first principles, Occam's razor, inversion, and more.",
   "author": {
     "name": "Brandon Beidel"

--- a/plugins/consider/CHANGELOG.md
+++ b/plugins/consider/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.2.0
+
+- **Cycle 5 rows 2 + 24**: simplify `consider` skills.
+  - Row 2: replace the 17-row `## Available Models` table in
+    `consider/SKILL.md` with a one-line invocation note pointing at the
+    marketplace listing.
+  - Row 24: drop the `- Does not X; produces Y` Key Instructions
+    bullets across 16 mental-model SKILLs (`<objective>` blocks already
+    convey the positive scope). Meta `consider/SKILL.md` also drops its
+    "Does not execute implementations" bullet. `pick-model` is out of
+    scope — its bold `**Does not recommend...**` bullets serve a
+    different rhetorical role.
+
 ## 0.1.3
 
 - Add `license: MIT` to skill frontmatter; teach the scaffolder and

--- a/plugins/consider/skills/10-10-10/SKILL.md
+++ b/plugins/consider/skills/10-10-10/SKILL.md
@@ -71,8 +71,6 @@ Incremental refactor (Option B). The 10-month horizon reveals that the rewrite's
 
 - If the user hasn't identified options yet, help them articulate 2–3 distinct choices before running the analysis.
 - If all three time horizons point to the same option, state that clearly — the model confirms rather than complicates the decision.
-- Does not make the decision for the user; produces structured analysis to inform the choice.
-- Does not apply to factual questions or already-made decisions being rationalized after the fact.
 
 ## Anti-Pattern Guards
 

--- a/plugins/consider/skills/5-whys/SKILL.md
+++ b/plugins/consider/skills/5-whys/SKILL.md
@@ -72,8 +72,6 @@ Create per-suite database instances in CI using a template database that's clone
 
 - If the chain reaches "human error" or "bad luck," keep going — those are symptoms, not root causes; ask why that error was possible.
 - Stop when fixing the identified root cause would demonstrably prevent the original symptom from recurring.
-- Does not prescribe solutions; produces diagnosis to inform action.
-- Does not apply to novel one-off incidents where recurrence is not the concern.
 
 ## Anti-Pattern Guards
 

--- a/plugins/consider/skills/circle-of-competence/SKILL.md
+++ b/plugins/consider/skills/circle-of-competence/SKILL.md
@@ -77,8 +77,6 @@ Bring in outside expertise. Hire or contract a mobile developer for the app shel
 ## Key Instructions
 
 - If the user has no relevant experience to assess, help them identify who does before mapping the circle.
-- Does not evaluate whether a decision is worth making; only maps competence boundaries relative to it.
-- Does not apply to pure preference questions where competence is irrelevant.
 
 ## Anti-Pattern Guards
 

--- a/plugins/consider/skills/consider/SKILL.md
+++ b/plugins/consider/skills/consider/SKILL.md
@@ -12,25 +12,7 @@ help the user choose by presenting the options below.
 
 ## Available Models
 
-| Model | When to use |
-|-------|------------|
-| `first-principles` | Break down assumptions, rebuild from fundamentals |
-| `occams-razor` | Find the simplest explanation that fits all facts |
-| `inversion` | Solve problems backwards, identify failure modes |
-| `second-order` | Think through consequences of consequences |
-| `eisenhower-matrix` | Prioritize by urgency and importance |
-| `opportunity-cost` | Analyze what you give up by choosing this option |
-| `via-negativa` | Improve by removing rather than adding |
-| `pareto` | Apply 80/20 rule to find leverage points |
-| `5-whys` | Drill to root cause by asking why repeatedly |
-| `swot` | Map strengths, weaknesses, opportunities, threats |
-| `10-10-10` | Evaluate decisions across three time horizons |
-| `one-thing` | Identify the single highest-leverage action |
-| `circle-of-competence` | Scope decisions, know what you don't know |
-| `map-vs-territory` | Recognize model limitations, check assumptions |
-| `reversibility` | Assess decision risk — one-way vs two-way doors |
-| `hanlons-razor` | Interpret behavior charitably, avoid conspiracy thinking |
-| `pick-model` | Select the right AI model for a task based on benchmarks, pricing, and effort tradeoffs |
+Each model invokes as `/consider:<model-name>` — see the marketplace listing or `plugins/consider/skills/` for the full set.
 
 ## Usage
 
@@ -46,7 +28,6 @@ suggest 2-3 models that would be most relevant to their problem.
 ## Key Instructions
 
 - When no model is specified and the user's problem is unclear, ask one clarifying question before suggesting models.
-- Does not execute implementations or take action; produces framework analysis only.
 
 ## Anti-Pattern Guards
 

--- a/plugins/consider/skills/eisenhower-matrix/SKILL.md
+++ b/plugins/consider/skills/eisenhower-matrix/SKILL.md
@@ -77,7 +77,6 @@ PR reviews feel urgent because notifications pile up, but they're not important 
 
 - "Urgent" means time-sensitive with an external deadline, not just "feels pressing right now."
 - If the user's list has more than 10 items, group related items before applying the matrix.
-- Does not make scheduling decisions; produces a prioritization framework the user applies.
 
 ## Anti-Pattern Guards
 

--- a/plugins/consider/skills/first-principles/SKILL.md
+++ b/plugins/consider/skills/first-principles/SKILL.md
@@ -70,7 +70,6 @@ The assumption "scaling = microservices" skipped the question "what are we actua
 ## Key Instructions
 
 - If all assumptions survive challenge, note that the conventional approach may already be optimal — first-principles doesn't always produce a novel solution.
-- Does not generate solutions from scratch; produces a framework for rebuilding reasoning once fundamentals are verified.
 
 ## Anti-Pattern Guards
 

--- a/plugins/consider/skills/hanlons-razor/SKILL.md
+++ b/plugins/consider/skills/hanlons-razor/SKILL.md
@@ -74,7 +74,6 @@ Break the PR into 2-3 smaller PRs if possible. Message the reviewer offering to 
 ## Key Instructions
 
 - Charitable interpretation does not mean ignoring evidence of genuine malice; it means exhausting more likely explanations first.
-- Does not resolve the situation; produces a clearer interpretation framework and a recommended response approach.
 
 ## Anti-Pattern Guards
 

--- a/plugins/consider/skills/inversion/SKILL.md
+++ b/plugins/consider/skills/inversion/SKILL.md
@@ -78,7 +78,6 @@ We haven't considered what happens if pilot teams' pain points diverge significa
 ## Key Instructions
 
 - If all failure modes seem low-likelihood, explicitly ask what would have to be true for the plan to fail — most teams systematically underestimate operational risks.
-- Does not substitute for direct planning; produces a failure-mode inventory to inform a positive plan.
 
 ## Anti-Pattern Guards
 

--- a/plugins/consider/skills/map-vs-territory/SKILL.md
+++ b/plugins/consider/skills/map-vs-territory/SKILL.md
@@ -76,7 +76,6 @@ Ask the external team for their delivery date and confidence level. If they can'
 ## Key Instructions
 
 - The goal is to find gaps before they cause failures, not to invalidate the model — a well-calibrated map with known limits is still useful.
-- Does not update the model; produces a gap audit and a verification plan the user acts on.
 
 ## Anti-Pattern Guards
 

--- a/plugins/consider/skills/occams-razor/SKILL.md
+++ b/plugins/consider/skills/occams-razor/SKILL.md
@@ -70,7 +70,6 @@ Check the provider's status page for Tuesday incidents. If clean, run `curl` dir
 ## Key Instructions
 
 - A simpler explanation that doesn't account for all known facts is not Occam's Razor — it's an incomplete explanation; simplicity cannot come at the cost of explanatory coverage.
-- Does not prescribe investigation steps; identifies the most parsimonious explanation to test first.
 
 ## Anti-Pattern Guards
 

--- a/plugins/consider/skills/one-thing/SKILL.md
+++ b/plugins/consider/skills/one-thing/SKILL.md
@@ -74,7 +74,6 @@ Pause the architecture video project and the onboarding doc rewrite until setup 
 
 - If no candidate action dominates on domino effect, help the user identify the constraint blocking progress before forcing a single choice.
 - The one thing must be within the user's control — not "hope the market changes" or "wait for someone else to decide."
-- Does not make the decision; produces a leverage analysis so the user can commit to one focus.
 
 ## Anti-Pattern Guards
 

--- a/plugins/consider/skills/opportunity-cost/SKILL.md
+++ b/plugins/consider/skills/opportunity-cost/SKILL.md
@@ -73,7 +73,6 @@ Auth0 justified. The opportunity cost of building (delayed notifications = reven
 ## Key Instructions
 
 - Always include "do nothing" as an alternative — it is the most frequently overlooked option and often has the clearest opportunity cost.
-- Does not make the decision; produces a comparison that makes the tradeoff explicit so the user can decide.
 
 ## Anti-Pattern Guards
 

--- a/plugins/consider/skills/pareto/SKILL.md
+++ b/plugins/consider/skills/pareto/SKILL.md
@@ -78,7 +78,6 @@ Two changes (self-service password reset + billing page redesign) would eliminat
 ## Key Instructions
 
 - Contribution estimates don't need to be precise — ballpark percentages identify the vital few; perfect data is usually unavailable and not required.
-- Does not prescribe what to cut; produces a leverage map the user applies.
 
 ## Anti-Pattern Guards
 

--- a/plugins/consider/skills/reversibility/SKILL.md
+++ b/plugins/consider/skills/reversibility/SKILL.md
@@ -70,7 +70,6 @@ Use PostgreSQL vs DynamoDB for a new event-sourcing service.
 ## Key Instructions
 
 - If a decision appears one-way but has a viable partial path (pilot, phased rollout, abstraction layer), always surface it — full irreversibility is rarer than it appears.
-- Does not recommend whether to proceed; calibrates the appropriate level of analysis and commitment.
 
 ## Anti-Pattern Guards
 

--- a/plugins/consider/skills/second-order/SKILL.md
+++ b/plugins/consider/skills/second-order/SKILL.md
@@ -75,7 +75,6 @@ Keep mandatory review but with one approval, not two. Add a "trivial" label for 
 
 - Stop at third-order effects for most decisions — deeper chains multiply uncertainty without adding insight.
 - If a feedback loop identified in step 5 is reinforcing (amplifying), treat it as high severity regardless of the original decision's apparent scale.
-- Does not recommend actions; produces a consequence map so the user can make an informed decision.
 
 ## Anti-Pattern Guards
 

--- a/plugins/consider/skills/swot/SKILL.md
+++ b/plugins/consider/skills/swot/SKILL.md
@@ -76,7 +76,6 @@ Ship the IDE adapter integration — it leverages the core strength (simple CLI)
 ## Key Instructions
 
 - The value is the cross-reference step (steps 6–7), not the lists; a SWOT that produces only four quadrant lists without strategic options hasn't been completed.
-- Does not make strategic decisions; produces a structured inventory and options the user evaluates.
 
 ## Anti-Pattern Guards
 

--- a/plugins/consider/skills/via-negativa/SKILL.md
+++ b/plugins/consider/skills/via-negativa/SKILL.md
@@ -74,7 +74,6 @@ The 30-minute canary monitor looks like wasted time but caught a memory leak las
 ## Key Instructions
 
 - Always assess whether a removal candidate is load-bearing before proposing it; the "What NOT to Remove" section must be completed, not skipped.
-- Does not implement removals; produces a removal plan the user executes.
 
 ## Anti-Pattern Guards
 

--- a/plugins/wiki/.claude-plugin/plugin.json
+++ b/plugins/wiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Skills for building and maintaining structured project context — setup, research, ingest, and lint.",
   "author": {
     "name": "Brandon Beidel"

--- a/plugins/wiki/CHANGELOG.md
+++ b/plugins/wiki/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.4
+
+- **Cycle 5 row 10**: drop `research/SKILL.md` `## Common Deviations
+  (Do Not)` section. Phase Gates immediately above already enforce
+  the checkpoints these bullets restated.
+
 ## 0.5.3
 
 - Cycle 4 process-echo guard sweep: drop `wiki/setup` Anti-Pattern Guard

--- a/plugins/wiki/pyproject.toml
+++ b/plugins/wiki/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wiki"
-version = "0.5.3"
+version = "0.5.4"
 description = "Claude Code plugin for building and maintaining structured project context."
 requires-python = ">=3.9"
 dependencies = []

--- a/plugins/wiki/skills/research/SKILL.md
+++ b/plugins/wiki/skills/research/SKILL.md
@@ -265,20 +265,6 @@ Each phase ends with a checkpoint. Do not proceed until the gate is met.
 
 STOP at each gate. If the condition is not met, complete it before proceeding.
 
-## Common Deviations (Do Not)
-
-- **Do not write the entire document in one pass at the end.** Each phase
-  writes to disk. If you haven't written to disk since Phase 2, you've
-  skipped checkpoints.
-- **Do not skip sub-questions.** They structure Phase 6 synthesis. Without
-  them, findings will organize by whatever taxonomy emerges from searching.
-- **Do not SIFT "in your head."** Use the SIFT evaluation log in the
-  sources table. If there's no visible per-source tier annotation, SIFT
-  didn't happen.
-- **Do not skip `url_checker`.** Fetching content via WebFetch verifies
-  content; `url_checker` verifies the URL itself (catches 404s, hallucinated
-  URLs).
-
 ## Output Document Format
 
 The final research document is saved with a `{date}-{slug}.research.md`

--- a/plugins/work/.claude-plugin/plugin.json
+++ b/plugins/work/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "work",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Skills for the full work lifecycle — scope-work, plan-work, start-work, verify-work, and finish-work.",
   "author": {
     "name": "Brandon Beidel"

--- a/plugins/work/CHANGELOG.md
+++ b/plugins/work/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.2.4
+
+- **Cycle 5 row 12**: merge `start-work/SKILL.md` Key Instructions /
+  Anti-Pattern Guards overlap. Drop two KI bullets that restated guards
+  ("Commit per task creates rollback boundaries" → AG #6;
+  "Execute the plan as written" → AG #4). Anti-Pattern Guards retain
+  all 6 bullets.
+
 ## 0.2.3
 
 - Cycle 4 process-echo guard sweep: drop guards whose body paraphrases

--- a/plugins/work/skills/start-work/SKILL.md
+++ b/plugins/work/skills/start-work/SKILL.md
@@ -128,9 +128,6 @@ Wait for user confirmation before invoking the skill.
 
 ## Key Instructions
 
-- **Commit per task creates rollback boundaries.** Every completed task
-  gets its own git commit. On failure, diff against the last passing
-  commit SHA from the checkbox annotation.
 - **Plan file is source of truth.** Checkbox state + commit SHAs are the
   execution record. Do not rely on conversation context for state.
 - **Don't check boxes without proof.** Every `[x]` requires verification
@@ -138,9 +135,6 @@ Wait for user confirmation before invoking the skill.
 - **Intermediates go to disk.** Write discovered decisions, edge cases,
   and API findings to the plan file or a companion notes file. Context
   resets; files persist.
-- **Execute the plan as written.** Don't add features, refactor adjacent
-  code, or expand scope during execution. If the plan needs changes,
-  pause and discuss with the user.
 
 ## Anti-Pattern Guards
 


### PR DESCRIPTION
## Summary

Closeout PR for the 2026-05-07 simplification sweep design. Lands the 9
one-shot deletions deferred to its final cycle — no detector, no
scaffolder change, no codification.

Affected rows from `.designs/2026-05-07-simplification-sweep.design.md`:
- **Row 1**: drop `AGENTS.md` `## Content Routing` duplicate (a42762f, d197085)
- **Row 2**: replace `consider/SKILL.md` 17-row models table with one-line invocation note (613594e)
- **Row 10**: drop `wiki/research/SKILL.md` `## Common Deviations` section (be05d49)
- **Row 12**: merge `work/start-work/SKILL.md` Key Instructions / Anti-Pattern Guards overlap (aa02f60)
- **Row 17**: collapse `CLAUDE.md` to `@AGENTS.md`; absorb "build the tools" preamble (a42762f)
- **Row 24**: drop "Does not X; produces Y" Key Instructions across 16 consider mental-models + meta (5c68070, 613594e)
- **Row 25**: drop dead-link reference in `check-bash-script/check-commenting-intent.md` (d3ec243)
- **Row 27**: drop `RESOLVER.md` `## Notes` housekeeping sentence (e6d525a)
- **Row 28**: compress `AGENTS.md` `build/check-skill` vs. `skill-audit-*` paragraph to one bullet (3064908)

Plan: `.plans/2026-05-07-cycle-5-loose-ends.plan.md`

## Plugin bumps

- `build` 0.24.0 → 0.24.1 (row 25; 53a14ab)
- `work` 0.2.3 → 0.2.4 (row 12; e73557d)
- `wiki` 0.5.3 → 0.5.4 (row 10; e07eafb)
- `consider` 0.1.3 → 0.2.0 (rows 2 + 24, minor bump; ec0726e)

## Test plan

- [x] `python3 plugins/wiki/scripts/lint.py` → "All checks passed."
- [x] `check_skill_pattern.py` over modified SKILLs → zero new FAIL/WARN vs. main (diffed)
- [x] `check_reference_lead.py` on the surgically-edited `check-commenting-intent.md` → pass
- [x] `pytest plugins/wiki/tests/ plugins/build/_shared/scripts/tests/` → 309 passed