### PR TITLE
Post-sweep cleanup: Source principles tail, Scope/Review Gate guards, Won't bullets

### DIFF
--- a/plugins/build/.claude-plugin/plugin.json
+++ b/plugins/build/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "build",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "Skills for creating and refining Claude Code skills, rules, hooks, and subagents.",
   "author": {
     "name": "Brandon Beidel"

--- a/plugins/build/CHANGELOG.md
+++ b/plugins/build/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.24.2
+
+- **Post-sweep cleanup** (re-audit findings A, B, C from
+  `.prompts/repo-simplification-audit.reverify-2026-05-07.findings.md`):
+  - Drop `Source principles: ...` trailing clause across 15 reference
+    files in `check-readme/`, `check-subagent/`, `check-python-script/`
+    (original audit row 6 — never previously scoped).
+  - Drop "Skipping the Review Gate" + "Scaffolding over an existing
+    Makefile" Anti-Pattern Guards from `build-makefile/SKILL.md`
+    (process-echo of Scope Gate / Review Gate workflow steps).
+  - Drop "Skipping the Review Gate" guard from
+    `build-pre-commit-config/SKILL.md` (same pattern).
+
 ## 0.24.1
 
 - **Cycle 5 row 25**: drop dead-link to nonexistent `rule-header-comment.md`

--- a/plugins/build/pyproject.toml
+++ b/plugins/build/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "check"
-version = "0.24.1"
+version = "0.24.2"
 description = "Claude Code plugin for auditing Claude Code skills and rules for quality issues."
 requires-python = ">=3.9"
 dependencies = []

--- a/plugins/build/skills/build-makefile/SKILL.md
+++ b/plugins/build/skills/build-makefile/SKILL.md
@@ -273,20 +273,16 @@ Check missed and gives the user a baseline-clean starting point.
 
 ## Anti-Pattern Guards
 
-1. **Scaffolding over an existing Makefile** — Scope Gate signal #1
-   applies without exception. Offer `/build:check-makefile` instead.
-2. **Scaffolding for compilation trees** — this skill is scoped to
+1. **Scaffolding for compilation trees** — this skill is scoped to
    workflow orchestration. Pattern rules, implicit inference, and
    object-file build graphs belong in a real build system.
-3. **Declaring file-producing targets as `.PHONY`** — breaks Make's
+2. **Declaring file-producing targets as `.PHONY`** — breaks Make's
    incremental semantics. If `build` produces `$(BUILD_DIR)/<file>`,
    the target should be `$(BUILD_DIR)/<file>:`, not `build:`.
-4. **Hand-maintained `help` text** — the scaffolded `help` parses
+3. **Hand-maintained `help` text** — the scaffolded `help` parses
    `##` descriptions from `$(MAKEFILE_LIST)`. Do not emit a help
    target that hardcodes a list of commands; it rots the moment a
    target is added.
-5. **Skipping the Review Gate** — write to disk only after explicit
-   user approval. Present both artifacts first.
 
 ## Key Instructions
 

--- a/plugins/build/skills/build-pre-commit-config/SKILL.md
+++ b/plugins/build/skills/build-pre-commit-config/SKILL.md
@@ -296,8 +296,6 @@ Also offer the CI mirror (explicitly not scaffolded above):
 4. **Scaffolding test runners or whole-repo type checkers.**
    `pytest`, `go test`, `tsc`, `mypy .` belong in CI / `pre-push`,
    not here. Refuse if the user asks for them in the commit stage.
-5. **Skipping the Review Gate.** Write to disk only after explicit
-   approval.
 
 ## Key Instructions
 

--- a/plugins/build/skills/check-python-script/references/check-collision.md
+++ b/plugins/build/skills/check-python-script/references/check-collision.md
@@ -7,8 +7,7 @@ paths:
 
 When the audit scope holds multiple Python scripts in the same directory, surface near-identical `get_parser()` / error-handler / docstring patterns that the maintainer could lift into a shared helper module.
 
-**Why:** Duplicated scaffolding is the early signal that a collection of scripts wants a real package. Shared parsing logic maintained in triplicate drifts: an `--out` flag added to one script gets a different default in the other two; a common error handler updated in one place keeps the old behavior elsewhere. A single source of truth keeps the arguments coherent and documents the shared conventions in one place. Source principles: *Keep functions small and single-purpose* + *Review and Decay* — duplication across scripts is the structural signal that a `_helpers.py` (or a proper package) is overdue.
-
+**Why:** Duplicated scaffolding is the early signal that a collection of scripts wants a real package. Shared parsing logic maintained in triplicate drifts: an `--out` flag added to one script gets a different default in the other two; a common error handler updated in one place keeps the old behavior elsewhere. A single source of truth keeps the arguments coherent and documents the shared conventions in one place.
 **How to apply:** scan the directory for repeated scaffolding — argparse setup, exception-handling try/except blocks, common docstring shapes, shared constants. If three or more scripts carry near-identical blocks, propose extracting the shared piece into `<dir>/_helpers.py` (or a package) and importing from it. If the scripts are truly independent and unlikely to co-evolve, accept the duplication — DRY applies to code that will change together, not code that happens to look alike.
 
 ```python

--- a/plugins/build/skills/check-python-script/references/check-function-design.md
+++ b/plugins/build/skills/check-python-script/references/check-function-design.md
@@ -5,8 +5,7 @@ paths:
   - "**/*.py"
 ---
 
-**Why:** Short, well-named functions read as their own commentary — `main()` becomes a sequence of named operations rather than a 200-line wall. Duplicated blocks drift: fix one copy, forget the others, ship a partial bug. Conjunction names are a smell that the function is doing more than one thing and should be split. Source principles: *Keep functions small and single-purpose*; *Eliminate duplication* (plus Clean Code ch. 3 and Pragmatic Programmer §15 DRY).
-
+**Why:** Short, well-named functions read as their own commentary — `main()` becomes a sequence of named operations rather than a 200-line wall. Duplicated blocks drift: fix one copy, forget the others, ship a partial bug. Conjunction names are a smell that the function is doing more than one thing and should be split.
 **How to apply:** read `main()` aloud — if it doesn't sound like a sequence of named operations, extract the cohesive sections. Helper functions get verb-phrased single-purpose names (`fetch`, `transform`, `validate`, `write`). Three near-identical blocks become a single helper called three times.
 
 ```python

--- a/plugins/build/skills/check-python-script/references/check-input-validation.md
+++ b/plugins/build/skills/check-python-script/references/check-input-validation.md
@@ -5,8 +5,7 @@ paths:
   - "**/*.py"
 ---
 
-**Why:** "Fail before damage" is cheap to implement and expensive to skip. A `shutil.rmtree()` that runs before the path is checked destroys state on bad input; a `--dry-run` flag that's declared but never consulted is worse than no flag — it implies a safety that isn't there. Hardcoded credentials and hostnames leak through git history and break across environments. Source principles: *Fail loud, fail early, return meaningful codes*; *Hold the safety posture.*
-
+**Why:** "Fail before damage" is cheap to implement and expensive to skip. A `shutil.rmtree()` that runs before the path is checked destroys state on bad input; a `--dry-run` flag that's declared but never consulted is worse than no flag — it implies a safety that isn't there. Hardcoded credentials and hostnames leak through git history and break across environments.
 **How to apply:** make input validation the first work `main()` does after argparse — exists/readable/correct-shape checks before any irreversible step. In every destructive branch (delete, overwrite, irreversible network call), read `args.dry_run` (or the confirmation flag) and short-circuit when set. Keep credentials and absolute paths out of string literals — read them from arguments or `os.environ.get(...)`.
 
 ```python

--- a/plugins/build/skills/check-python-script/references/check-output-discipline.md
+++ b/plugins/build/skills/check-python-script/references/check-output-discipline.md
@@ -5,8 +5,7 @@ paths:
   - "**/*.py"
 ---
 
-**Why:** Unix pipelines depend on the stdout-for-data, stderr-for-chatter convention; a script that mixes status narration into stdout silently corrupts every caller that consumes its output. Callers in cron, CI, and Make depend on the exit-code contract — an error branch that logs and then `return 0` makes the failure invisible: cron sends no email, CI marks the job green, the bug ships. Source principles: *Treat I/O as a contract*; *Fail loud, fail early, return meaningful codes.*
-
+**Why:** Unix pipelines depend on the stdout-for-data, stderr-for-chatter convention; a script that mixes status narration into stdout silently corrupts every caller that consumes its output. Callers in cron, CI, and Make depend on the exit-code contract — an error branch that logs and then `return 0` makes the failure invisible: cron sends no email, CI marks the job green, the bug ships.
 **How to apply:** keep `print()` of error or log content off stdout — pass `file=sys.stderr` or use `logging` (configured to stderr). Ensure every documented or implied failure mode results in `return N` where `N > 0`, or `raise`. When the script carries verbosity flags or runs in automation, route operational messages through `logging` rather than `print`.
 
 ```python

--- a/plugins/build/skills/check-python-script/references/check-performance-intent.md
+++ b/plugins/build/skills/check-python-script/references/check-performance-intent.md
@@ -5,8 +5,7 @@ paths:
   - "**/*.py"
 ---
 
-**Why:** Scripts get run on files larger than the author imagined. `open(path).read()` followed by `splitlines()` works fine on the 10 KB sample but OOMs on the 2 GB production input — a failure mode the user shouldn't have to work around. `list(map(f, xs))` for a single iteration pays the materialization cost twice (allocation + traversal) when a generator would stream. Source principles: *Treat I/O as a contract* (streaming subset); the performance subsection of the principles doc.
-
+**Why:** Scripts get run on files larger than the author imagined. `open(path).read()` followed by `splitlines()` works fine on the 10 KB sample but OOMs on the 2 GB production input — a failure mode the user shouldn't have to work around. `list(map(f, xs))` for a single iteration pays the materialization cost twice (allocation + traversal) when a generator would stream.
 **How to apply:** use line-by-line iteration (`for line in f:`) for text files consumed once; chain generators for transformations; reserve `list()` for cases that genuinely need random access, `len()`, or repeated traversal. The default shape is "stream one record at a time."
 
 ```python

--- a/plugins/build/skills/check-readme/references/check-installation-correctness.md
+++ b/plugins/build/skills/check-readme/references/check-installation-correctness.md
@@ -8,8 +8,7 @@ paths:
 
 List versioned prerequisites before install commands, cover every supported platform with its own labeled command block, and never assume preexisting state silently.
 
-**Why:** First-run failure is the largest source of abandoned adoption — a reader who hits a missing dependency, a wrong package manager, or a hidden setup step on their first attempt does not return. "Just run `make install`" with no Make prerequisite, a Node command without a Node version, or a macOS-only `brew` recipe in a project that claims Linux support all break the implicit promise that copy-pasted commands will work. Source principles: *Versioned prerequisites before install commands*; *Copy-pasteable install and run commands*; *Install commands that assume preexisting state* (anti-pattern).
-
+**Why:** First-run failure is the largest source of abandoned adoption — a reader who hits a missing dependency, a wrong package manager, or a hidden setup step on their first attempt does not return. "Just run `make install`" with no Make prerequisite, a Node command without a Node version, or a macOS-only `brew` recipe in a project that claims Linux support all break the implicit promise that copy-pasted commands will work.
 **How to apply:** Verify the Prerequisites list names every runtime, tool, and external service the reader needs, with minimum versions. Verify the install commands would succeed on a clean machine that has only the prerequisites. If the project supports multiple platforms, verify each is covered with a labeled command block. Verify destructive install steps (database migrations, filesystem modifications) are noted. If commands would fail on a clean machine, add the missing prerequisites with versions, list any hidden setup steps, and test on a fresh VM or container.
 
 ```markdown

--- a/plugins/build/skills/check-readme/references/check-maintenance-posture.md
+++ b/plugins/build/skills/check-readme/references/check-maintenance-posture.md
@@ -8,8 +8,7 @@ paths:
 
 Keep the README a pointer to detailed docs rather than a duplicate; remove drift indicators (dated roadmaps, pasted `--help` output, pinned versions out of date, "coming soon" links, content duplicated from `CONTRIBUTING.md` or `ARCHITECTURE.md`).
 
-**Why:** Stale docs cost reader trust; one stale line taints nearby correct ones. A "Roadmap" with items marked "Q3 2023" or a pasted `--help` block three years old signals that nothing here is current. Hand-maintained duplicates of `--help` and copies of `CONTRIBUTING.md` content drift silently from their authoritative source — and the README, by virtue of being where readers look first, becomes the version they trust. Source principles: *Keep the README in sync with the code*; *Hand-maintained duplicates of `--help` output* (anti-pattern); *Duplicated docs inside the README* (anti-pattern).
-
+**Why:** Stale docs cost reader trust; one stale line taints nearby correct ones. A "Roadmap" with items marked "Q3 2023" or a pasted `--help` block three years old signals that nothing here is current. Hand-maintained duplicates of `--help` and copies of `CONTRIBUTING.md` content drift silently from their authoritative source — and the README, by virtue of being where readers look first, becomes the version they trust.
 **How to apply:** Scan for staleness indicators visible in the text: commands referring to renamed flags or removed subcommands, pinned version numbers that look out of date, hand-maintained `--help` output, "coming soon" links, content duplicated from `CONTRIBUTING.md` or `ARCHITECTURE.md`, references to features the project has moved past. If found, update version references, replace pasted `--help` with a link to `tool --help` or a generated docs page, and prune roadmap items completed or abandoned.
 
 ```markdown

--- a/plugins/build/skills/check-readme/references/check-opening-clarity.md
+++ b/plugins/build/skills/check-readme/references/check-opening-clarity.md
@@ -8,8 +8,7 @@ paths:
 
 Open with the project name as H1, a one-sentence "what is this" statement immediately below, and 2-3 sentences naming the problem and audience — before any feature list, screenshot wall, or marketing copy.
 
-**Why:** The top 30 seconds are the only bytes most readers see — package-index visitors, dependency-list browsers, and search-result skimmers bounce in seconds if they cannot answer "what is this and should I care". An H1 that is a tagline, an opening that leads with `Features:`, or a first content block that is a screenshot all fail that test. Source principles: *One-sentence "what is this" on line 2*; *Wall-of-features before "what is this"* (anti-pattern).
-
+**Why:** The top 30 seconds are the only bytes most readers see — package-index visitors, dependency-list browsers, and search-result skimmers bounce in seconds if they cannot answer "what is this and should I care". An H1 that is a tagline, an opening that leads with `Features:`, or a first content block that is a screenshot all fail that test.
 **How to apply:** Verify the H1 names the project (not marketing copy). Verify the next line or paragraph answers "what is this" in one sentence. Verify the next 2-3 sentences state the problem solved and the intended audience. If the opening is a feature list, screenshot, or implementation tour, rewrite the first three content lines: H1 (project name), one-sentence "what is this", 2-3 sentences stating the problem.
 
 ```markdown

--- a/plugins/build/skills/check-readme/references/check-placeholder-discipline.md
+++ b/plugins/build/skills/check-readme/references/check-placeholder-discipline.md
@@ -8,8 +8,7 @@ paths:
 
 Mark every user-supplied value as a placeholder (`<YOUR_API_KEY>`, `<PROJECT_ID>`), define each placeholder exactly once in Configuration or adjacent prose, and use the same token everywhere.
 
-**Why:** Reader copies. Reader pastes. Reader hits prod. A README that mixes real-looking values (`sk-proj-abc123`) with placeholders trains readers to ignore the difference; a placeholder used in three blocks with no definition leaves them guessing. A URL that looks internal but is passed off as documentation invites accidental traffic to systems the reader does not own. Source principles: *User-supplied values are marked placeholders*; *Real secrets, tokens, hostnames, or IPs in examples* (anti-pattern).
-
+**Why:** Reader copies. Reader pastes. Reader hits prod. A README that mixes real-looking values (`sk-proj-abc123`) with placeholders trains readers to ignore the difference; a placeholder used in three blocks with no definition leaves them guessing. A URL that looks internal but is passed off as documentation invites accidental traffic to systems the reader does not own.
 **How to apply:** Verify every user-supplied value is bracketed. Verify each placeholder is defined once and used consistently. Verify no production hostnames, tokens, or IPs appear in example blocks. Verify placeholder tokens are visually distinct from real values. If placeholders are undefined, inconsistent, or mixed with real values, define each placeholder once (typically in Configuration), use the same token everywhere, and swap any real-looking example values for `<...>`.
 
 ```bash

--- a/plugins/build/skills/check-readme/references/check-quickstart-effectiveness.md
+++ b/plugins/build/skills/check-readme/references/check-quickstart-effectiveness.md
@@ -8,8 +8,7 @@ paths:
 
 Reduce the Quickstart to one primary command or call that demonstrates the project's core value, and follow it with an expected-output block matching what a reader would actually see.
 
-**Why:** Silence after a command breeds doubt — readers who run the example and see no output cannot tell whether it worked, hung, or silently failed. "Minimal" means smallest thing that demonstrates value, not smallest thing that runs without erroring; a feature tour covering three use cases or a fifteen-line setup is not a Quickstart. An example whose output is mocked or aspirational is worse than no example, because the reader's confusion turns into mistrust. Source principles: *Minimal runnable example in Quickstart*; *Forgetting expected output in Quickstart* (anti-pattern).
-
+**Why:** Silence after a command breeds doubt — readers who run the example and see no output cannot tell whether it worked, hung, or silently failed. "Minimal" means smallest thing that demonstrates value, not smallest thing that runs without erroring; a feature tour covering three use cases or a fifteen-line setup is not a Quickstart. An example whose output is mocked or aspirational is worse than no example, because the reader's confusion turns into mistrust.
 **How to apply:** Verify the Quickstart has one primary command or call. Verify an expected-output block follows and matches what a reader would see. Verify the example demonstrates the project's core value, not a tangent. If the Quickstart is a feature tour or has no expected output, trim the example to one command or call that demonstrates the core value and add an expected-output block beneath.
 
 ````markdown

--- a/plugins/build/skills/check-readme/references/check-style-and-voice.md
+++ b/plugins/build/skills/check-readme/references/check-style-and-voice.md
@@ -8,8 +8,7 @@ paths:
 
 Write instructions in imperative mood and second person ("Run `npm install`"), define jargon on first use, keep headings ASCII-clean, and strip hedging adverbs ("simply", "just").
 
-**Why:** Imperative + second person is the clearest instruction form; hedging reads as uncertainty and trains the reader to question every step. "You might want to consider running `npm install`" is longer, weaker, and ambiguous compared to "Run `npm install`". Emoji in headings (`## 🚀 Getting Started`) break grep, anchor slug generation, and screen readers. "Just" and "simply" insult readers who do not yet know what is being skipped past. Source principles: *Imperative mood for instructions*; *No emoji in headings* (anti-pattern); *Prose lines under 120 characters*.
-
+**Why:** Imperative + second person is the clearest instruction form; hedging reads as uncertainty and trains the reader to question every step. "You might want to consider running `npm install`" is longer, weaker, and ambiguous compared to "Run `npm install`". Emoji in headings (`## 🚀 Getting Started`) break grep, anchor slug generation, and screen readers. "Just" and "simply" insult readers who do not yet know what is being skipped past.
 **How to apply:** Verify instructions are in imperative mood and second person. Verify jargon is defined on first appearance. Verify headings are plain text with no emoji. Verify language is direct — no "simply", "just", "obviously", or implicit assumption of expertise. If instructions use indicative or passive voice, jargon goes undefined, or headings carry emoji, convert to imperative ("Run X", not "You should run X"), define jargon on first use, and remove heading emoji.
 
 ```markdown

--- a/plugins/build/skills/check-readme/references/check-warning-prominence.md
+++ b/plugins/build/skills/check-readme/references/check-warning-prominence.md
@@ -8,8 +8,7 @@ paths:
 
 Promote warnings on destructive or security-sensitive steps to blockquotes, bold callouts, or a dedicated `⚠ Warning` prefix immediately adjacent to the block — not inline prose the reader's eye skims.
 
-**Why:** Readers scan; warnings must catch a scanning eye, not a careful read. "Note: this will delete all your data" in a normal sentence after an `rm -rf` block fails the proportionality test — the prominence of the warning must match the cost of the mistake. A pipe-to-shell installer with no manual alternative pushes the reader into a security posture they should opt into. A sudo-requiring step with no explanation of why is a request for trust the reader has no basis to grant. Source principles: *Destructive commands without a warning callout* (anti-pattern); *Piped-to-shell installers with no manual alternative* (anti-pattern); *Hard safety rules*.
-
+**Why:** Readers scan; warnings must catch a scanning eye, not a careful read. "Note: this will delete all your data" in a normal sentence after an `rm -rf` block fails the proportionality test — the prominence of the warning must match the cost of the mistake. A pipe-to-shell installer with no manual alternative pushes the reader into a security posture they should opt into. A sudo-requiring step with no explanation of why is a request for trust the reader has no basis to grant.
 **How to apply:** When destructive or security-sensitive operations appear (destructive commands, pipe-to-shell installers, privilege-requiring steps), verify warnings are visually prominent — callouts, blockquotes, bold, or `⚠ Warning` prefix — and proportional to the risk. Verify pipe-to-shell installers list a manual alternative within the same section. If warnings are inline prose, promote them to blockquotes or bold callouts immediately adjacent to the block.
 
 ````markdown

--- a/plugins/build/skills/check-subagent/references/check-output-contract.md
+++ b/plugins/build/skills/check-subagent/references/check-output-contract.md
@@ -6,8 +6,7 @@ paths:
   - "**/agents/**/*.md"
 ---
 
-**Why:** Downstream callers parse the response. Free-form prose output forces every consumer to write its own parser — and drifts silently when the agent's phrasing changes. A concrete input/output example at the point of maximum ambiguity removes interpretive ambiguity the prose alone cannot. Synthetic placeholders (`<placeholder>`, `foo`, `bar`) do not pin behavior the way a realistic case does. Source principles: *Output format is explicit.* *One concrete example when the task is ambiguous.*
-
+**Why:** Downstream callers parse the response. Free-form prose output forces every consumer to write its own parser — and drifts silently when the agent's phrasing changes. A concrete input/output example at the point of maximum ambiguity removes interpretive ambiguity the prose alone cannot. Synthetic placeholders (`<placeholder>`, `foo`, `bar`) do not pin behavior the way a realistic case does.
 **How to apply:** Name the output format explicitly — JSON schema, named markdown structure, or artifact path. For ambiguous tasks (multiple reasonable output shapes exist), add one realistic input/output example with real-looking values.
 
 ```markdown

--- a/plugins/build/skills/check-subagent/references/check-scope-discipline.md
+++ b/plugins/build/skills/check-subagent/references/check-scope-discipline.md
@@ -6,8 +6,7 @@ paths:
   - "**/agents/**/*.md"
 ---
 
-**Why:** Single-responsibility subagents route deterministically. Mixed-scope agents — "lint TypeScript and also generate migrations" — produce ambiguous routing, bloated prompts, and unclear failure modes. Out-of-scope is as load-bearing as in-scope: it tells the agent when to stop rather than improvise. Source principles: *Single responsibility.* *Scope and out-of-scope stated explicitly.*
-
+**Why:** Single-responsibility subagents route deterministically. Mixed-scope agents — "lint TypeScript and also generate migrations" — produce ambiguous routing, bloated prompts, and unclear failure modes. Out-of-scope is as load-bearing as in-scope: it tells the agent when to stop rather than improvise.
 **How to apply:** Confirm the description and body cover one workflow over one artifact type. Add an explicit Scope / Out-of-scope section (or equivalent) naming both what the agent handles and what it refuses or escalates. If the description joins distinct capabilities with "and", split into two subagents.
 
 ```markdown

--- a/plugins/build/skills/check-subagent/references/check-tool-proportionality.md
+++ b/plugins/build/skills/check-subagent/references/check-tool-proportionality.md
@@ -6,8 +6,7 @@ paths:
   - "**/agents/**/*.md"
 ---
 
-**Why:** Least privilege limits blast radius on misinterpretation or prompt injection. Every granted tool is an attack surface. An eight-tool allowlist is appropriate for a workflow that needs eight tools, but suspicious for a narrow single-verb workflow. `Bash`, `Write`, and `Edit` are high-risk; without body-level scoping (enumerated commands for `Bash`, path constraints for `Write` / `Edit`) a misinterpretation can do real damage. Source principles: *Least privilege.* *Scope dangerous tools.*
-
+**Why:** Least privilege limits blast radius on misinterpretation or prompt injection. Every granted tool is an attack surface. An eight-tool allowlist is appropriate for a workflow that needs eight tools, but suspicious for a narrow single-verb workflow. `Bash`, `Write`, and `Edit` are high-risk; without body-level scoping (enumerated commands for `Bash`, path constraints for `Write` / `Edit`) a misinterpretation can do real damage.
 **How to apply:** Anchor the assessment to the description. Remove tools the workflow does not use. For required high-risk tools, add body-level scoping: enumerated allowed commands for `Bash`, path constraints for `Write` / `Edit`. A read-only review agent should not list `Write` or `Edit`; an internal-only workflow should not list `WebFetch` or `WebSearch`.
 
 ```yaml

--- a/plugins/wiki/.claude-plugin/plugin.json
+++ b/plugins/wiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Skills for building and maintaining structured project context — setup, research, ingest, and lint.",
   "author": {
     "name": "Brandon Beidel"

--- a/plugins/wiki/CHANGELOG.md
+++ b/plugins/wiki/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.5.5
+
+- **Post-sweep cleanup** (re-audit finding D): drop process-echo
+  `**Won't ...**` Key Instructions bullets across `research/SKILL.md`
+  (3 bullets), `ingest/SKILL.md` (3 bullets), and `setup/SKILL.md`
+  (1 bullet — Key Instructions section now empty and removed). Each
+  bullet restated an explicit workflow gate or duplicated a positive
+  Key Instruction immediately following it.
+
 ## 0.5.4
 
 - **Cycle 5 row 10**: drop `research/SKILL.md` `## Common Deviations

--- a/plugins/wiki/pyproject.toml
+++ b/plugins/wiki/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wiki"
-version = "0.5.4"
+version = "0.5.5"
 description = "Claude Code plugin for building and maintaining structured project context."
 requires-python = ">=3.9"
 dependencies = []

--- a/plugins/wiki/skills/ingest/SKILL.md
+++ b/plugins/wiki/skills/ingest/SKILL.md
@@ -273,9 +273,6 @@ The high-rigor path is never required. It is appropriate when the user wants to 
 
 ## Key Instructions
 
-- **Won't overwrite existing prose** — ingest is append-only; every `git diff` should show only additions
-- **Won't write until confirmed** — Step 1b gate is non-negotiable; present the full list and wait for approval
-- **Won't ingest without resolving filing target** — Pre-Ingest reads RESOLVER.md (or asks the user in degraded mode) before any page identification
 - **Recovery:** if an ingest produces unwanted changes, use `git diff` to review; writes are isolated to the filing target(s) resolved in Pre-Ingest, so `git checkout -- <filing-target>/` reverts cleanly
 
 ## Anti-Pattern Guards

--- a/plugins/wiki/skills/research/SKILL.md
+++ b/plugins/wiki/skills/research/SKILL.md
@@ -330,9 +330,6 @@ loop itself remains single-threaded (HIGH).
 
 ## Key Instructions
 
-- **Won't proceed without brief approval** — the Step 3 user approval gate is mandatory; no research stages execute until the user confirms the framing brief
-- **Won't finalize without claim verification** — statistics, attributions, and superlatives must be traced to source before `<!-- DRAFT -->` is removed
-- **Won't skip SIFT** — every source requires tier classification; un-tiered sources do not enter the document
 - **SIFT every source** — no source enters the document without tier classification. See `evaluate-sources-sift.md`.
 - **Counter-evidence is required** for deep-dive, options, and technical modes. See `research-modes.md`.
 - **Log every search** during Phase 2 and include the protocol in the final document.

--- a/plugins/wiki/skills/setup/SKILL.md
+++ b/plugins/wiki/skills/setup/SKILL.md
@@ -150,10 +150,6 @@ Report what was done:
 
 If everything was already set up, confirm: "Project context is up to date. No changes needed."
 
-## Key Instructions
-
-- **Won't overwrite content outside managed markers** — only the section between `<!-- wiki:begin -->` / `<!-- wiki:end -->` is managed; content the user wrote outside these markers is never touched
-
 ## Anti-Pattern Guards
 
 1. **Running setup with uncommitted changes in the repo** — setup writes AGENTS.md and CLAUDE.md. Check for tracked modified files (`git diff --name-only HEAD`) before proceeding. Untracked-only changes are advisory — note them but do not block. If tracked modifications exist, warn the user: setup writes to AGENTS.md and CLAUDE.md, making the diff ambiguous and recovery harder if setup fails partway. Suggest `git stash` as remediation and wait for the user to decide whether to stash, continue anyway, or abort.

--- a/plugins/work/.claude-plugin/plugin.json
+++ b/plugins/work/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "work",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Skills for the full work lifecycle — scope-work, plan-work, start-work, verify-work, and finish-work.",
   "author": {
     "name": "Brandon Beidel"

--- a/plugins/work/CHANGELOG.md
+++ b/plugins/work/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.2.5
+
+- **Post-sweep cleanup** (re-audit finding D): drop process-echo
+  `**Won't ...**` Key Instructions bullets from `plan-work/SKILL.md`
+  (1 bullet) and `finish-work/SKILL.md` (2 bullets). Each restated
+  an explicit workflow gate or the frontmatter's scope statement.
+
 ## 0.2.4
 
 - **Cycle 5 row 12**: merge `start-work/SKILL.md` Key Instructions /

--- a/plugins/work/skills/finish-work/SKILL.md
+++ b/plugins/work/skills/finish-work/SKILL.md
@@ -136,8 +136,6 @@ Summary:
 
 ## Key Instructions
 
-- **Won't present integration options until tests pass** — the hard gate in Step 1 enforces this; failing tests must be fixed before continuing
-- **Won't discard without typed "discard" confirmation** — Option 4 is irreversible; no shortcut, no yes/no prompt
 - **Plan is optional.** The skill works for both plan-backed branches and
   ad-hoc feature branches. Skip plan-related steps when no plan exists.
 - **Worktree cleanup follows the option.** Only clean up worktrees on

--- a/plugins/work/skills/plan-work/SKILL.md
+++ b/plugins/work/skills/plan-work/SKILL.md
@@ -118,8 +118,6 @@ ready for execution by an agent with zero prior context.
 
 ## Key Instructions
 
-- **Won't write code, modify files, or invoke execution skills** — the plan is the
-  deliverable; implementation is `start-work`'s job.
 - **Plans are files, not chat.** Save to disk with frontmatter. Plans that
   exist only in conversation are lost on context reset.
 - **Plans survive context resets.** A new session resumes by reading


### PR DESCRIPTION
## Summary

Three carry-over simplifications surfaced by the post-merge re-audit
(`.prompts/repo-simplification-audit.reverify-2026-05-07.findings.md`).
None were in-scope-row regressions — all are patterns the original
audit flagged but no cycle picked up, or process-echo siblings that
fell outside cycle 4's file list.

- **Finding A** — drop `Source principles: ...` trailing clause from 15 reference files in `check-readme/`, `check-subagent/`, `check-python-script/` (original audit row 6, S-effort, never scoped).
- **Finding B + C** — drop "Skipping the Review Gate" + "Scaffolding over an existing Makefile" Anti-Pattern Guards from `build-makefile/SKILL.md`; drop "Skipping the Review Gate" from `build-pre-commit-config/SKILL.md`. Cycle 4 caught equivalent guards in 4 sibling skills but missed these two.
- **Finding D** — drop 10 process-echo `**Won't ...**` Key Instructions bullets across `wiki/research`, `wiki/ingest`, `wiki/setup`, `work/plan-work`, `work/finish-work`. Each restated an explicit workflow gate or the frontmatter's scope statement.

## Plugin bumps

- `build` 0.24.1 → 0.24.2 (findings A, B, C)
- `wiki` 0.5.4 → 0.5.5 (finding D — wiki portion)
- `work` 0.2.4 → 0.2.5 (finding D — work portion)

## Test plan

- [x] `python3 plugins/wiki/scripts/lint.py` → "All checks passed."
- [x] `pytest plugins/wiki/tests/ plugins/build/_shared/scripts/tests/` → 309 passed